### PR TITLE
Fix: remove tmpfs and overlay from special FS exclusion list

### DIFF
--- a/scripts/thunderstorm-collector-ash.sh
+++ b/scripts/thunderstorm-collector-ash.sh
@@ -58,7 +58,7 @@ EXCLUDE_PATHS="/proc /sys /dev /run /snap /.snapshots"
 
 # Network and special filesystem types
 NETWORK_FS_TYPES="nfs nfs4 cifs smbfs smb3 sshfs fuse.sshfs afp webdav davfs2 fuse.rclone fuse.s3fs"
-SPECIAL_FS_TYPES="proc procfs sysfs devtmpfs devpts tmpfs cgroup cgroup2 pstore bpf tracefs debugfs securityfs hugetlbfs mqueue overlay autofs fusectl rpc_pipefs nsfs configfs binfmt_misc selinuxfs efivarfs ramfs"
+SPECIAL_FS_TYPES="proc procfs sysfs devtmpfs devpts cgroup cgroup2 pstore bpf tracefs debugfs securityfs hugetlbfs mqueue autofs fusectl rpc_pipefs nsfs configfs binfmt_misc selinuxfs efivarfs ramfs"
 
 # Cloud storage folder names (lowercase for comparison)
 CLOUD_DIR_NAMES="onedrive dropbox .dropbox googledrive nextcloud owncloud mega megasync tresorit syncthing"

--- a/scripts/thunderstorm-collector-py2.py
+++ b/scripts/thunderstorm-collector-py2.py
@@ -50,9 +50,9 @@ hard_skips = [
 
 NETWORK_FS_TYPES = set(["nfs", "nfs4", "cifs", "smbfs", "smb3", "sshfs", "fuse.sshfs",
                         "afp", "webdav", "davfs2", "fuse.rclone", "fuse.s3fs"])
-SPECIAL_FS_TYPES = set(["proc", "procfs", "sysfs", "devtmpfs", "devpts", "tmpfs",
+SPECIAL_FS_TYPES = set(["proc", "procfs", "sysfs", "devtmpfs", "devpts",
                         "cgroup", "cgroup2", "pstore", "bpf", "tracefs", "debugfs",
-                        "securityfs", "hugetlbfs", "mqueue", "overlay", "autofs",
+                        "securityfs", "hugetlbfs", "mqueue", "autofs",
                         "fusectl", "rpc_pipefs", "nsfs", "configfs", "binfmt_misc",
                         "selinuxfs", "efivarfs", "ramfs"])
 CLOUD_DIR_NAMES = set(["onedrive", "dropbox", ".dropbox", "googledrive", "google drive",

--- a/scripts/thunderstorm-collector.pl
+++ b/scripts/thunderstorm-collector.pl
@@ -38,7 +38,7 @@ our @hardSkips = ('/proc', '/dev', '/sys', '/run', '/snap', '/.snapshots');
 
 # Network and special filesystem types (mount points with these types are excluded)
 our %networkFsTypes = map { $_ => 1 } qw(nfs nfs4 cifs smbfs smb3 sshfs fuse.sshfs afp webdav davfs2 fuse.rclone fuse.s3fs);
-our %specialFsTypes = map { $_ => 1 } qw(proc procfs sysfs devtmpfs devpts tmpfs cgroup cgroup2 pstore bpf tracefs debugfs securityfs hugetlbfs mqueue overlay autofs fusectl rpc_pipefs nsfs configfs binfmt_misc selinuxfs efivarfs ramfs);
+our %specialFsTypes = map { $_ => 1 } qw(proc procfs sysfs devtmpfs devpts cgroup cgroup2 pstore bpf tracefs debugfs securityfs hugetlbfs mqueue autofs fusectl rpc_pipefs nsfs configfs binfmt_misc selinuxfs efivarfs ramfs);
 
 # Cloud storage folder names (lowercase)
 our %cloudDirNames = map { $_ => 1 } ('onedrive', 'dropbox', '.dropbox', 'googledrive', 'google drive',

--- a/scripts/thunderstorm-collector.py
+++ b/scripts/thunderstorm-collector.py
@@ -36,9 +36,9 @@ hard_skips = [
 # Network and special filesystem types to exclude via /proc/mounts
 NETWORK_FS_TYPES = {"nfs", "nfs4", "cifs", "smbfs", "smb3", "sshfs", "fuse.sshfs",
                     "afp", "webdav", "davfs2", "fuse.rclone", "fuse.s3fs"}
-SPECIAL_FS_TYPES = {"proc", "procfs", "sysfs", "devtmpfs", "devpts", "tmpfs",
+SPECIAL_FS_TYPES = {"proc", "procfs", "sysfs", "devtmpfs", "devpts",
                     "cgroup", "cgroup2", "pstore", "bpf", "tracefs", "debugfs",
-                    "securityfs", "hugetlbfs", "mqueue", "overlay", "autofs",
+                    "securityfs", "hugetlbfs", "mqueue", "autofs",
                     "fusectl", "rpc_pipefs", "nsfs", "configfs", "binfmt_misc",
                     "selinuxfs", "efivarfs", "ramfs"}
 

--- a/scripts/thunderstorm-collector.sh
+++ b/scripts/thunderstorm-collector.sh
@@ -58,7 +58,7 @@ EXCLUDE_PATHS=(
 # Network and special filesystem types — mount points with these types are
 # discovered from /proc/mounts and excluded automatically.
 NETWORK_FS_TYPES="nfs nfs4 cifs smbfs smb3 sshfs fuse.sshfs afp webdav davfs2 fuse.rclone fuse.s3fs"
-SPECIAL_FS_TYPES="proc procfs sysfs devtmpfs devpts tmpfs cgroup cgroup2 pstore bpf tracefs debugfs securityfs hugetlbfs mqueue overlay autofs fusectl rpc_pipefs nsfs configfs binfmt_misc selinuxfs efivarfs ramfs"
+SPECIAL_FS_TYPES="proc procfs sysfs devtmpfs devpts cgroup cgroup2 pstore bpf tracefs debugfs securityfs hugetlbfs mqueue autofs fusectl rpc_pipefs nsfs configfs binfmt_misc selinuxfs efivarfs ramfs"
 
 # Cloud storage folder names — if any path segment matches (case-insensitive),
 # the directory is pruned. Covers OneDrive, Dropbox, Google Drive, iCloud,


### PR DESCRIPTION
The previous commit included `tmpfs` and `overlay` in the special filesystem exclusion list. This causes problems:

- **tmpfs**: Used for `/tmp` on Fedora/systemd systems and for container volume mounts — excluding it silently skips scan targets
- **overlay**: Root filesystem inside containers — excluding it skips everything

Both are too commonly used for user data to blanket-exclude. The remaining special FS types (proc, sysfs, debugfs, cgroup, etc.) are genuinely non-scannable.

Verified: full test matrix passes across Fedora 43, CentOS 7, Debian 9, Alpine 3.18, BusyBox 1.36, and Bash 3.2 — 14/14 Unix collectors submit 4/4 files (cloud-excluded file correctly skipped).