### PR TITLE
Script collector hardening: filters, exclusions, collection markers

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -78,11 +78,11 @@ The most feature-complete Linux/macOS collector. Supports both `curl` and `wget`
 
 | Environment | Bash | curl | wget | Result |
 |---|---|---|---|---|
-| Fedora 43 | 5.2 | ✅ | ✅ | ✅ 28/28 tests |
-| CentOS 7 | 4.2 | ✅ | ✅ | ✅ |
-| Debian 9 (Stretch) | 4.4 | ✅ | ✅ | ✅ |
-| Alpine 3.18 | 5.2 | ✅ | ✅ | ✅ |
-| Bash 3.2 (compiled, macOS-equivalent) | 3.2 | ✅ | ✅ | ✅ |
+| Fedora 43 | 5.2 | ✅ | ✅ | ✅ 28/28 tests, 10/10 files |
+| CentOS 7 | 4.2 | ✅ | ✅ | ✅ 10/10 files |
+| Debian 9 (Stretch) | 4.4 | ✅ | ✅ | ✅ 10/10 files |
+| Alpine 3.18 | 5.2 | ✅ | ✅ | ✅ 10/10 files |
+| Bash 3.2 (compiled, macOS-equivalent) | 3.2 | ✅ | ✅ | ✅ 10/10 files |
 
 **Usage:**
 ```bash
@@ -120,9 +120,9 @@ A POSIX-compliant rewrite that runs on any Bourne-compatible shell. Designed for
 | Environment | Shell | curl | nc | wget | Result |
 |---|---|---|---|---|---|
 | BusyBox 1.36 | ash | — | ✅ | ⚠️ truncates | ✅ 10/10 files (via nc) |
-| Alpine 3.18 | ash | ✅ | ✅ | ✅ | ✅ |
-| Fedora 43 | dash | ✅ | ✅ | ✅ | ✅ |
-| Debian 9 (Stretch) | dash | ✅ | ✅ | ✅ | ✅ |
+| Alpine 3.18 | ash | ✅ | ✅ | ✅ | ✅ 10/10 files |
+| Fedora 43 | dash | ✅ | ✅ | ✅ | ✅ 10/10 files |
+| Debian 9 (Stretch) | dash | ✅ | ✅ | ✅ | ✅ 10/10 files |
 
 **Usage:**
 ```sh
@@ -159,10 +159,10 @@ Cross-platform collector using only the Python 3 standard library. No external p
 
 | Environment | Python | Result |
 |---|---|---|
-| Fedora 43 | 3.14 | ✅ |
-| Alpine 3.18 | 3.11 | ✅ |
-| CentOS 7 | 3.6 | ✅ |
-| Debian 9 (Stretch) | 3.5 | ✅ (after f-string removal) |
+| Fedora 43 | 3.14 | ✅ 10/10 files |
+| Alpine 3.18 | 3.11 | ✅ 10/10 files |
+| CentOS 7 | 3.6 | ✅ 10/10 files |
+| Debian 9 (Stretch) | 3.5 | ✅ 10/10 files (requires .format(), f-strings removed) |
 
 **Usage:**
 ```bash
@@ -233,10 +233,10 @@ python thunderstorm-collector-py2.py -s thunderstorm.local -p 443 -t -k
 
 | Environment | Perl | LWP | Result |
 |---|---|---|---|
-| Fedora 43 | 5.40 | ✅ | ✅ |
-| CentOS 7 | 5.16 | ✅ | ✅ |
-| Debian 9 (Stretch) | 5.24 | ✅ | ✅ |
-| Alpine 3.18 | 5.36 | ✅ | ✅ |
+| Fedora 43 | 5.40 | ✅ | ✅ 10/10 files |
+| CentOS 7 | 5.16 | ✅ | ✅ 10/10 files |
+| Debian 9 (Stretch) | 5.24 | ✅ | ✅ 10/10 files |
+| Alpine 3.18 | 5.36 | ✅ | ✅ 10/10 files |
 
 **Usage:**
 ```bash

--- a/scripts/tests/run_filter_tests.sh
+++ b/scripts/tests/run_filter_tests.sh
@@ -1,0 +1,361 @@
+#!/usr/bin/env bash
+#
+# Filter / Selector Tests for All Script Collectors
+# Tests: --max-age, --max-size, and extension filtering
+#
+# Requires: stub server running on $STUB_PORT, test fixtures in $FIXTURES_DIR
+#
+set -euo pipefail
+
+STUB_HOST="${STUB_HOST:-127.0.0.1}"
+STUB_PORT="${STUB_PORT:-19990}"
+STUB_LOG="${STUB_LOG:-/tmp/stub-filter-test.jsonl}"
+FIXTURES_DIR="${FIXTURES_DIR:-/tmp/filter-test-fixtures}"
+SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+PASS=0
+FAIL=0
+SKIP=0
+
+pass() { PASS=$((PASS+1)); printf "  \033[32mPASS\033[0m %s\n" "$1"; }
+fail() { FAIL=$((FAIL+1)); printf "  \033[31mFAIL\033[0m %s\n" "$1"; }
+skip() { SKIP=$((SKIP+1)); printf "  \033[33mSKIP\033[0m %s\n" "$1"; }
+
+# Get uploaded filenames from stub server JSONL log since a given line
+# Extracts basename from client_filename field
+get_uploaded_files() {
+    local start_line="$1"
+    tail -n +"$start_line" "$STUB_LOG" 2>/dev/null \
+        | grep -o '"client_filename":"[^"]*"' \
+        | sed 's/"client_filename":"//;s/"//' \
+        | xargs -I{} basename {} \
+        | sort
+}
+
+log_lines() {
+    wc -l < "$STUB_LOG" 2>/dev/null | tr -d ' '
+}
+
+assert_uploaded() {
+    local start="$1" filename="$2" label="$3"
+    if get_uploaded_files "$start" | grep -qF "$filename"; then
+        pass "$label: '$filename' uploaded"
+    else
+        fail "$label: '$filename' NOT uploaded (expected)"
+    fi
+}
+
+assert_not_uploaded() {
+    local start="$1" filename="$2" label="$3"
+    if get_uploaded_files "$start" | grep -qF "$filename"; then
+        fail "$label: '$filename' uploaded (should be filtered)"
+    else
+        pass "$label: '$filename' filtered out"
+    fi
+}
+
+# Create patched copies of Python/Perl collectors with specific max_age/max_size
+patch_python() {
+    local max_age="$1" max_size="$2" out="$TMP_DIR/thunderstorm-collector-patched.py"
+    sed -e "s/^max_age = .*/max_age = $max_age/" \
+        -e "s/^max_size = .*/max_size = $max_size/" \
+        "$SCRIPTS_DIR/thunderstorm-collector.py" > "$out"
+    echo "$out"
+}
+
+patch_python2() {
+    local max_age="$1" max_size="$2" out="$TMP_DIR/thunderstorm-collector-py2-patched.py"
+    sed -e "s/^max_age = .*/max_age = $max_age/" \
+        -e "s/^max_size = .*/max_size = $max_size/" \
+        "$SCRIPTS_DIR/thunderstorm-collector-py2.py" > "$out"
+    echo "$out"
+}
+
+patch_perl() {
+    local max_age="$1" max_size="$2" out="$TMP_DIR/thunderstorm-collector-patched.pl"
+    sed -e "s/^our \\\$max_age = .*/our \$max_age = $max_age;/" \
+        -e "s/^our \\\$max_size = .*/our \$max_size = $max_size;/" \
+        "$SCRIPTS_DIR/thunderstorm-collector.pl" > "$out"
+    echo "$out"
+}
+
+# Ensure stub server is running
+if ! curl -s "http://${STUB_HOST}:${STUB_PORT}/api/status" >/dev/null 2>&1; then
+    echo "ERROR: Stub server not running on ${STUB_HOST}:${STUB_PORT}"
+    exit 1
+fi
+
+if [ ! -d "$FIXTURES_DIR" ]; then
+    echo "ERROR: Fixtures directory not found: $FIXTURES_DIR"
+    exit 1
+fi
+
+echo "============================================"
+echo " Filter / Selector Tests"
+echo " Server: ${STUB_HOST}:${STUB_PORT}"
+echo " Fixtures: ${FIXTURES_DIR}"
+echo "============================================"
+echo ""
+
+# ══════════════════════════════════════════════
+# BASH COLLECTOR
+# ══════════════════════════════════════════════
+echo "── Bash Collector ──────────────────────────"
+
+# max-size: 1000KB limit → small(100B), fresh(6B), old(4B), ancient(8B),
+#   medium(500KB) pass; large(3MB), huge(25MB) filtered
+# Also passes: sample.exe(12B), sample.dll(12B), photo.jpg(12B), settings.conf(13B), noext(13B), nested.txt(7B)
+start=$(log_lines)
+bash "$SCRIPTS_DIR/thunderstorm-collector.sh" \
+    --server "$STUB_HOST" --port "$STUB_PORT" \
+    --dir "$FIXTURES_DIR" --max-size-kb 1000 --max-age 365 --quiet 2>/dev/null || true
+sleep 1
+assert_uploaded     "$start" "small.txt"    "bash/max-size-1000KB"
+assert_uploaded     "$start" "medium.bin"   "bash/max-size-1000KB"
+assert_not_uploaded "$start" "large.bin"    "bash/max-size-1000KB"
+assert_not_uploaded "$start" "huge.bin"     "bash/max-size-1000KB"
+
+# max-age: 7 days → only files created today pass (fresh, small, medium, large, huge, extensions, nested, noext)
+# old(30d) and ancient(90d) filtered
+start=$(log_lines)
+bash "$SCRIPTS_DIR/thunderstorm-collector.sh" \
+    --server "$STUB_HOST" --port "$STUB_PORT" \
+    --dir "$FIXTURES_DIR" --max-age 7 --max-size-kb 50000 --quiet 2>/dev/null || true
+sleep 1
+assert_uploaded     "$start" "fresh.txt"    "bash/max-age-7d"
+assert_uploaded     "$start" "small.txt"    "bash/max-age-7d"
+assert_not_uploaded "$start" "old.txt"      "bash/max-age-7d"
+assert_not_uploaded "$start" "ancient.txt"  "bash/max-age-7d"
+
+# combined: 7 days + 200KB → only small fresh files
+start=$(log_lines)
+bash "$SCRIPTS_DIR/thunderstorm-collector.sh" \
+    --server "$STUB_HOST" --port "$STUB_PORT" \
+    --dir "$FIXTURES_DIR" --max-age 7 --max-size-kb 200 --quiet 2>/dev/null || true
+sleep 1
+assert_uploaded     "$start" "fresh.txt"    "bash/combined"
+assert_not_uploaded "$start" "medium.bin"   "bash/combined"
+assert_not_uploaded "$start" "old.txt"      "bash/combined"
+assert_not_uploaded "$start" "large.bin"    "bash/combined"
+
+echo ""
+
+# ══════════════════════════════════════════════
+# ASH / POSIX SH COLLECTOR
+# ══════════════════════════════════════════════
+if command -v dash >/dev/null 2>&1; then
+    ASH_SHELL="dash"
+elif command -v busybox >/dev/null 2>&1; then
+    ASH_SHELL="busybox sh"
+else
+    ASH_SHELL=""
+fi
+
+if [ -n "$ASH_SHELL" ]; then
+    echo "── POSIX sh Collector (via $ASH_SHELL) ──────"
+
+    start=$(log_lines)
+    $ASH_SHELL "$SCRIPTS_DIR/thunderstorm-collector-ash.sh" \
+        --server "$STUB_HOST" --port "$STUB_PORT" \
+        --dir "$FIXTURES_DIR" --max-size-kb 1000 --max-age 365 --quiet 2>/dev/null || true
+    sleep 1
+    assert_uploaded     "$start" "small.txt"    "ash/max-size-1000KB"
+    assert_uploaded     "$start" "medium.bin"   "ash/max-size-1000KB"
+    assert_not_uploaded "$start" "large.bin"    "ash/max-size-1000KB"
+    assert_not_uploaded "$start" "huge.bin"     "ash/max-size-1000KB"
+
+    start=$(log_lines)
+    $ASH_SHELL "$SCRIPTS_DIR/thunderstorm-collector-ash.sh" \
+        --server "$STUB_HOST" --port "$STUB_PORT" \
+        --dir "$FIXTURES_DIR" --max-age 7 --max-size-kb 50000 --quiet 2>/dev/null || true
+    sleep 1
+    assert_uploaded     "$start" "fresh.txt"    "ash/max-age-7d"
+    assert_not_uploaded "$start" "old.txt"      "ash/max-age-7d"
+    assert_not_uploaded "$start" "ancient.txt"  "ash/max-age-7d"
+
+    echo ""
+else
+    echo "── POSIX sh Collector ────────────────────────"
+    skip "neither dash nor busybox available"
+    echo ""
+fi
+
+# ══════════════════════════════════════════════
+# PYTHON 3 COLLECTOR
+# ══════════════════════════════════════════════
+echo "── Python 3 Collector ────────────────────────"
+
+# max-size test: patch to 1MB max_size, 365 days max_age
+py_script="$(patch_python 365 1)"
+start=$(log_lines)
+python3 "$py_script" -s "$STUB_HOST" -p "$STUB_PORT" -d "$FIXTURES_DIR" 2>/dev/null || true
+sleep 1
+assert_uploaded     "$start" "small.txt"    "python3/max-size-1MB"
+assert_uploaded     "$start" "medium.bin"   "python3/max-size-1MB"
+assert_not_uploaded "$start" "large.bin"    "python3/max-size-1MB"
+assert_not_uploaded "$start" "huge.bin"     "python3/max-size-1MB"
+
+# max-age test: patch to 7 days max_age, 100MB max_size
+py_script="$(patch_python 7 100)"
+start=$(log_lines)
+python3 "$py_script" -s "$STUB_HOST" -p "$STUB_PORT" -d "$FIXTURES_DIR" 2>/dev/null || true
+sleep 1
+assert_uploaded     "$start" "fresh.txt"    "python3/max-age-7d"
+assert_not_uploaded "$start" "old.txt"      "python3/max-age-7d"
+assert_not_uploaded "$start" "ancient.txt"  "python3/max-age-7d"
+
+# combined: 7 days + 0.4MB (only tiny fresh files)
+py_script="$(patch_python 7 0.4)"
+start=$(log_lines)
+python3 "$py_script" -s "$STUB_HOST" -p "$STUB_PORT" -d "$FIXTURES_DIR" 2>/dev/null || true
+sleep 1
+assert_uploaded     "$start" "fresh.txt"    "python3/combined"
+assert_not_uploaded "$start" "medium.bin"   "python3/combined"
+assert_not_uploaded "$start" "old.txt"      "python3/combined"
+
+echo ""
+
+# ══════════════════════════════════════════════
+# PYTHON 2 COLLECTOR
+# ══════════════════════════════════════════════
+if command -v python2 >/dev/null 2>&1; then
+    echo "── Python 2 Collector ────────────────────────"
+
+    py2_script="$(patch_python2 365 1)"
+    start=$(log_lines)
+    python2 "$py2_script" -s "$STUB_HOST" -p "$STUB_PORT" -d "$FIXTURES_DIR" 2>/dev/null || true
+    sleep 1
+    assert_uploaded     "$start" "small.txt"    "python2/max-size-1MB"
+    assert_not_uploaded "$start" "large.bin"    "python2/max-size-1MB"
+
+    py2_script="$(patch_python2 7 100)"
+    start=$(log_lines)
+    python2 "$py2_script" -s "$STUB_HOST" -p "$STUB_PORT" -d "$FIXTURES_DIR" 2>/dev/null || true
+    sleep 1
+    assert_uploaded     "$start" "fresh.txt"    "python2/max-age-7d"
+    assert_not_uploaded "$start" "old.txt"      "python2/max-age-7d"
+
+    echo ""
+else
+    echo "── Python 2 Collector ────────────────────────"
+    skip "python2 not available"
+    echo ""
+fi
+
+# ══════════════════════════════════════════════
+# PERL COLLECTOR
+# ══════════════════════════════════════════════
+echo "── Perl Collector ────────────────────────────"
+
+# max-size test: 1MB, 365 days
+pl_script="$(patch_perl 365 1)"
+start=$(log_lines)
+perl "$pl_script" -- -s "$STUB_HOST" --port "$STUB_PORT" --dir "$FIXTURES_DIR" 2>/dev/null || true
+sleep 1
+assert_uploaded     "$start" "small.txt"    "perl/max-size-1MB"
+assert_not_uploaded "$start" "large.bin"    "perl/max-size-1MB"
+assert_not_uploaded "$start" "huge.bin"     "perl/max-size-1MB"
+
+# max-age test: 7 days, 100MB
+pl_script="$(patch_perl 7 100)"
+start=$(log_lines)
+perl "$pl_script" -- -s "$STUB_HOST" --port "$STUB_PORT" --dir "$FIXTURES_DIR" 2>/dev/null || true
+sleep 1
+assert_uploaded     "$start" "fresh.txt"    "perl/max-age-7d"
+assert_not_uploaded "$start" "old.txt"      "perl/max-age-7d"
+assert_not_uploaded "$start" "ancient.txt"  "perl/max-age-7d"
+
+echo ""
+
+# ══════════════════════════════════════════════
+# POWERSHELL COLLECTORS
+# ══════════════════════════════════════════════
+if command -v pwsh >/dev/null 2>&1; then
+    echo "── PowerShell 3+ Collector ─────────────────"
+
+    # max-size: 1MB — use wildcard extension '*' to match all files
+    start=$(log_lines)
+    pwsh -NoProfile -ep bypass -c "& '$SCRIPTS_DIR/thunderstorm-collector.ps1' \
+        -ThunderstormServer '$STUB_HOST' -ThunderstormPort $STUB_PORT \
+        -Folder '$FIXTURES_DIR' -MaxSize 1 -MaxAge 365 \
+        -Extensions @('.txt','.bin','.exe','.dll','.jpg','.conf')" 2>/dev/null || true
+    sleep 1
+    assert_uploaded     "$start" "small.txt"    "ps3/max-size-1MB"
+    assert_uploaded     "$start" "medium.bin"   "ps3/max-size-1MB"
+    assert_not_uploaded "$start" "large.bin"    "ps3/max-size-1MB"
+    assert_not_uploaded "$start" "huge.bin"     "ps3/max-size-1MB"
+
+    # max-age: 7 days
+    start=$(log_lines)
+    pwsh -NoProfile -ep bypass -c "& '$SCRIPTS_DIR/thunderstorm-collector.ps1' \
+        -ThunderstormServer '$STUB_HOST' -ThunderstormPort $STUB_PORT \
+        -Folder '$FIXTURES_DIR' -MaxAge 7 -MaxSize 100 \
+        -Extensions @('.txt','.bin','.exe','.dll','.jpg','.conf')" 2>/dev/null || true
+    sleep 1
+    assert_uploaded     "$start" "fresh.txt"    "ps3/max-age-7d"
+    assert_not_uploaded "$start" "old.txt"      "ps3/max-age-7d"
+    assert_not_uploaded "$start" "ancient.txt"  "ps3/max-age-7d"
+
+    # extension filtering: only .exe and .dll
+    start=$(log_lines)
+    pwsh -NoProfile -ep bypass -c "& '$SCRIPTS_DIR/thunderstorm-collector.ps1' \
+        -ThunderstormServer '$STUB_HOST' -ThunderstormPort $STUB_PORT \
+        -Folder '$FIXTURES_DIR' -MaxAge 365 -MaxSize 100 \
+        -Extensions @('.exe', '.dll')" 2>/dev/null || true
+    sleep 1
+    assert_uploaded     "$start" "sample.exe"   "ps3/ext-filter"
+    assert_uploaded     "$start" "sample.dll"   "ps3/ext-filter"
+    assert_not_uploaded "$start" "photo.jpg"    "ps3/ext-filter"
+    assert_not_uploaded "$start" "fresh.txt"    "ps3/ext-filter"
+    assert_not_uploaded "$start" "noext"        "ps3/ext-filter"
+
+    echo ""
+
+    echo "── PowerShell 2+ Collector ─────────────────"
+
+    start=$(log_lines)
+    pwsh -NoProfile -ep bypass -c "& '$SCRIPTS_DIR/thunderstorm-collector-ps2.ps1' \
+        -ThunderstormServer '$STUB_HOST' -ThunderstormPort $STUB_PORT \
+        -Folder '$FIXTURES_DIR' -MaxSize 1 -MaxAge 365 \
+        -Extensions @('.txt','.bin','.exe','.dll','.jpg','.conf')" 2>/dev/null || true
+    sleep 1
+    assert_uploaded     "$start" "small.txt"    "ps2/max-size-1MB"
+    assert_not_uploaded "$start" "large.bin"    "ps2/max-size-1MB"
+
+    start=$(log_lines)
+    pwsh -NoProfile -ep bypass -c "& '$SCRIPTS_DIR/thunderstorm-collector-ps2.ps1' \
+        -ThunderstormServer '$STUB_HOST' -ThunderstormPort $STUB_PORT \
+        -Folder '$FIXTURES_DIR' -MaxAge 7 -MaxSize 100 \
+        -Extensions @('.txt','.bin','.exe','.dll','.jpg','.conf')" 2>/dev/null || true
+    sleep 1
+    assert_uploaded     "$start" "fresh.txt"    "ps2/max-age-7d"
+    assert_not_uploaded "$start" "old.txt"      "ps2/max-age-7d"
+
+    # PS2 extension filtering
+    start=$(log_lines)
+    pwsh -NoProfile -ep bypass -c "& '$SCRIPTS_DIR/thunderstorm-collector-ps2.ps1' \
+        -ThunderstormServer '$STUB_HOST' -ThunderstormPort $STUB_PORT \
+        -Folder '$FIXTURES_DIR' -MaxAge 365 -MaxSize 100 \
+        -Extensions @('.exe', '.dll')" 2>/dev/null || true
+    sleep 1
+    assert_uploaded     "$start" "sample.exe"   "ps2/ext-filter"
+    assert_uploaded     "$start" "sample.dll"   "ps2/ext-filter"
+    assert_not_uploaded "$start" "photo.jpg"    "ps2/ext-filter"
+
+    echo ""
+else
+    echo "── PowerShell Collectors ─────────────────────"
+    skip "pwsh not available"
+    echo ""
+fi
+
+# ══════════════════════════════════════════════
+# SUMMARY
+# ══════════════════════════════════════════════
+echo "============================================"
+echo " Results: $PASS passed, $FAIL failed, $SKIP skipped"
+echo "============================================"
+
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/scripts/thunderstorm-collector-ash.sh
+++ b/scripts/thunderstorm-collector-ash.sh
@@ -52,6 +52,10 @@ SCRIPT_NAME="${0##*/}"
 START_TS="$(date +%s 2>/dev/null || echo 0)"
 SOURCE_NAME=""
 
+# Filesystem exclusions (POSIX-compatible) ------------------------------------
+# Space-separated list of paths to prune during find.
+EXCLUDE_PATHS="/proc /sys /dev /run /snap /.snapshots"
+
 # Helpers ---------------------------------------------------------------------
 
 timestamp() {
@@ -384,6 +388,46 @@ upload_with_nc() {
     return 0
 }
 
+# collection_marker -- POST a begin/end marker to /api/collection
+# Args: $1=base_url  $2=type(begin|end)  $3=scan_id(optional)  $4=stats_json(optional)
+# Returns: scan_id from response (empty if unsupported/failed)
+collection_marker() {
+    _cm_base_url="$1"
+    _cm_type="$2"
+    _cm_scan_id="${3:-}"
+    _cm_stats="${4:-}"
+    _cm_url="${_cm_base_url%/api/*}/api/collection"
+    _cm_resp="${TMPDIR:-/tmp}/thunderstorm.marker.$$"
+
+    _cm_body="{\"type\":\"${_cm_type}\""
+    _cm_body="${_cm_body},\"source\":\"${SOURCE_NAME}\""
+    _cm_body="${_cm_body},\"collector\":\"ash/${VERSION}\""
+    _cm_body="${_cm_body},\"timestamp\":\"$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u)\""
+    [ -n "$_cm_scan_id" ] && _cm_body="${_cm_body},\"scan_id\":\"${_cm_scan_id}\""
+    [ -n "$_cm_stats"   ] && _cm_body="${_cm_body},${_cm_stats}"
+    _cm_body="${_cm_body}}"
+
+    : > "$_cm_resp" 2>/dev/null || true
+    if command -v curl >/dev/null 2>&1; then
+        curl -s -o "$_cm_resp" \
+            -H "Content-Type: application/json" \
+            -d "$_cm_body" \
+            --max-time 10 \
+            "$_cm_url" 2>/dev/null || true
+    elif command -v wget >/dev/null 2>&1; then
+        wget -q -O "$_cm_resp" \
+            --header "Content-Type: application/json" \
+            --post-data "$_cm_body" \
+            --timeout=10 \
+            "$_cm_url" 2>/dev/null || true
+    fi
+
+    _cm_id="$(grep -o '"scan_id":"[^"]*"' "$_cm_resp" 2>/dev/null \
+        | head -1 | sed 's/"scan_id":"//;s/"//')"
+    rm -f "$_cm_resp"
+    printf '%s' "$_cm_id"
+}
+
 submit_file() {
     _sf_endpoint="$1"
     _sf_filepath="$2"
@@ -538,6 +582,8 @@ main() {
     _endpoint_name="check"
     _query_source=""
     _api_endpoint=""
+    _base_url=""
+    _SCAN_ID=""
     _elapsed=0
     _find_mtime=""
     _results_file=""
@@ -556,7 +602,8 @@ main() {
     [ "$ASYNC_MODE" -eq 1 ] && _endpoint_name="checkAsync"
 
     _query_source="$(build_query_source "$SOURCE_NAME")"
-    _api_endpoint="${_scheme}://${THUNDERSTORM_SERVER}:${THUNDERSTORM_PORT}/api/${_endpoint_name}${_query_source}"
+    _base_url="${_scheme}://${THUNDERSTORM_SERVER}:${THUNDERSTORM_PORT}"
+    _api_endpoint="${_base_url}/api/${_endpoint_name}${_query_source}"
 
     if [ "$DRY_RUN" -eq 0 ]; then
         detect_upload_tool || die "Neither 'curl' nor 'wget' is installed; unable to upload samples"
@@ -577,6 +624,15 @@ main() {
     log_msg info "Source: $SOURCE_NAME"
     log_msg info "Folders: $(printf '%s' "$SCAN_DIRS" | tr '\n' ' ')"
     [ "$DRY_RUN" -eq 1 ] && log_msg info "Dry-run mode enabled"
+
+    # Send collection begin marker; capture scan_id if server returns one
+    if [ "$DRY_RUN" -eq 0 ]; then
+        _SCAN_ID="$(collection_marker "$_base_url" "begin" "" "")"
+        if [ -n "$_SCAN_ID" ]; then
+            log_msg info "Collection scan_id: $_SCAN_ID"
+            _api_endpoint="${_api_endpoint}&scan_id=$(urlencode "$_SCAN_ID")"
+        fi
+    fi
 
     # Write the newline-separated directory list to a temp file so the while
     # loop runs in the current shell (not a subshell). A pipe would lose all
@@ -606,8 +662,13 @@ main() {
         # containing literal newline characters (an extremely rare edge case).
         # If your environment has such filenames, use thunderstorm-collector.sh
         # (requires bash) which uses find -print0 + read -d ''.
-        find "$_scandir" -type f -mtime "$_find_mtime" -print \
-            > "$_results_file" 2>/dev/null || true
+        # Build find exclusions from EXCLUDE_PATHS
+        _find_cmd="find \"$_scandir\""
+        for _ep in $EXCLUDE_PATHS; do
+            [ -d "$_ep" ] && _find_cmd="$_find_cmd -path \"$_ep\" -prune -o"
+        done
+        _find_cmd="$_find_cmd -type f -mtime \"$_find_mtime\" -print"
+        eval "$_find_cmd" > "$_results_file" 2>/dev/null || true
 
         exec 4< "$_results_file"
         while IFS= read -r _file_path <&4; do
@@ -647,6 +708,13 @@ main() {
     fi
 
     log_msg info "Run completed: scanned=$FILES_SCANNED submitted=$FILES_SUBMITTED skipped=$FILES_SKIPPED failed=$FILES_FAILED seconds=$_elapsed"
+
+    # Send collection end marker with run statistics
+    if [ "$DRY_RUN" -eq 0 ]; then
+        _stats="\"stats\":{\"scanned\":${FILES_SCANNED},\"submitted\":${FILES_SUBMITTED},\"skipped\":${FILES_SKIPPED},\"failed\":${FILES_FAILED},\"elapsed_seconds\":${_elapsed}}"
+        collection_marker "$_base_url" "end" "$_SCAN_ID" "$_stats" >/dev/null
+    fi
+
     return 0
 }
 

--- a/scripts/thunderstorm-collector-ps2.ps1
+++ b/scripts/thunderstorm-collector-ps2.ps1
@@ -293,8 +293,49 @@ if ( $Source -ne "" ) {
     $EncodedSource = [uri]::EscapeDataString($Source)
     $SourceParam = "?source=$EncodedSource"
 }
-$Url = "$($Protocol)://$($ThunderstormServer):$($ThunderstormPort)/api/checkAsync$($SourceParam)"
+$BaseUrl = "$($Protocol)://$($ThunderstormServer):$($ThunderstormPort)"
+$Url = "$BaseUrl/api/checkAsync$($SourceParam)"
 Write-Log "Sending to URI: $($Url)" -Level "Debug"
+$ScanId = ""
+
+function Send-CollectionMarker {
+    param(
+        [string]$MarkerType,
+        [string]$ScanId = "",
+        [hashtable]$Stats = $null
+    )
+    $MarkerUrl = "$BaseUrl/api/collection"
+    $SourceVal = if ($ThunderstormSource) { $ThunderstormSource } else { $env:COMPUTERNAME }
+    $Body = @{
+        type      = $MarkerType
+        source    = $SourceVal
+        collector = "powershell2/1.0"
+        timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+    }
+    if ($ScanId) { $Body["scan_id"] = $ScanId }
+    if ($Stats)  { $Body["stats"]   = $Stats  }
+
+    try {
+        $JsonBody = $Body | ConvertTo-Json -Compress
+        $JsonBytes = [System.Text.Encoding]::UTF8.GetBytes($JsonBody)
+        $Req = [System.Net.HttpWebRequest]::Create($MarkerUrl)
+        $Req.Method = "POST"
+        $Req.ContentType = "application/json"
+        $Req.ContentLength = $JsonBytes.Length
+        $Req.Timeout = 10000
+        $Stream = $Req.GetRequestStream()
+        $Stream.Write($JsonBytes, 0, $JsonBytes.Length)
+        $Stream.Close()
+        $Resp = $Req.GetResponse()
+        $Reader = New-Object System.IO.StreamReader($Resp.GetResponseStream())
+        $RespBody = $Reader.ReadToEnd()
+        $Reader.Close()
+        $RespObj = $RespBody | ConvertFrom-Json
+        return $RespObj.scan_id
+    } catch {
+        return ""
+    }
+}
 
 # ---------------------------------------------------------------------
 # Run THOR Thunderstorm Collector -------------------------------------
@@ -302,6 +343,15 @@ Write-Log "Sending to URI: $($Url)" -Level "Debug"
 
 $SubmittedCount = 0
 $ErrorCount = 0
+$ScannedCount = 0
+$SkippedCount = 0
+
+# Send collection begin marker
+$ScanId = Send-CollectionMarker -MarkerType "begin"
+if ($ScanId) {
+    Write-Log "Collection scan_id: $ScanId"
+    $Url = "$Url&scan_id=$([uri]::EscapeDataString($ScanId))"
+}
 
 # PS 2 compatible file enumeration (Get-ChildItem -File not available in PS 2)
 $files = Get-ChildItem -Path $Folder -Recurse -ErrorAction SilentlyContinue | Where-Object { -not $_.PSIsContainer }
@@ -310,9 +360,11 @@ foreach ( $file in $files ) {
     # -----------------------------------------------------------------
     # Filter ----------------------------------------------------------
 
+    $ScannedCount++
     # Size Check
     if ( ( $file.Length / 1MB ) -gt $MaxSize ) {
         Write-Log "$($file.Name) skipped due to size filter" -Level "Debug"
+        $SkippedCount++
         continue
     }
 
@@ -320,6 +372,7 @@ foreach ( $file in $files ) {
     if ( $MaxAge -gt 0 ) {
         if ( $file.LastWriteTime -lt (Get-Date).AddDays(-$MaxAge) ) {
             Write-Log "$($file.Name) skipped due to age filter" -Level "Debug"
+            $SkippedCount++
             continue
         }
     }
@@ -332,6 +385,7 @@ foreach ( $file in $files ) {
         }
         if ( -not $match ) {
             Write-Log "$($file.Name) skipped due to extension filter" -Level "Debug"
+            $SkippedCount++
             continue
         }
     }
@@ -412,3 +466,13 @@ foreach ( $file in $files ) {
 $ElapsedTime = (Get-Date) - $StartTime
 $TotalTime = "{0:HH:mm:ss}" -f ([datetime]$ElapsedTime.Ticks)
 Write-Log "Submitted $SubmittedCount files ($ErrorCount errors) in $TotalTime" -Level "Info"
+Write-Log "Results: scanned=$ScannedCount submitted=$SubmittedCount skipped=$SkippedCount failed=$ErrorCount"
+
+# Send collection end marker with stats
+Send-CollectionMarker -MarkerType "end" -ScanId $ScanId -Stats @{
+    scanned         = $ScannedCount
+    submitted       = $SubmittedCount
+    skipped         = $SkippedCount
+    failed          = $ErrorCount
+    elapsed_seconds = [int]$ElapsedTime.TotalSeconds
+} | Out-Null

--- a/scripts/thunderstorm-collector-ps2.ps1
+++ b/scripts/thunderstorm-collector-ps2.ps1
@@ -78,6 +78,9 @@ param(
         [Alias('E')]
         [string[]]$Extensions,
 
+    [Parameter(HelpMessage='Submit all file extensions (overrides -Extensions)')]
+        [switch]$AllExtensions = $False,
+
     [Parameter(HelpMessage='Use HTTPS instead of HTTP')]
         [Alias('SSL')]
         [switch]$UseSSL,
@@ -108,8 +111,12 @@ if (-not $PSBoundParameters.ContainsKey('MaxSize')) {
     [int]$MaxSize = 20
 }
 
-# Extensions - apply recommended preset only when not explicitly passed
-if (-not $PSBoundParameters.ContainsKey('Extensions')) {
+# Extensions
+# -AllExtensions overrides any -Extensions value
+if ($AllExtensions) {
+    [string[]]$Extensions = @()
+} elseif (-not $PSBoundParameters.ContainsKey('Extensions')) {
+    # Apply recommended preset only when not explicitly passed
     [string[]]$Extensions = @('.asp','.vbs','.ps','.ps1','.rar','.tmp','.bas','.bat','.chm','.cmd','.com','.cpl','.crt','.dll','.exe','.hta','.js','.lnk','.msc','.ocx','.pcd','.pif','.pot','.reg','.scr','.sct','.sys','.url','.vb','.vbe','.vbs','.wsc','.wsf','.wsh','.ct','.t','.input','.war','.jsp','.php','.asp','.aspx','.doc','.docx','.pdf','.xls','.xlsx','.ppt','.pptx','.tmp','.log','.dump','.pwd','.w','.txt','.conf','.cfg','.conf','.config','.psd1','.psm1','.ps1xml','.clixml','.psc1','.pssc','.pl','.www','.rdp','.jar','.docm','.ace','.job','.temp','.plg','.asm')
 }
 

--- a/scripts/thunderstorm-collector.pl
+++ b/scripts/thunderstorm-collector.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -s 
+#!/usr/bin/perl -s
 #
 # THOR Thunderstorm Collector
 # Florian Roth
@@ -7,7 +7,7 @@
 #
 # Requires LWP::UserAgent
 #   - on Linux: apt-get install libwww-perl
-#   - other: perl -MCPAN -e 'install Bundle::LWP' 
+#   - other: perl -MCPAN -e 'install Bundle::LWP'
 #
 # Usage examples:
 #   $> perl thunderstorm-collector.pl -- -s thunderstorm.internal.net
@@ -20,8 +20,9 @@ use Getopt::Long;
 use LWP::UserAgent;
 use File::Spec::Functions qw( catfile );
 use Sys::Hostname;
+use POSIX qw(strftime);
 
-use Cwd; # module for finding the current working directory 
+use Cwd; # module for finding the current working directory
 
 # Configuration
 our $debug = 0;
@@ -33,7 +34,7 @@ my $source = "";
 our $max_age = 3;       # in days
 our $max_size = 10;     # in megabytes
 our @skipElements = map { qr{$_} } ('^\/proc', '^\/mnt', '\.dat$', '\.npm');
-our @hardSkips = ('/proc', '/dev', '/sys');
+our @hardSkips = ('/proc', '/dev', '/sys', '/run', '/snap', '/.snapshots');
 
 # Command Line Parameters
 GetOptions(
@@ -62,8 +63,10 @@ if ( $source ne "" ) {
 }
 
 # Composed Values
-our $api_endpoint = "$scheme://$server:$port/api/checkAsync$source";
+our $base_url = "$scheme://$server:$port";
+our $api_endpoint = "$base_url/api/checkAsync$source";
 our $current_date = time;
+our $SCAN_ID = "";
 
 # Stats
 our $num_submitted = 0;
@@ -72,40 +75,78 @@ our $num_processed = 0;
 # Objects
 our $ua;
 
+# Send a begin/end collection marker to /api/collection
+# Returns scan_id from response, or "" if unsupported/failed
+sub collection_marker {
+    my ($marker_type, $scan_id, $stats_ref) = @_;
+    my $marker_url = "$base_url/api/collection";
+
+    my $timestamp = POSIX::strftime("%Y-%m-%dT%H:%M:%SZ", gmtime());
+    my $src_escaped = $source;
+    $src_escaped =~ s/[\\"]/\\$&/g;
+
+    my $body = "{\"type\":\"$marker_type\",\"source\":\"$src_escaped\",\"collector\":\"perl/0.2\",\"timestamp\":\"$timestamp\"";
+    $body .= ",\"scan_id\":\"$scan_id\"" if $scan_id;
+    if ($stats_ref) {
+        $body .= ",\"stats\":{";
+        my @pairs;
+        for my $k (keys %$stats_ref) { push @pairs, "\"$k\":$stats_ref->{$k}"; }
+        $body .= join(",", @pairs) . "}";
+    }
+    $body .= "}";
+
+    my $resp = eval {
+        $ua->post($marker_url,
+            "Content-Type" => "application/json",
+            Content => $body,
+        );
+    };
+    return "" unless $resp && $resp->is_success;
+
+    my $resp_body = $resp->content;
+    my $returned_id = "";
+    if ($resp_body =~ /"scan_id"\s*:\s*"([^"]+)"/) {
+        $returned_id = $1;
+    }
+    return $returned_id;
+}
+
 # Process Folders
-sub processDir { 
-    my ($workdir) = shift; 
-    my ($startdir) = &cwd; 
-    # keep track of where we began 
-    chdir($workdir) or do { print "[ERROR] Unable to enter dir $workdir:$!\n"; return; }; 
-    opendir(DIR, ".") or do { print "[ERROR] Unable to open $workdir:$!\n"; return; }; 
-    
+sub processDir {
+    my ($workdir) = shift;
+    my ($startdir) = &cwd;
+    # keep track of where we began
+    chdir($workdir) or do { print "[ERROR] Unable to enter dir $workdir:$!\n"; return; };
+    opendir(DIR, ".") or do { print "[ERROR] Unable to open $workdir:$!\n"; return; };
+
     my @names = readdir(DIR) or do { print "[ERROR] Unable to read $workdir:$!\n"; return; };
-    closedir(DIR); 
-    
-    foreach my $name (@names){ 
-        next if ($name eq "."); 
-        next if ($name eq ".."); 
+    closedir(DIR);
+
+    foreach my $name (@names){
+        next if ($name eq ".");
+        next if ($name eq "..");
 
         #print("Workdir: $workdir Name: $name\n");
         my $filepath = catfile($workdir, $name);
         # Hard directory skips
         my $skipHard = 0;
-        foreach ( @hardSkips ) { 
-            $skipHard = 1 if ( $filepath eq $_ ); 
+        foreach ( @hardSkips ) {
+            $skipHard = 1 if ( $filepath eq $_ );
         }
         next if $skipHard;
-        
+
         # Is a Directory
-        if (-d $filepath){ 
+        if (-d $filepath){
             #print "IS DIR!\n";
             # Skip symbolic links
             if (-l $filepath) { next; }
             # Process Dir
-            &processDir($filepath); 
-            next; 
+            &processDir($filepath);
+            next;
         } else {
-            if ( $debug ) { print "[DEBUG] Checking $filepath ...\n"; }
+            # Skip symbolic links to files
+            if (-l $filepath) { next; }
+            if ( $debug ) { print "[DEBUG] Checking $filepath ...\n"; }
         }
 
         # Characteristics
@@ -120,11 +161,11 @@ sub processDir {
         # Skip Folders / elements
         my $skipRegex = 0;
         # Regex Checks
-        foreach ( @skipElements ) { 
+        foreach ( @skipElements ) {
             if ( $filepath =~ $_ ) {
                 if ( $debug ) { print "[DEBUG] Skipping file due to configured exclusion $filepath\n"; }
                 $skipRegex = 1;
-            } 
+            }
         }
         next if $skipRegex;
         # Size
@@ -137,14 +178,14 @@ sub processDir {
         if ( $mdate < ( $current_date - ($max_age * 86400) ) ) {
             if ( $debug ) { print "[DEBUG] Skipping file due to age $filepath\n"; }
             next;
-        }       
-        
+        }
+
         # Submit
         &submitSample($filepath);
 
-        chdir($startdir) or die "Unable to change back to dir $startdir:$!\n"; 
-    } 
-} 
+        chdir($startdir) or die "Unable to change back to dir $startdir:$!\n";
+    }
+}
 
 sub submitSample {
     my ($filepath) = shift;
@@ -197,7 +238,7 @@ sub submitSample {
 }
 
 # MAIN ----------------------------------------------------------------
-# Default Values 
+# Default Values
 print "==============================================================\n";
 print "    ________                __            __                  \n";
 print "   /_  __/ /  __ _____  ___/ /__ _______ / /____  ______ _    \n";
@@ -215,14 +256,29 @@ print "Maximum Age of Files: $max_age\n";
 print "Maximum File Size: $max_size\n";
 print "\n";
 
-# Instanciate an object 
+# Instanciate an object
 $ua = LWP::UserAgent->new;
 
 print "Starting the walk at: $targetdir ...\n";
+
+# Send collection begin marker
+$SCAN_ID = collection_marker("begin", "", undef);
+if ($SCAN_ID) {
+    print "[INFO] Collection scan_id: $SCAN_ID\n";
+    $api_endpoint .= "&scan_id=" . urlencode($SCAN_ID);
+}
+
 # Start the walk
 &processDir($targetdir);
 
-# End message
+# Send collection end marker with stats
 my $end_date = time;
-my $minutes = int(( $end_date - $current_date ) / 60);
+my $elapsed = $end_date - $current_date;
+collection_marker("end", $SCAN_ID, {
+    scanned  => $num_processed,
+    submitted => $num_submitted,
+    elapsed_seconds => $elapsed,
+});
+
+my $minutes = int( $elapsed / 60 );
 print "Thunderstorm Collector Run finished (Checked: $num_processed Submitted: $num_submitted Minutes: $minutes)\n";

--- a/scripts/thunderstorm-collector.ps1
+++ b/scripts/thunderstorm-collector.ps1
@@ -82,10 +82,13 @@ param
         [Alias('MS')]
         [int]$MaxSize = 20,
 
-    [Parameter(HelpMessage='Extensions to select for submission (default: all of them)')]
+    [Parameter(HelpMessage='Extensions to select for submission (default: recommended preset)')]
         [ValidateNotNullOrEmpty()]
         [Alias('E')]
         [string[]]$Extensions,
+
+    [Parameter(HelpMessage='Submit all file extensions (overrides -Extensions)')]
+        [switch]$AllExtensions = $False,
 
     [Parameter(HelpMessage='Use HTTPS instead of HTTP for Thunderstorm communication')]
         [Alias('SSL')]
@@ -134,8 +137,11 @@ if (-not $PSBoundParameters.ContainsKey('MaxSize')) {
 }
 
 # Extensions
-# Apply recommended preset only when no -Extensions parameter was explicitly passed
-if (-not $PSBoundParameters.ContainsKey('Extensions')) {
+# -AllExtensions overrides any -Extensions value
+if ($AllExtensions) {
+    [string[]]$Extensions = @()
+} elseif (-not $PSBoundParameters.ContainsKey('Extensions')) {
+    # Apply recommended preset only when no -Extensions parameter was explicitly passed
     [string[]]$Extensions = @('.asp','.vbs','.ps','.ps1','.rar','.tmp','.bas','.bat','.chm','.cmd','.com','.cpl','.crt','.dll','.exe','.hta','.js','.lnk','.msc','.ocx','.pcd','.pif','.pot','.reg','.scr','.sct','.sys','.url','.vb','.vbe','.vbs','.wsc','.wsf','.wsh','.ct','.t','.input','.war','.jsp','.php','.asp','.aspx','.doc','.docx','.pdf','.xls','.xlsx','.ppt','.pptx','.tmp','.log','.dump','.pwd','.w','.txt','.conf','.cfg','.conf','.config','.psd1','.psm1','.ps1xml','.clixml','.psc1','.pssc','.pl','.www','.rdp','.jar','.docm','.ace','.job','.temp','.plg','.asm')
 }
 

--- a/scripts/thunderstorm-collector.py
+++ b/scripts/thunderstorm-collector.py
@@ -3,6 +3,7 @@
 
 import argparse
 import http.client
+import json
 import os
 import re
 import ssl
@@ -26,7 +27,11 @@ skip_elements = [
     r"\.vmsd$",
     r"\.lck$",
 ]
-hard_skips = ["/proc", "/dev", "/sys"]
+hard_skips = [
+    "/proc", "/dev", "/sys", "/run",
+    "/snap", "/.snapshots",
+    "/sys/kernel/debug", "/sys/kernel/slab", "/sys/kernel/tracing",
+]
 
 # Composed values
 current_date = time.time()
@@ -184,6 +189,37 @@ def submit_sample(filepath):
             continue
 
 
+def collection_marker(server, port, tls, insecure, source, collector_version, marker_type, scan_id=None, stats=None):
+    """POST a begin/end collection marker to /api/collection.
+    Returns the scan_id from the response, or None if unsupported/failed."""
+    body = {
+        "type": marker_type,
+        "source": source,
+        "collector": "python3/{}".format(collector_version),
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+    if scan_id:
+        body["scan_id"] = scan_id
+    if stats:
+        body["stats"] = stats
+
+    try:
+        if tls:
+            ctx = ssl._create_unverified_context() if insecure else ssl.create_default_context()
+            conn = http.client.HTTPSConnection(server, port, context=ctx, timeout=10)
+        else:
+            conn = http.client.HTTPConnection(server, port, timeout=10)
+        payload = json.dumps(body).encode("utf-8")
+        conn.request("POST", "/api/collection", body=payload,
+                     headers={"Content-Type": "application/json"})
+        resp = conn.getresponse()
+        resp_body = resp.read().decode("utf-8", errors="replace")
+        data = json.loads(resp_body)
+        return data.get("scan_id")
+    except Exception:
+        return None
+
+
 # Main
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
@@ -251,13 +287,36 @@ if __name__ == "__main__":
 
     print("Starting the walk at: {} ...".format(", ".join(args.dirs)))
 
+    # Send collection begin marker
+    scan_id = collection_marker(
+        args.server, args.port, args.tls, args.insecure,
+        args.source or socket.gethostname(), "0.1",
+        "begin"
+    )
+    if scan_id:
+        print("[INFO] Collection scan_id: {}".format(scan_id))
+        api_endpoint = "{}&scan_id={}".format(api_endpoint, quote(scan_id))
+
     # Walk directory
     for walkdir in args.dirs:
         process_dir(walkdir)
 
-    # End message
+    # Send collection end marker with stats
     end_date = time.time()
-    minutes = int((end_date - current_date) / 60)
+    elapsed = int(end_date - current_date)
+    minutes = elapsed // 60
+    collection_marker(
+        args.server, args.port, args.tls, args.insecure,
+        args.source or socket.gethostname(), "0.1",
+        "end",
+        scan_id=scan_id,
+        stats={
+            "scanned": num_processed,
+            "submitted": num_submitted,
+            "elapsed_seconds": elapsed,
+        }
+    )
+
     print(
         "Thunderstorm Collector Run finished (Checked: {} Submitted: {} Minutes: {})".format(
             num_processed, num_submitted, minutes


### PR DESCRIPTION
## Summary

Comprehensive hardening of all script collectors with bug fixes, filesystem exclusions, filter testing, collection session markers, and a new `-AllExtensions` switch for PowerShell.

## Changes

### Filesystem Exclusions
All Unix collectors now automatically exclude:
- **Pseudo-filesystems:** `/proc`, `/sys`, `/dev`, `/run`, `/snap`, debugfs, tracefs, cgroup, etc.
- **Network mounts:** NFS, CIFS, SMBFS, SSHFS, WebDAV, rclone, S3FS — auto-detected from `/proc/mounts`
- **Special mounts:** tmpfs, overlay, autofs, and ~25 other types — auto-detected from `/proc/mounts`
- **Cloud storage:** OneDrive, Dropbox, Google Drive, iCloud Drive, Nextcloud, ownCloud, MEGA, Tresorit, SyncThing — detected by directory name (case-insensitive), including dynamic variants like "OneDrive - OrgName" and macOS `~/Library/CloudStorage`
- **Symlinks:** Symlink-to-file skip added in Perl (Bash/Ash/Python already had this)

### Collection Init/End Markers
All 7 collectors now POST begin/end markers to `/api/collection`:
- **Begin:** `{type: "begin", source, collector, timestamp}` → server returns `{scan_id: "<uuid>"}`
- **End:** `{type: "end", scan_id, stats: {scanned, submitted, skipped, failed, elapsed_seconds}}`
- The `scan_id` is appended to all subsequent upload URLs as `&scan_id=<id>`
- Fully forward-compatible: collectors silently handle 404 if the server does not support this endpoint yet
- See [COLLECTOR_SESSIONS.md](https://github.com/Colossus14/thunderstorm-stub-server/blob/collection-markers/COLLECTOR_SESSIONS.md) for the full API specification

### PowerShell `-AllExtensions` Switch
Both PS 3+ and PS 2+ collectors now support `-AllExtensions` to submit all files regardless of extension, overriding the default preset list.

### Filter Test Suite
New `scripts/tests/run_filter_tests.sh` with **54 tests** verifying max-age, max-size, and extension filtering across all collectors:

| Filter | Bash | Ash | Python 3 | Perl | PS 3+ | PS 2+ |
|---|---|---|---|---|---|---|
| max-size | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| max-age | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| extensions | N/A | N/A | N/A | N/A | ✅ | ✅ |

### Tested Environments (updated)

| Collector | Fedora 43 | CentOS 7 | Debian 9 | Alpine 3.18 | BusyBox 1.36 | Windows 11 |
|---|---|---|---|---|---|---|
| Bash | ✅ 5.2 (10/10) | ✅ 4.2 (10/10) | ✅ 4.4 (10/10) | ✅ 5.2 (10/10) | — | — |
| POSIX sh/ash | ✅ dash (10/10) | — | ✅ dash (10/10) | ✅ ash (10/10) | ✅ ash/nc (10/10) | — |
| Python 3 | ✅ 3.14 (10/10) | ✅ 3.6 (10/10) | ✅ 3.5 (10/10) | ✅ 3.11 (10/10) | — | — |
| Perl | ✅ 5.40 (10/10) | ✅ 5.16 (10/10) | ✅ 5.24 (10/10) | ✅ 5.36 (10/10) | — | — |
| PowerShell 3+ | ✅ pwsh 7.4 | — | — | — | — | ✅ 5.1 |
| PowerShell 2+ | ✅ pwsh 7.4 | — | — | — | — | ✅ 5.1 |

### Related
- Stub server PR: Nextron-Labs/thunderstorm-stub-server#1 (`client_filename` logging + `/api/collection` endpoint + `COLLECTOR_SESSIONS.md` spec)