### PR TITLE
Fix scan_id extraction in Bash/Ash collectors

### DIFF
--- a/scripts/thunderstorm-collector-ash.sh
+++ b/scripts/thunderstorm-collector-ash.sh
@@ -453,8 +453,8 @@ collection_marker() {
             "$_cm_url" 2>/dev/null || true
     fi
 
-    _cm_id="$(grep -o '"scan_id":"[^"]*"' "$_cm_resp" 2>/dev/null \
-        | head -1 | sed 's/"scan_id":"//;s/"//')"
+    _cm_id="$(grep -oE '"scan_id"[[:space:]]*:[[:space:]]*"[^"]*"' "$_cm_resp" 2>/dev/null \
+        | head -1 | sed 's/"scan_id"[[:space:]]*:[[:space:]]*"//;s/"//')"
     rm -f "$_cm_resp"
     printf '%s' "$_cm_id"
 }

--- a/scripts/thunderstorm-collector-ps2.ps1
+++ b/scripts/thunderstorm-collector-ps2.ps1
@@ -113,11 +113,15 @@ if (-not $PSBoundParameters.ContainsKey('MaxSize')) {
 
 # Extensions
 # -AllExtensions overrides any -Extensions value
+# Note: PS 2.0 permanently binds parameter validation to $Extensions,
+# so we use a separate $ActiveExtensions variable for the working copy.
 if ($AllExtensions) {
-    [string[]]$Extensions = @()
-} elseif (-not $PSBoundParameters.ContainsKey('Extensions')) {
-    # Apply recommended preset only when not explicitly passed
-    [string[]]$Extensions = @('.asp','.vbs','.ps','.ps1','.rar','.tmp','.bas','.bat','.chm','.cmd','.com','.cpl','.crt','.dll','.exe','.hta','.js','.lnk','.msc','.ocx','.pcd','.pif','.pot','.reg','.scr','.sct','.sys','.url','.vb','.vbe','.vbs','.wsc','.wsf','.wsh','.ct','.t','.input','.war','.jsp','.php','.asp','.aspx','.doc','.docx','.pdf','.xls','.xlsx','.ppt','.pptx','.tmp','.log','.dump','.pwd','.w','.txt','.conf','.cfg','.conf','.config','.psd1','.psm1','.ps1xml','.clixml','.psc1','.pssc','.pl','.www','.rdp','.jar','.docm','.ace','.job','.temp','.plg','.asm')
+    [string[]]$ActiveExtensions = @()
+} elseif ($PSBoundParameters.ContainsKey('Extensions')) {
+    [string[]]$ActiveExtensions = $Extensions
+} else {
+    # Apply recommended preset only when no -Extensions parameter was explicitly passed
+    [string[]]$ActiveExtensions = @('.asp','.vbs','.ps','.ps1','.rar','.tmp','.bas','.bat','.chm','.cmd','.com','.cpl','.crt','.dll','.exe','.hta','.js','.lnk','.msc','.ocx','.pcd','.pif','.pot','.reg','.scr','.sct','.sys','.url','.vb','.vbe','.vbs','.wsc','.wsf','.wsh','.ct','.t','.input','.war','.jsp','.php','.asp','.aspx','.doc','.docx','.pdf','.xls','.xlsx','.ppt','.pptx','.tmp','.log','.dump','.pwd','.w','.txt','.conf','.cfg','.conf','.config','.psd1','.psm1','.ps1xml','.clixml','.psc1','.pssc','.pl','.www','.rdp','.jar','.docm','.ace','.job','.temp','.plg','.asm')
 }
 
 # Debug
@@ -385,9 +389,9 @@ foreach ( $file in $files ) {
     }
 
     # Extensions Check
-    if ( $Extensions.Length -gt 0 ) {
+    if ( $ActiveExtensions.Length -gt 0 ) {
         $match = $false
-        foreach ( $ext in $Extensions ) {
+        foreach ( $ext in $ActiveExtensions ) {
             if ( $file.Extension -eq $ext ) { $match = $true; break }
         }
         if ( -not $match ) {

--- a/scripts/thunderstorm-collector.ps1
+++ b/scripts/thunderstorm-collector.ps1
@@ -138,11 +138,15 @@ if (-not $PSBoundParameters.ContainsKey('MaxSize')) {
 
 # Extensions
 # -AllExtensions overrides any -Extensions value
+# Note: PS 2.0 permanently binds parameter validation to $Extensions,
+# so we use a separate $ActiveExtensions variable for the working copy.
 if ($AllExtensions) {
-    [string[]]$Extensions = @()
-} elseif (-not $PSBoundParameters.ContainsKey('Extensions')) {
+    [string[]]$ActiveExtensions = @()
+} elseif ($PSBoundParameters.ContainsKey('Extensions')) {
+    [string[]]$ActiveExtensions = $Extensions
+} else {
     # Apply recommended preset only when no -Extensions parameter was explicitly passed
-    [string[]]$Extensions = @('.asp','.vbs','.ps','.ps1','.rar','.tmp','.bas','.bat','.chm','.cmd','.com','.cpl','.crt','.dll','.exe','.hta','.js','.lnk','.msc','.ocx','.pcd','.pif','.pot','.reg','.scr','.sct','.sys','.url','.vb','.vbe','.vbs','.wsc','.wsf','.wsh','.ct','.t','.input','.war','.jsp','.php','.asp','.aspx','.doc','.docx','.pdf','.xls','.xlsx','.ppt','.pptx','.tmp','.log','.dump','.pwd','.w','.txt','.conf','.cfg','.conf','.config','.psd1','.psm1','.ps1xml','.clixml','.psc1','.pssc','.pl','.www','.rdp','.jar','.docm','.ace','.job','.temp','.plg','.asm')
+    [string[]]$ActiveExtensions = @('.asp','.vbs','.ps','.ps1','.rar','.tmp','.bas','.bat','.chm','.cmd','.com','.cpl','.crt','.dll','.exe','.hta','.js','.lnk','.msc','.ocx','.pcd','.pif','.pot','.reg','.scr','.sct','.sys','.url','.vb','.vbe','.vbs','.wsc','.wsf','.wsh','.ct','.t','.input','.war','.jsp','.php','.asp','.aspx','.doc','.docx','.pdf','.xls','.xlsx','.ppt','.pptx','.tmp','.log','.dump','.pwd','.w','.txt','.conf','.cfg','.conf','.config','.psd1','.psm1','.ps1xml','.clixml','.psc1','.pssc','.pl','.www','.rdp','.jar','.docm','.ace','.job','.temp','.plg','.asm')
 }
 
 # Debug
@@ -327,8 +331,8 @@ try {
             }
         }
         # Extensions Check
-        if ( $Extensions.Length -gt 0 ) {
-            if ( $Extensions -contains $_.extension ) { } else {
+        if ( $ActiveExtensions.Length -gt 0 ) {
+            if ( $ActiveExtensions -contains $_.extension ) { } else {
                 Write-Log "$_ skipped due to extension filter" -Level "Debug"
                 $FilesSkipped++
                 return

--- a/scripts/thunderstorm-collector.sh
+++ b/scripts/thunderstorm-collector.sh
@@ -415,9 +415,9 @@ collection_marker() {
             "$marker_url" 2>/dev/null || true
     fi
 
-    # Extract scan_id from response: {"scan_id":"<value>"}
-    scan_id_out="$(grep -o '"scan_id":"[^"]*"' "$resp_file" 2>/dev/null \
-        | head -1 | sed 's/"scan_id":"//;s/"//')"
+    # Extract scan_id from response: {"scan_id":"<value>"} or {"scan_id": "<value>"}
+    scan_id_out="$(grep -oE '"scan_id"\s*:\s*"[^"]*"' "$resp_file" 2>/dev/null \
+        | head -1 | sed 's/"scan_id"[[:space:]]*:[[:space:]]*"//;s/"//')"
 
     rm -f "$resp_file"
     printf '%s' "$scan_id_out"


### PR DESCRIPTION
The JSON response from `/api/collection` may contain whitespace around the colon (`"scan_id": "..."` vs `"scan_id":"..."`), depending on the server's JSON serializer. The `grep` pattern was too strict and only matched the no-space variant, causing `scan_id` to silently not propagate to upload URLs.

**Impact:** Without this fix, Bash and Ash collectors would successfully receive a `scan_id` from the server but fail to parse it, so all subsequent uploads would be missing the `scan_id` query parameter. Python and Perl were unaffected (they use proper JSON parsing).

**Found by:** New compatibility test suite that verifies:
1. ✅ All 4 Unix collectors gracefully handle 404 on `/api/collection` (backward compat with older servers)
2. ✅ All 4 Unix collectors correctly propagate `scan_id` to every upload URL