### PR TITLE
fix: 404 handling and bug fixes for collector scripts

### DIFF
--- a/scripts/thunderstorm-collector-ash.sh
+++ b/scripts/thunderstorm-collector-ash.sh
@@ -15,7 +15,7 @@
 # - No associative arrays, no C-style for loops — all replaced with
 #   POSIX-compatible equivalents
 
-VERSION="0.4.0"
+VERSION="0.5.0"
 
 # Defaults --------------------------------------------------------------------
 
@@ -29,6 +29,7 @@ THUNDERSTORM_SERVER="ygdrasil.nextron"
 THUNDERSTORM_PORT=8080
 USE_SSL=0
 INSECURE=0
+CA_CERT=""
 ASYNC_MODE=1
 
 MAX_AGE=14
@@ -48,10 +49,13 @@ FILES_SCANNED=0
 FILES_SUBMITTED=0
 FILES_SKIPPED=0
 FILES_FAILED=0
+PROGRESS=1
+PROGRESS_SET=0
 
 SCRIPT_NAME="${0##*/}"
 START_TS="$(date +%s 2>/dev/null || echo 0)"
 SOURCE_NAME=""
+PROGRESS_ACTIVE=0
 
 # Filesystem exclusions (POSIX-compatible) ------------------------------------
 # Space-separated list of paths to prune during find.
@@ -113,11 +117,34 @@ cleanup_tmp_files() {
     done
 }
 
+INTERRUPTED=0
+
 on_exit() {
     cleanup_tmp_files
 }
 
-trap on_exit EXIT INT TERM
+on_signal() {
+    INTERRUPTED=1
+    # Close file descriptors that may be open from the main loop
+    exec 3<&- 2>/dev/null
+    exec 4<&- 2>/dev/null
+    PROGRESS_ACTIVE=0
+    log_msg warn "Signal received — sending interrupted collection marker"
+    if [ "$DRY_RUN" -eq 0 ] && [ -n "$_GLOBAL_BASE_URL" ]; then
+        _sig_elapsed=0
+        if [ "$START_TS" -gt 0 ] 2>/dev/null; then
+            _sig_elapsed=$(( $(date +%s 2>/dev/null || echo "$START_TS") - START_TS ))
+            [ "$_sig_elapsed" -lt 0 ] && _sig_elapsed=0
+        fi
+        _sig_stats="\"stats\":{\"scanned\":${FILES_SCANNED},\"submitted\":${FILES_SUBMITTED},\"skipped\":${FILES_SKIPPED},\"failed\":${FILES_FAILED},\"elapsed_seconds\":${_sig_elapsed}}"
+        collection_marker "$_GLOBAL_BASE_URL" "interrupted" "$_GLOBAL_SCAN_ID" "$_sig_stats" >/dev/null
+    fi
+    cleanup_tmp_files
+    exit 1
+}
+
+trap on_exit EXIT
+trap on_signal INT TERM
 
 log_msg() {
     _lm_level="$1"
@@ -150,13 +177,26 @@ log_msg() {
     fi
 
     if [ "$LOG_TO_CMDLINE" -eq 1 ]; then
-        printf "[%s] %s\n" "$_lm_level" "$_lm_clean" >&2
+        case "$_lm_level" in
+            error|warn)
+                if [ "$PROGRESS_ACTIVE" -eq 1 ]; then
+                    printf '\r%80s\r' '' >&2
+                fi
+                printf "[%s] %s\n" "$_lm_level" "$_lm_clean" >&2
+                ;;
+            *)
+                if [ "$PROGRESS_ACTIVE" -eq 1 ]; then
+                    printf '\r%80s\r' '' >&2
+                fi
+                printf "[%s] %s\n" "$_lm_level" "$_lm_clean" >&2
+                ;;
+        esac
     fi
 }
 
 die() {
     log_msg error "$*"
-    exit 1
+    exit 2
 }
 
 print_banner() {
@@ -187,6 +227,7 @@ Options:
   --source <name>            Source identifier (default: hostname)
   --ssl                      Use HTTPS
   -k, --insecure             Skip TLS certificate verification
+  --ca-cert <path>           Path to custom CA certificate bundle for TLS
   --sync                     Use /api/check (default: /api/checkAsync)
   --retries <num>            Retry attempts per file (default: 3)
   --dry-run                  Do not upload, only show what would be submitted
@@ -194,6 +235,8 @@ Options:
   --log-file <path>          Log file path (default: ./thunderstorm.log)
   --no-log-file              Disable file logging
   --syslog                   Enable syslog logging
+  --progress                 Force progress reporting on
+  --no-progress              Force progress reporting off
   --quiet                    Disable command-line logging
   -h, --help                 Show this help text
 
@@ -234,6 +277,11 @@ urlencode() {
     _ue_result=""
     for _ue_byte; do
         [ -z "$_ue_byte" ] && continue
+        # Validate hex token: must be exactly 2 hex digits
+        case "$_ue_byte" in
+            [0-9a-fA-F][0-9a-fA-F]) ;;
+            *) continue ;;
+        esac
         _ue_dec=$(printf '%d' "0x${_ue_byte}" 2>/dev/null) || continue
         # Pass through RFC 3986 unreserved characters: A-Z a-z 0-9 - _ . ~
         if   { [ "$_ue_dec" -ge 65 ] && [ "$_ue_dec" -le  90 ]; } \
@@ -274,16 +322,30 @@ mktemp_portable() {
         echo "$_mp_t"
         return 0
     fi
-    _mp_t="${TMPDIR:-/tmp}/thunderstorm.$$.$(date +%s 2>/dev/null || echo 0)"
-    : > "$_mp_t" 2>/dev/null || return 1
-    echo "$_mp_t"
+    # mktemp unavailable — create a private temp directory with restrictive
+    # permissions, then place files inside it to avoid symlink races.
+    _mp_dir="${TMPDIR:-/tmp}/thunderstorm.$$"
+    if [ ! -d "$_mp_dir" ]; then
+        ( umask 077 && mkdir "$_mp_dir" ) 2>/dev/null || return 1
+    fi
+    _mp_seq=0
+    while :; do
+        _mp_t="${_mp_dir}/${_mp_seq}.$(date +%s 2>/dev/null || echo 0)"
+        if ( set -C; : > "$_mp_t" ) 2>/dev/null; then
+            echo "$_mp_t"
+            return 0
+        fi
+        _mp_seq=$((_mp_seq + 1))
+        [ "$_mp_seq" -gt 100 ] && return 1
+    done
 }
 
 _wget_is_busybox() {
     # BusyBox wget truncates --post-file at the first NUL byte, making it
     # unable to upload binary files.  Detect it so we can fall back to nc.
     # Note: BusyBox wget does not support --version; use --help instead.
-    wget --help 2>&1 | grep -qi busybox
+    # Use head -1 to check only the first line and avoid excessive output.
+    wget --help 2>&1 | head -5 | grep -qi busybox
 }
 
 detect_upload_tool() {
@@ -315,17 +377,49 @@ upload_with_curl() {
     _uc_filename="$3"
     _uc_safe_name="$(sanitize_filename_for_multipart "$_uc_filename")"
     _uc_resp="$(mktemp_portable)" || return 91
-    TMP_FILES="${TMP_FILES} ${_uc_resp}"
+    _uc_hdr="$(mktemp_portable)" || return 91
+    TMP_FILES="${TMP_FILES} ${_uc_resp} ${_uc_hdr}"
 
-    # Escape double-quotes in filepath for curl's --form
-    _uc_escaped="$(printf '%s' "$_uc_filepath" | sed 's/"/\\"/g')"
+    # Build TLS arguments safely to avoid word-splitting on paths with spaces
+    set -- -sS -X POST -o "$_uc_resp" -D "$_uc_hdr" -w '%{http_code}'
+    [ "$INSECURE" -eq 1 ] && set -- "$@" -k
+    [ -n "$CA_CERT" ] && set -- "$@" --cacert "$CA_CERT"
+    set -- "$@" "$_uc_endpoint" -F "file=@${_uc_filepath};filename=${_uc_safe_name}"
 
-    curl -sS --fail --show-error -X POST $CURL_INSECURE \
-        "$_uc_endpoint" \
-        --form "file=@\"${_uc_escaped}\";filename=\"${_uc_safe_name}\"" \
-        > "$_uc_resp" 2>&1
+    # Use -w to capture HTTP status code; do NOT use --fail so we can inspect 503
+    _uc_http_code="$(curl "$@" 2>"${_uc_resp}.err")"
     _uc_code=$?
-    [ "$_uc_code" -ne 0 ] && return "$_uc_code"
+
+    if [ "$_uc_code" -ne 0 ]; then
+        _uc_err="$(cat "${_uc_resp}.err" 2>/dev/null | tr '\r\n' '  ')"
+        TMP_FILES="${TMP_FILES} ${_uc_resp}.err"
+        log_msg debug "curl error (code $_uc_code) for '$_uc_filepath': $_uc_err"
+        return "$_uc_code"
+    fi
+    TMP_FILES="${TMP_FILES} ${_uc_resp}.err"
+
+    # Handle 503 back-pressure: return special code 103 and set RETRY_AFTER
+    if [ "$_uc_http_code" = "503" ]; then
+        RETRY_AFTER=""
+        _uc_ra="$(grep -i '^Retry-After:' "$_uc_hdr" 2>/dev/null | head -1 | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r')"
+        if is_integer "$_uc_ra" 2>/dev/null && [ "$_uc_ra" -gt 0 ] 2>/dev/null; then
+            # Cap at 120 seconds
+            [ "$_uc_ra" -gt 120 ] && _uc_ra=120
+            RETRY_AFTER="$_uc_ra"
+        fi
+        log_msg warn "Server returned 503 for '$_uc_filepath'"
+        return 103
+    fi
+
+    # Any other non-2xx status
+    case "$_uc_http_code" in
+        2*) ;;
+        *)
+            _uc_body="$(cat "$_uc_resp" 2>/dev/null | tr '\r\n' '  ')"
+            log_msg error "Server returned HTTP $_uc_http_code for '$_uc_filepath': $_uc_body"
+            return 92
+            ;;
+    esac
 
     if grep -qi "reason" "$_uc_resp" 2>/dev/null; then
         _uc_body="$(cat "$_uc_resp" 2>/dev/null | tr '\r\n' '  ')"
@@ -335,15 +429,34 @@ upload_with_curl() {
     return 0
 }
 
+# generate_safe_boundary: produce a multipart boundary that does not appear in
+# the given file.  Regenerates up to 10 times if a collision is detected.
+generate_safe_boundary() {
+    _gsb_filepath="$1"
+    _gsb_attempt=0
+    while [ "$_gsb_attempt" -lt 10 ]; do
+        _gsb_rand="$(od -An -N16 -tx1 /dev/urandom 2>/dev/null | tr -d ' \n')"
+        _gsb_boundary="----ThunderstormBoundary${$}${_gsb_rand:-$(date +%s 2>/dev/null || echo 0)${_gsb_attempt}}"
+        if ! grep -qF "$_gsb_boundary" "$_gsb_filepath" 2>/dev/null; then
+            printf '%s' "$_gsb_boundary"
+            return 0
+        fi
+        _gsb_attempt=$((_gsb_attempt + 1))
+    done
+    # Exhausted attempts — return last candidate (collision is astronomically unlikely)
+    printf '%s' "$_gsb_boundary"
+}
+
 upload_with_wget() {
     _uw_endpoint="$1"
     _uw_filepath="$2"
     _uw_filename="$3"
     _uw_safe_name="$(sanitize_filename_for_multipart "$_uw_filename")"
-    _uw_boundary="----ThunderstormBoundary$$"
+    _uw_boundary="$(generate_safe_boundary "$_uw_filepath")"
     _uw_body="$(mktemp_portable)" || return 93
     _uw_resp="$(mktemp_portable)" || return 94
-    TMP_FILES="${TMP_FILES} ${_uw_body} ${_uw_resp}"
+    _uw_hdr="$(mktemp_portable)" || return 94
+    TMP_FILES="${TMP_FILES} ${_uw_body} ${_uw_resp} ${_uw_hdr}"
 
     {
         printf -- "--%s\r\n" "$_uw_boundary"
@@ -354,13 +467,53 @@ upload_with_wget() {
         printf '\r\n--%s--\r\n' "$_uw_boundary"
     } > "$_uw_body" 2>/dev/null || return 95
 
-    wget -q -O "$_uw_resp" \
-        --header="Content-Type: multipart/form-data; boundary=${_uw_boundary}" \
+    # Use --server-response to capture HTTP status; stderr has the headers
+    # Build TLS arguments safely to avoid word-splitting on paths with spaces
+    set -- -O "$_uw_resp" -S
+    [ "$INSECURE" -eq 1 ] && set -- "$@" --no-check-certificate
+    [ -n "$CA_CERT" ] && set -- "$@" "--ca-certificate=$CA_CERT"
+    set -- "$@" --header="Content-Type: multipart/form-data; boundary=${_uw_boundary}" \
         --post-file="$_uw_body" \
         "$_uw_endpoint"
-    _uw_code=$?
-    [ "$_uw_code" -ne 0 ] && return "$_uw_code"
 
+    wget "$@" 2>"$_uw_hdr"
+    _uw_code=$?
+
+    # Parse HTTP status code from wget's server response output
+    # wget -S prints "  HTTP/1.1 200 OK" lines to stderr
+    # Use sed instead of grep -oE for POSIX/BusyBox compatibility
+    _uw_http_code="$(sed -n 's/.*HTTP\/[0-9.]*[[:space:]]*\([0-9][0-9][0-9]\).*/\1/p' "$_uw_hdr" 2>/dev/null | tail -1)"
+
+    # If wget failed and we couldn't parse a status, return the wget error
+    if [ "$_uw_code" -ne 0 ] && [ -z "$_uw_http_code" ]; then
+        return "$_uw_code"
+    fi
+
+    # Handle 503 back-pressure
+    if [ "$_uw_http_code" = "503" ]; then
+        RETRY_AFTER=""
+        _uw_ra="$(grep -i 'Retry-After:' "$_uw_hdr" 2>/dev/null | head -1 | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r')"
+        if is_integer "$_uw_ra" 2>/dev/null && [ "$_uw_ra" -gt 0 ] 2>/dev/null; then
+            [ "$_uw_ra" -gt 120 ] && _uw_ra=120
+            RETRY_AFTER="$_uw_ra"
+        fi
+        log_msg warn "Server returned 503 for '$_uw_filepath'"
+        return 103
+    fi
+
+    # Accept 2xx as success
+    if [ -n "$_uw_http_code" ]; then
+        case "$_uw_http_code" in
+            2[0-9][0-9]) ;;
+            *)
+                _uw_body_content="$(cat "$_uw_resp" 2>/dev/null | tr '\r\n' '  ')"
+                log_msg error "Server returned HTTP $_uw_http_code for '$_uw_filepath': $_uw_body_content"
+                return 92
+                ;;
+        esac
+    fi
+
+    # wget returned success but check for rejection in body
     if grep -qi "reason" "$_uw_resp" 2>/dev/null; then
         _uw_body_content="$(cat "$_uw_resp" 2>/dev/null | tr '\r\n' '  ')"
         log_msg error "Server reported rejection for '$_uw_filepath': $_uw_body_content"
@@ -372,13 +525,18 @@ upload_with_wget() {
 upload_with_nc() {
     # Raw HTTP POST via netcat — binary-safe, no NUL truncation.
     # Used as a fallback when only BusyBox wget + nc are available.
+    # WARNING: nc does not support TLS — only works with plain HTTP.
     _nc_endpoint="$1"    # full URL: http://host:port/path?query
+    case "$_nc_endpoint" in
+        https://*) log_msg error "nc (netcat) does not support HTTPS; use curl or wget"; return 99 ;;
+    esac
     _nc_filepath="$2"
     _nc_filename="$3"
     _nc_safe_name="$(sanitize_filename_for_multipart "$_nc_filename")"
-    _nc_boundary="----ThunderstormBoundary$$"
+    _nc_boundary="$(generate_safe_boundary "$_nc_filepath")"
     _nc_body="$(mktemp_portable)" || return 97
-    TMP_FILES="${TMP_FILES} ${_nc_body}"
+    _nc_resp_file="$(mktemp_portable)" || return 97
+    TMP_FILES="${TMP_FILES} ${_nc_body} ${_nc_resp_file}"
 
     # Build multipart body
     {
@@ -404,75 +562,169 @@ upload_with_nc() {
     _nc_path="/${_nc_hostpath#*/}"
 
     # Send raw HTTP via nc (cat merges headers + binary body into one stream)
-    _nc_resp="$(
-        {
-            printf "POST %s HTTP/1.1\r\n" "$_nc_path"
-            printf "Host: %s\r\n" "$_nc_hostport"
-            printf "Content-Type: multipart/form-data; boundary=%s\r\n" "$_nc_boundary"
-            printf "Content-Length: %s\r\n" "$_nc_content_length"
-            printf "Connection: close\r\n"
-            printf "\r\n"
-            cat "$_nc_body"
-        } | nc "$_nc_host" "$_nc_port" -w 30 2>/dev/null
-    )"
+    {
+        printf "POST %s HTTP/1.1\r\n" "$_nc_path"
+        printf "Host: %s\r\n" "$_nc_hostport"
+        printf "Content-Type: multipart/form-data; boundary=%s\r\n" "$_nc_boundary"
+        printf "Content-Length: %s\r\n" "$_nc_content_length"
+        printf "Connection: close\r\n"
+        printf "\r\n"
+        cat "$_nc_body"
+    } | nc "$_nc_host" "$_nc_port" -w 30 > "$_nc_resp_file" 2>/dev/null
 
-    # Check for HTTP 200
-    case "$_nc_resp" in
-        *"200 OK"*|*"200 ok"*) return 0 ;;
-    esac
+    # No response or connection failure
+    if [ ! -s "$_nc_resp_file" ]; then
+        log_msg error "No response from server for '$_nc_filepath'"
+        return 1
+    fi
 
-    # Check for error indicators
-    case "$_nc_resp" in
-        *"400 Bad"*|*"500 Internal"*|*"503 Service"*)
-            _nc_status="$(printf '%s' "$_nc_resp" | head -1 | tr '\r\n' '  ')"
-            log_msg error "Server error for '$_nc_filepath': $_nc_status"
-            return 99
+    # Parse HTTP status code from the first line (e.g. "HTTP/1.1 200 OK")
+    _nc_status_line="$(head -1 "$_nc_resp_file" | tr -d '\r')"
+    _nc_http_code="$(printf '%s' "$_nc_status_line" | sed -n 's/^HTTP\/[^ ]* \([0-9][0-9]*\).*/\1/p')"
+
+    if [ -z "$_nc_http_code" ]; then
+        log_msg error "Could not parse HTTP status for '$_nc_filepath': $_nc_status_line"
+        return 99
+    fi
+
+    # Handle 503 back-pressure
+    if [ "$_nc_http_code" = "503" ]; then
+        RETRY_AFTER=""
+        _nc_ra="$(grep -i '^Retry-After:' "$_nc_resp_file" 2>/dev/null | head -1 | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r')"
+        if is_integer "$_nc_ra" 2>/dev/null && [ "$_nc_ra" -gt 0 ] 2>/dev/null; then
+            [ "$_nc_ra" -gt 120 ] && _nc_ra=120
+            RETRY_AFTER="$_nc_ra"
+        fi
+        log_msg warn "Server returned 503 for '$_nc_filepath'"
+        return 103
+    fi
+
+    # Accept 2xx as success
+    case "$_nc_http_code" in
+        2[0-9][0-9])
+            # Check for rejection in response body (consistent with curl/wget paths)
+            if grep -qi "reason" "$_nc_resp_file" 2>/dev/null; then
+                _nc_body_content="$(sed '1,/^\r*$/d' "$_nc_resp_file" 2>/dev/null | tr '\r\n' '  ')"
+                log_msg error "Server reported rejection for '$_nc_filepath': $_nc_body_content"
+                return 99
+            fi
+            return 0
             ;;
     esac
 
-    # No response or connection failure
-    [ -z "$_nc_resp" ] && return 1
-    return 0
+    # All other statuses are errors
+    log_msg error "Server returned HTTP $_nc_http_code for '$_nc_filepath': $_nc_status_line"
+    return 99
+}
+
+# json_escape: escape a string for safe inclusion in JSON values
+# Handles backslash, double-quote, and all control characters (0x00-0x1F)
+# Uses od + byte-by-byte rebuild for full POSIX portability
+json_escape() {
+    _je_hex="$(printf '%s' "$1" | od -An -tx1 | tr -d '\n')"
+    _je_result=""
+    # shellcheck disable=SC2086
+    set -- $_je_hex
+    for _je_byte; do
+        [ -z "$_je_byte" ] && continue
+        _je_dec=$(printf '%d' "0x${_je_byte}" 2>/dev/null) || continue
+        if [ "$_je_dec" -eq 92 ]; then
+            # backslash
+            _je_result="${_je_result}\\\\"
+        elif [ "$_je_dec" -eq 34 ]; then
+            # double quote
+            _je_result="${_je_result}\\\""
+        elif [ "$_je_dec" -eq 8 ]; then
+            _je_result="${_je_result}\\b"
+        elif [ "$_je_dec" -eq 9 ]; then
+            _je_result="${_je_result}\\t"
+        elif [ "$_je_dec" -eq 10 ]; then
+            _je_result="${_je_result}\\n"
+        elif [ "$_je_dec" -eq 12 ]; then
+            _je_result="${_je_result}\\f"
+        elif [ "$_je_dec" -eq 13 ]; then
+            _je_result="${_je_result}\\r"
+        elif [ "$_je_dec" -lt 32 ]; then
+            # Other control characters: emit \u00XX
+            _je_result="${_je_result}$(printf '\\u00%02x' "$_je_dec")"
+        else
+            _je_result="${_je_result}$(printf "\\$(printf '%03o' "$_je_dec")")"
+        fi
+    done
+    printf '%s' "$_je_result"
 }
 
 # collection_marker -- POST a begin/end marker to /api/collection
 # Args: $1=base_url  $2=type(begin|end)  $3=scan_id(optional)  $4=stats_json(optional)
 # Returns: scan_id from response (empty if unsupported/failed)
+# Exit status: 0 = success, 1 = connection/request failure
 collection_marker() {
     _cm_base_url="$1"
     _cm_type="$2"
     _cm_scan_id="${3:-}"
     _cm_stats="${4:-}"
-    _cm_url="${_cm_base_url%/api/*}/api/collection"
-    _cm_resp="${TMPDIR:-/tmp}/thunderstorm.marker.$$"
+    _cm_url="${_cm_base_url%/}/api/collection"
+    _cm_resp="$(mktemp_portable)" || return 1
 
+    _cm_safe_source="$(json_escape "$SOURCE_NAME")"
     _cm_body="{\"type\":\"${_cm_type}\""
-    _cm_body="${_cm_body},\"source\":\"${SOURCE_NAME}\""
+    _cm_safe_hostname="$(json_escape "$(uname -n 2>/dev/null || echo unknown)")"
+    _cm_body="${_cm_body},\"source\":\"${_cm_safe_source}\""
+    _cm_body="${_cm_body},\"hostname\":\"${_cm_safe_hostname}\""
     _cm_body="${_cm_body},\"collector\":\"ash/${VERSION}\""
     _cm_body="${_cm_body},\"timestamp\":\"$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u)\""
     [ -n "$_cm_scan_id" ] && _cm_body="${_cm_body},\"scan_id\":\"${_cm_scan_id}\""
     [ -n "$_cm_stats"   ] && _cm_body="${_cm_body},${_cm_stats}"
     _cm_body="${_cm_body}}"
 
+    _cm_ok=0
+    _cm_hdr="$(mktemp_portable)" || { rm -f "$_cm_resp"; return 1; }
     : > "$_cm_resp" 2>/dev/null || true
     if command -v curl >/dev/null 2>&1; then
-        curl -s -o "$_cm_resp" $CURL_INSECURE \
-            -H "Content-Type: application/json" \
-            -d "$_cm_body" \
-            --max-time 10 \
-            "$_cm_url" 2>/dev/null || true
+        set -- -sS -o "$_cm_resp" -D "$_cm_hdr" -w '%{http_code}' -H "Content-Type: application/json" -d "$_cm_body" --max-time 10
+        [ "$INSECURE" -eq 1 ] && set -- "$@" -k
+        [ -n "$CA_CERT" ] && set -- "$@" --cacert "$CA_CERT"
+        set -- "$@" "$_cm_url"
+        _cm_http_code="$(curl "$@" 2>/dev/null)"
+        _cm_curl_rc=$?
+        if [ "$_cm_curl_rc" -eq 0 ]; then
+            case "$_cm_http_code" in
+                2[0-9][0-9]) _cm_ok=1 ;;
+                404) log_msg warn "Collection marker '$_cm_type' not supported (HTTP 404) — server does not implement /api/collection"; _cm_ok=1 ;;
+                *) log_msg warn "Collection marker '$_cm_type' got HTTP $_cm_http_code" ;;
+            esac
+        fi
     elif command -v wget >/dev/null 2>&1; then
-        wget -q -O "$_cm_resp" \
-            --header "Content-Type: application/json" \
-            --post-data "$_cm_body" \
-            --timeout=10 \
-            "$_cm_url" 2>/dev/null || true
+        set -- -O "$_cm_resp" -S --header "Content-Type: application/json" --post-data "$_cm_body" --timeout=10
+        [ "$INSECURE" -eq 1 ] && set -- "$@" --no-check-certificate
+        [ -n "$CA_CERT" ] && set -- "$@" "--ca-certificate=$CA_CERT"
+        set -- "$@" "$_cm_url"
+        wget "$@" 2>"$_cm_hdr"
+        _cm_wget_rc=$?
+        _cm_http_code="$(sed -n 's/.*HTTP\/[0-9.]*[[:space:]]*\([0-9][0-9][0-9]\).*/\1/p' "$_cm_hdr" 2>/dev/null | tail -1)"
+        if [ "$_cm_wget_rc" -eq 0 ]; then
+            case "$_cm_http_code" in
+                2[0-9][0-9]|"") _cm_ok=1 ;;
+                404) log_msg warn "Collection marker '$_cm_type' not supported (HTTP 404) — server does not implement /api/collection"; _cm_ok=1 ;;
+                *) log_msg warn "Collection marker '$_cm_type' got HTTP $_cm_http_code" ;;
+            esac
+        else
+            if [ -n "$_cm_http_code" ]; then
+                log_msg warn "Collection marker '$_cm_type' got HTTP $_cm_http_code (wget exit $_cm_wget_rc)"
+            fi
+        fi
     fi
+    rm -f "$_cm_hdr"
 
-    _cm_id="$(grep -oE '"scan_id"[[:space:]]*:[[:space:]]*"[^"]*"' "$_cm_resp" 2>/dev/null \
-        | head -1 | sed 's/"scan_id"[[:space:]]*:[[:space:]]*"//;s/"//')"
+    # Extract scan_id value using a strict regex that only matches plain
+    # (unescaped) JSON string values containing safe characters.
+    # This avoids partial JSON unescaping bugs — if the server returns an
+    # escaped scan_id we simply won't match it, which is safe (we continue
+    # without a scan_id).
+    _cm_id="$(sed -n 's/.*"scan_id"[[:space:]]*:[[:space:]]*"\([A-Za-z0-9._:-]*\)".*/\1/p' "$_cm_resp" 2>/dev/null | head -1)"
     rm -f "$_cm_resp"
     printf '%s' "$_cm_id"
+    [ "$_cm_ok" -eq 1 ]
 }
 
 submit_file() {
@@ -482,12 +734,15 @@ submit_file() {
     _sf_try=1
     _sf_rc=1
     _sf_wait=2
+    RETRY_AFTER=""
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+        log_msg info "DRY-RUN: would submit '$_sf_filepath'"
+        return 0
+    fi
 
     while [ "$_sf_try" -le "$RETRIES" ]; do
-        if [ "$DRY_RUN" -eq 1 ]; then
-            log_msg info "DRY-RUN: would submit '$_sf_filepath'"
-            return 0
-        fi
+        RETRY_AFTER=""
 
         case "$UPLOAD_TOOL" in
             curl)
@@ -505,8 +760,15 @@ submit_file() {
 
         log_msg warn "Upload failed for '$_sf_filepath' (attempt ${_sf_try}/${RETRIES}, code ${_sf_rc})"
         if [ "$_sf_try" -lt "$RETRIES" ]; then
-            sleep "$_sf_wait"
-            _sf_wait=$((_sf_wait * 2))
+            # Use Retry-After from 503 if available, otherwise exponential backoff
+            if [ "$_sf_rc" -eq 103 ] && [ -n "$RETRY_AFTER" ]; then
+                log_msg info "Server requested Retry-After: ${RETRY_AFTER}s"
+                sleep "$RETRY_AFTER"
+            else
+                sleep "$_sf_wait"
+                _sf_wait=$((_sf_wait * 2))
+                [ "$_sf_wait" -gt 60 ] && _sf_wait=60
+            fi
         fi
         _sf_try=$((_sf_try + 1))
     done
@@ -565,6 +827,11 @@ parse_args() {
             -k|--insecure)
                 INSECURE=1
                 ;;
+            --ca-cert)
+                [ -n "$2" ] || die "Missing value for $_pa_arg"
+                CA_CERT="$2"
+                shift
+                ;;
             --sync)
                 ASYNC_MODE=0
                 ;;
@@ -592,6 +859,14 @@ parse_args() {
                 ;;
             --quiet)
                 LOG_TO_CMDLINE=0
+                ;;
+            --progress)
+                PROGRESS=1
+                PROGRESS_SET=1
+                ;;
+            --no-progress)
+                PROGRESS=0
+                PROGRESS_SET=1
                 ;;
             --)
                 shift
@@ -637,6 +912,8 @@ main() {
     _elapsed=0
     _find_mtime=""
     _results_file=""
+    _GLOBAL_BASE_URL=""
+    _GLOBAL_SCAN_ID=""
 
     parse_args "$@"
     _find_mtime="-${MAX_AGE}"
@@ -649,16 +926,19 @@ main() {
     fi
 
     [ "$USE_SSL"    -eq 1 ] && _scheme="https"
-    CURL_INSECURE=""
-    [ "$INSECURE"   -eq 1 ] && CURL_INSECURE="-k"
+    if [ -n "$CA_CERT" ]; then
+        [ -f "$CA_CERT" ] || die "CA certificate file not found: '$CA_CERT'"
+    fi
     [ "$ASYNC_MODE" -eq 1 ] && _endpoint_name="checkAsync"
 
     _query_source="$(build_query_source "$SOURCE_NAME")"
     _base_url="${_scheme}://${THUNDERSTORM_SERVER}:${THUNDERSTORM_PORT}"
     _api_endpoint="${_base_url}/api/${_endpoint_name}${_query_source}"
+    log_msg debug "Base URL: $_base_url"
+    log_msg debug "API endpoint: $_api_endpoint"
 
     if [ "$DRY_RUN" -eq 0 ]; then
-        detect_upload_tool || die "Neither 'curl' nor 'wget' is installed; unable to upload samples"
+        detect_upload_tool || die "Neither 'curl', 'wget', nor 'nc' is installed; unable to upload samples"
     else
         if detect_upload_tool; then
             log_msg info "Dry-run mode active (upload tool detected: $UPLOAD_TOOL)"
@@ -677,12 +957,51 @@ main() {
     log_msg info "Folders: $(printf '%s' "$SCAN_DIRS" | tr '\n' ' ')"
     [ "$DRY_RUN" -eq 1 ] && log_msg info "Dry-run mode enabled"
 
+    # TTY auto-detection for progress reporting
+    if [ "$PROGRESS_SET" -eq 0 ]; then
+        if [ -t 2 ]; then
+            PROGRESS=1
+        else
+            PROGRESS=0
+        fi
+    fi
+
+    # Store in globals for signal handler access
+    _GLOBAL_BASE_URL="$_base_url"
+    _GLOBAL_SCAN_ID=""
+
     # Send collection begin marker; capture scan_id if server returns one
+    # Retry once after 2s on initial connection failure
     if [ "$DRY_RUN" -eq 0 ]; then
-        _SCAN_ID="$(collection_marker "$_base_url" "begin" "" "")"
+        _begin_ok=0
+        _scan_id_file="$(mktemp_portable)" || die "Could not create temp file for scan_id"
+        TMP_FILES="${TMP_FILES} ${_scan_id_file}"
+        if collection_marker "$_base_url" "begin" "" "" > "$_scan_id_file"; then
+            _SCAN_ID="$(cat "$_scan_id_file")"
+            _begin_ok=1
+        fi
+        if [ "$_begin_ok" -eq 0 ]; then
+            log_msg warn "Begin marker failed; retrying in 2 seconds..."
+            sleep 2
+            if collection_marker "$_base_url" "begin" "" "" > "$_scan_id_file"; then
+                _SCAN_ID="$(cat "$_scan_id_file")"
+                _begin_ok=1
+            else
+                die "Cannot connect to Thunderstorm server at ${_base_url}/api/collection after retry"
+            fi
+        fi
+        rm -f "$_scan_id_file"
         if [ -n "$_SCAN_ID" ]; then
             log_msg info "Collection scan_id: $_SCAN_ID"
-            _api_endpoint="${_api_endpoint}&scan_id=$(urlencode "$_SCAN_ID")"
+            _GLOBAL_SCAN_ID="$_SCAN_ID"
+            # Check if endpoint already has query params
+            case "$_api_endpoint" in
+                *"?"*) _api_endpoint="${_api_endpoint}&scan_id=$(urlencode "$_SCAN_ID")" ;;
+                *)     _api_endpoint="${_api_endpoint}?scan_id=$(urlencode "$_SCAN_ID")" ;;
+            esac
+            log_msg debug "API endpoint (with scan_id): $_api_endpoint"
+        else
+            log_msg warn "Could not obtain scan_id from server; continuing without it"
         fi
     fi
 
@@ -695,6 +1014,7 @@ main() {
 
     exec 3< "$_dirs_file"
     while IFS= read -r _scandir <&3; do
+        [ "$INTERRUPTED" -eq 1 ] && break
         [ -z "$_scandir" ] && continue
 
         if [ ! -d "$_scandir" ]; then
@@ -714,22 +1034,48 @@ main() {
         # containing literal newline characters (an extremely rare edge case).
         # If your environment has such filenames, use thunderstorm-collector.sh
         # (requires bash) which uses find -print0 + read -d ''.
-        # Build find exclusions from EXCLUDE_PATHS
-        _find_cmd="find \"$_scandir\""
-        for _ep in $EXCLUDE_PATHS; do
-            [ -d "$_ep" ] && _find_cmd="$_find_cmd -path \"$_ep\" -prune -o"
-        done
-        # Exclude mount points of network and special filesystems
-        _mount_excludes="$(get_excluded_mounts)"
-        for _ep in $_mount_excludes; do
-            [ -d "$_ep" ] && _find_cmd="$_find_cmd -path \"$_ep\" -prune -o"
-        done
-        _find_cmd="$_find_cmd -type f -mtime \"$_find_mtime\" -print"
-        eval "$_find_cmd" > "$_results_file" 2>/dev/null || true
+        # Build find exclusion arguments safely in a subshell to avoid
+        # clobbering positional parameters of the outer loop.
+        # The resulting find expression is:
+        #   find <dir> -path <excl1> -prune -o -path <excl2> -prune -o ... -type f -mtime <age> -print
+        # Each -prune -o short-circuits excluded paths; the final -type f -print
+        # matches only regular files in non-excluded subtrees.
+        (
+            set -- "$_scandir"
+            for _ep in $EXCLUDE_PATHS; do
+                [ -d "$_ep" ] && set -- "$@" -path "$_ep" -prune -o
+            done
+            _mount_file="$(mktemp_portable)" || true
+            if [ -n "$_mount_file" ]; then
+                get_excluded_mounts > "$_mount_file"
+                while IFS= read -r _ep; do
+                    [ -n "$_ep" ] && [ -d "$_ep" ] && set -- "$@" -path "$_ep" -prune -o
+                done < "$_mount_file"
+                rm -f "$_mount_file"
+            fi
+            set -- "$@" -type f -mtime "$_find_mtime" -print
+            find "$@"
+        ) > "$_results_file" 2>/dev/null || true
+
+        # Count total lines for progress reporting
+        _total_in_dir="$(wc -l < "$_results_file" 2>/dev/null | tr -d ' \t')"
+        [ -z "$_total_in_dir" ] && _total_in_dir=0
+        _current_in_dir=0
 
         exec 4< "$_results_file"
         while IFS= read -r _file_path <&4; do
+            [ "$INTERRUPTED" -eq 1 ] && break
             [ -z "$_file_path" ] && continue
+
+            _current_in_dir=$((_current_in_dir + 1))
+
+            # Progress reporting (based on lines consumed, not files processed)
+            if [ "$PROGRESS" -eq 1 ] && [ "$_total_in_dir" -gt 0 ]; then
+                _pct=$(( _current_in_dir * 100 / _total_in_dir ))
+                printf '\r[%d/%d] %d%% - %s' "$_current_in_dir" "$_total_in_dir" "$_pct" "$_scandir" >&2
+                PROGRESS_ACTIVE=1
+            fi
+
             [ -f "$_file_path" ] || continue
 
             FILES_SCANNED=$((FILES_SCANNED + 1))
@@ -763,6 +1109,11 @@ main() {
             fi
         done
         exec 4<&-
+        # Clear progress line
+        if [ "$PROGRESS" -eq 1 ] && [ "$_total_in_dir" -gt 0 ]; then
+            printf '\r%80s\r' '' >&2
+            PROGRESS_ACTIVE=0
+        fi
     done
     exec 3<&-
 
@@ -779,7 +1130,12 @@ main() {
         collection_marker "$_base_url" "end" "$_SCAN_ID" "$_stats" >/dev/null
     fi
 
+    # Exit code: 0 = success, 1 = partial failure (some uploads failed)
+    if [ "$FILES_FAILED" -gt 0 ]; then
+        return 1
+    fi
     return 0
 }
 
 main "$@"
+exit $?

--- a/scripts/thunderstorm-collector-ps2.ps1
+++ b/scripts/thunderstorm-collector-ps2.ps1
@@ -85,6 +85,19 @@ param(
         [Alias('SSL')]
         [switch]$UseSSL,
 
+    [Parameter(HelpMessage='Path to custom CA certificate bundle for TLS verification')]
+        [string]$CACert,
+
+    [Parameter(HelpMessage='Skip TLS certificate verification')]
+        [Alias('k')]
+        [switch]$Insecure,
+
+    [Parameter(HelpMessage='Force enable progress reporting')]
+        [switch]$Progress,
+
+    [Parameter(HelpMessage='Force disable progress reporting')]
+        [switch]$NoProgress,
+
     [Parameter(HelpMessage='Enable debug output')]
         [Alias('D')]
         [switch]$Debugging
@@ -93,6 +106,11 @@ param(
 # Fixing Certain Platform Environments --------------------------------
 $AutoDetectPlatform = ""
 $OutputPath = $PSScriptRoot
+# When run via 'powershell -Command', $PSScriptRoot is empty; fall back to TEMP
+if ( -not $OutputPath -or $OutputPath -eq "" ) {
+    $OutputPath = $env:TEMP
+}
+$global:NoLog = $false
 
 # Microsoft Defender ATP - Live Response
 if ( $OutputPath -eq "" -or $OutputPath -like "*Advanced Threat Protection*" ) {
@@ -127,11 +145,50 @@ if ($AllExtensions) {
 # Debug
 $Debug = $Debugging
 
+# Progress reporting: auto-detect TTY unless overridden
+$ShowProgress = $false
+if ($Progress) {
+    $ShowProgress = $true
+} elseif ($NoProgress) {
+    $ShowProgress = $false
+} else {
+    # Auto-detect: check if stdout is interactive (TTY)
+    try {
+        # First check if the environment is interactive at all
+        if (-not [Environment]::UserInteractive) {
+            $ShowProgress = $false
+        } else {
+            # Check if output is redirected (.NET 4.5+ only)
+            $isRedirected = $false
+            try {
+                $isRedirected = [Console]::IsOutputRedirected
+            } catch {
+                # Property not available in older .NET; fall back to host check
+                $isRedirected = $false
+            }
+            if ($isRedirected) {
+                $ShowProgress = $false
+            } else {
+                # Verify we have a real console window (not a non-interactive host)
+                $hostName = $Host.Name
+                if ($hostName -eq 'ConsoleHost') {
+                    $ShowProgress = [Console]::WindowWidth -gt 0
+                } else {
+                    # ISE, remoting, custom hosts — no carriage-return progress
+                    $ShowProgress = $false
+                }
+            }
+        }
+    } catch {
+        $ShowProgress = $false
+    }
+}
+
 # Show Help -----------------------------------------------------------
-if ( $Args.Count -eq 0 -and $ThunderstormServer -eq "" ) {
+if ( $ThunderstormServer -eq "" ) {
     Get-Help $MyInvocation.MyCommand.Definition -Detailed
     Write-Host -ForegroundColor Yellow 'Note: You must at least define a Thunderstorm server (-ThunderstormServer)'
-    return
+    exit 2
 }
 
 # #####################################################################
@@ -170,7 +227,7 @@ function Write-Log {
     if ( $Level -eq "Warning" ) {
         Write-Warning "$($Indicator) $($Entry)"
     } elseif ( $Level -eq "Error" ) {
-        Write-Host "$($Indicator) $($Entry)" -ForegroundColor Red
+        [Console]::Error.WriteLine("$($Indicator) $($Entry)")
     } elseif ( $Level -eq "Debug" -and $Debug -eq $False ) {
         return
     } else {
@@ -179,48 +236,129 @@ function Write-Log {
 
     # Log File
     if ( $global:NoLog -eq $False ) {
-        $ts = Get-Date -Format 'yyyy-MM-dd HH:mm:ss.fff'
-        "$ts $($env:COMPUTERNAME): $Entry" | Out-File -FilePath $LogFile -Append
+        try {
+            $ts = Get-Date -Format 'yyyy-MM-dd HH:mm:ss.fff'
+            $LogFilePath = $LogFile
+            if ($OutputPath -and (Test-Path $OutputPath -PathType Container)) {
+                $LogFilePath = Join-Path $OutputPath $LogFile
+            }
+            "$ts $($env:COMPUTERNAME): $Entry" | Out-File -FilePath $LogFilePath -Append
+        } catch {
+            # Logging failure should not affect collection
+        }
     }
 }
 
 # Submit-File: uploads a file using System.Net.HttpWebRequest (PS 2.0 compatible)
+# Streams file content directly from disk to avoid loading entire file into memory.
 # Returns the HTTP status code (int) or 0 on connection failure.
 function Submit-File {
     param(
         [Parameter(Mandatory=$True)][string]$Url,
         [Parameter(Mandatory=$True)][string]$FilePath,
-        [Parameter(Mandatory=$True)][byte[]]$FileBytes
+        [Parameter(Mandatory=$True)][long]$FileSize
     )
 
     $boundary = [System.Guid]::NewGuid().ToString()
     $CRLF = "`r`n"
 
-    # Build multipart header and footer as ASCII bytes
-    $headerText = "--$boundary$CRLF" +
-        "Content-Disposition: form-data; name=`"file`"; filename=`"$FilePath`"$CRLF" +
+    # Build multipart metadata fields for hostname, source, and filepath
+    $FileName = [System.IO.Path]::GetFileName($FilePath)
+    $EncodedFilename = [uri]::EscapeDataString($FileName)
+
+    # Sanitize field values: strip CR/LF to prevent multipart boundary injection
+    $SafeHostname = ($env:COMPUTERNAME) -replace '[\r\n]', ''
+    $SafeSource = ($Source) -replace '[\r\n]', ''
+    $SafeFilePath = ($FilePath) -replace '[\r\n]', ''
+
+    $metadataText = ""
+    # hostname field
+    $metadataText += "--$boundary$CRLF"
+    $metadataText += "Content-Disposition: form-data; name=`"hostname`"$CRLF$CRLF"
+    $metadataText += "$SafeHostname$CRLF"
+    # source field
+    $metadataText += "--$boundary$CRLF"
+    $metadataText += "Content-Disposition: form-data; name=`"source`"$CRLF$CRLF"
+    $metadataText += "$SafeSource$CRLF"
+    # filepath field
+    $metadataText += "--$boundary$CRLF"
+    $metadataText += "Content-Disposition: form-data; name=`"filepath`"$CRLF$CRLF"
+    $metadataText += "$SafeFilePath$CRLF"
+
+    # File part header and footer
+    # Use RFC 5987 encoding for filename to safely handle special characters
+    # Build ASCII-safe fallback filename: replace non-ASCII and control chars with underscores
+    $SafeAsciiFilename = ""
+    foreach ($ch in $FileName.ToCharArray()) {
+        $code = [int]$ch
+        if ($code -ge 0x20 -and $code -le 0x7E -and $ch -ne '"' -and $ch -ne '\') {
+            $SafeAsciiFilename += $ch
+        } else {
+            $SafeAsciiFilename += '_'
+        }
+    }
+    if ($SafeAsciiFilename -eq '') { $SafeAsciiFilename = 'upload' }
+    $fileHeaderText = "--$boundary$CRLF" +
+        "Content-Disposition: form-data; name=`"file`"; filename=`"$SafeAsciiFilename`"; filename*=UTF-8''$EncodedFilename$CRLF" +
         "Content-Type: application/octet-stream$CRLF$CRLF"
     $footerText = "$CRLF--$boundary--$CRLF"
 
-    $headerBytes = [System.Text.Encoding]::ASCII.GetBytes($headerText)
-    $footerBytes = [System.Text.Encoding]::ASCII.GetBytes($footerText)
-
-    $contentLength = $headerBytes.Length + $FileBytes.Length + $footerBytes.Length
+    $metadataBytes = [System.Text.Encoding]::UTF8.GetBytes($metadataText)
+    $fileHeaderBytes = [System.Text.Encoding]::UTF8.GetBytes($fileHeaderText)
+    $footerBytes = [System.Text.Encoding]::UTF8.GetBytes($footerText)
 
     try {
+        # Open the file first to get authoritative size and fail fast if locked/missing
+        $fileStream = $null
+        try {
+            $fileStream = [System.IO.File]::Open($FilePath, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+        } catch {
+            Write-Log "Cannot open file: $FilePath - $($_.Exception.Message)" -Level "Error"
+            return -1
+        }
+
+        $actualFileSize = $fileStream.Length
+        $contentLength = $metadataBytes.Length + $fileHeaderBytes.Length + $actualFileSize + $footerBytes.Length
+
         $request = [System.Net.HttpWebRequest]::Create($Url)
         $request.Method = "POST"
         $request.ContentType = "multipart/form-data; boundary=$boundary"
         $request.ContentLength = $contentLength
         $request.Timeout = 120000  # 120 seconds
         $request.AllowAutoRedirect = $true
+        $request.AllowWriteStreamBuffering = $false
+        $request.Headers.Add("X-Hostname", $env:COMPUTERNAME)
 
-        # Write raw bytes directly to the request stream — no encoding layer
-        $stream = $request.GetRequestStream()
-        $stream.Write($headerBytes, 0, $headerBytes.Length)
-        $stream.Write($FileBytes, 0, $FileBytes.Length)
-        $stream.Write($footerBytes, 0, $footerBytes.Length)
-        $stream.Close()
+        # Stream metadata and file content directly into the request stream
+        $stream = $null
+        try {
+            $stream = $request.GetRequestStream()
+            $stream.Write($metadataBytes, 0, $metadataBytes.Length)
+            $stream.Write($fileHeaderBytes, 0, $fileHeaderBytes.Length)
+
+            try {
+                $buffer = New-Object byte[] 65536
+                $totalBytesWritten = [long]0
+                $bytesRead = 0
+                do {
+                    $bytesRead = $fileStream.Read($buffer, 0, $buffer.Length)
+                    if ($bytesRead -gt 0) {
+                        # Clamp to declared size to prevent writing more than ContentLength
+                        $remaining = $actualFileSize - $totalBytesWritten
+                        if ($bytesRead -gt $remaining) { $bytesRead = [int]$remaining }
+                        if ($bytesRead -le 0) { break }
+                        $stream.Write($buffer, 0, $bytesRead)
+                        $totalBytesWritten += $bytesRead
+                    }
+                } while ($bytesRead -gt 0 -and $totalBytesWritten -lt $actualFileSize)
+            } finally {
+                if ($fileStream -ne $null) { $fileStream.Close() }
+            }
+
+            $stream.Write($footerBytes, 0, $footerBytes.Length)
+        } finally {
+            if ($stream -ne $null) { $stream.Close() }
+        }
 
         $response = $request.GetResponse()
         $statusCode = [int]$response.StatusCode
@@ -264,7 +402,7 @@ Write-Host "                                                              "
 Write-Host "=============================================================="
 
 # Measure time
-$StartTime = Get-Date
+$global:StartTime = Get-Date
 
 Write-Log "Started Thunderstorm Collector (PS2) with PowerShell v$($PSVersionTable.PSVersion)"
 
@@ -293,6 +431,75 @@ if ( $UseSSL ) {
             Write-Log "WARNING: Could not set TLS 1.2. HTTPS may fail on this system." -Level "Warning"
         }
     }
+    # Reject conflicting TLS options
+    if ( $Insecure -and $CACert ) {
+        Write-Log "Cannot use both -Insecure and -CACert at the same time" -Level "Error"
+        exit 2
+    }
+    # Handle --insecure: skip certificate validation
+    if ( $Insecure ) {
+        [System.Net.ServicePointManager]::ServerCertificateValidationCallback = { $true }
+        Write-Log "TLS certificate verification DISABLED (insecure mode)" -Level "Warning"
+    }
+    # Handle --ca-cert: custom CA bundle (single cert or PEM bundle)
+    if ( $CACert ) {
+        if ( -not (Test-Path $CACert) ) {
+            Write-Log "CA certificate file not found: $CACert" -Level "Error"
+            exit 2
+        }
+        try {
+            # Try to load as a PEM bundle containing multiple certificates
+            $caCerts = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2Collection
+            $pemContent = [System.IO.File]::ReadAllText($CACert)
+            $pemPattern = '-----BEGIN CERTIFICATE-----[^-]+-----END CERTIFICATE-----'
+            $pemMatches = [regex]::Matches($pemContent, $pemPattern)
+            if ($pemMatches.Count -gt 0) {
+                foreach ($pemMatch in $pemMatches) {
+                    $certText = $pemMatch.Value -replace '-----BEGIN CERTIFICATE-----', '' -replace '-----END CERTIFICATE-----', ''
+                    $certText = $certText.Trim()
+                    $certBytes = [Convert]::FromBase64String($certText)
+                    $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2(,$certBytes)
+                    $caCerts.Add($cert) | Out-Null
+                }
+                Write-Log "Loaded $($caCerts.Count) certificate(s) from CA bundle: $CACert"
+            } else {
+                # Try loading as a single DER/PFX certificate file
+                $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($CACert)
+                $caCerts.Add($cert) | Out-Null
+                Write-Log "Loaded single CA certificate: $CACert"
+            }
+            if ($caCerts.Count -eq 0) {
+                Write-Log "No certificates found in CA file: $CACert" -Level "Error"
+                exit 2
+            }
+            [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {
+                param($sender, $certificate, $chain, $sslPolicyErrors)
+                # Build a chain using the provided CA certificates
+                $chainObj = New-Object System.Security.Cryptography.X509Certificates.X509Chain
+                foreach ($ca in $caCerts) {
+                    $chainObj.ChainPolicy.ExtraStore.Add($ca) | Out-Null
+                }
+                $chainObj.ChainPolicy.VerificationFlags = [System.Security.Cryptography.X509Certificates.X509VerificationFlags]::AllowUnknownCertificateAuthority
+                $chainObj.ChainPolicy.RevocationMode = [System.Security.Cryptography.X509Certificates.X509RevocationMode]::NoCheck
+                $valid = $chainObj.Build($certificate)
+                if (-not $valid) { return $false }
+                # Verify that the chain root is one of the supplied CA certificates
+                $chainRoot = $chainObj.ChainElements[$chainObj.ChainElements.Count - 1].Certificate
+                $rootThumbprint = $chainRoot.Thumbprint
+                $anchored = $false
+                foreach ($ca in $caCerts) {
+                    if ($ca.Thumbprint -eq $rootThumbprint) {
+                        $anchored = $true
+                        break
+                    }
+                }
+                return $anchored
+            }
+        } catch {
+            Write-Log "Failed to load CA certificate: $_" -Level "Error"
+            exit 2
+        }
+    }
     Write-Log "HTTPS mode enabled"
 }
 
@@ -309,6 +516,79 @@ $Url = "$BaseUrl/api/checkAsync$($SourceParam)"
 Write-Log "Sending to URI: $($Url)" -Level "Debug"
 $ScanId = ""
 
+# PS 2.0 compatible JSON escape helper — single-pass over original string
+function Escape-JsonString {
+    param([string]$s)
+    if ($s -eq $null) { return "" }
+    $sb = New-Object System.Text.StringBuilder
+    foreach ($c in $s.ToCharArray()) {
+        $code = [int]$c
+        switch ($c) {
+            '"'  { $sb.Append('\"') | Out-Null }
+            '\'  { $sb.Append('\\') | Out-Null }
+            "`r" { $sb.Append('\r') | Out-Null }
+            "`n" { $sb.Append('\n') | Out-Null }
+            "`t" { $sb.Append('\t') | Out-Null }
+            default {
+                if ($code -eq 0x08) {
+                    $sb.Append('\b') | Out-Null
+                } elseif ($code -eq 0x0C) {
+                    $sb.Append('\f') | Out-Null
+                } elseif ($code -lt 0x20) {
+                    $sb.Append(('\u{0:X4}' -f $code)) | Out-Null
+                } else {
+                    $sb.Append($c) | Out-Null
+                }
+            }
+        }
+    }
+    return $sb.ToString()
+}
+
+# PS 2.0 compatible: extract a JSON string value by key (handles escaped characters)
+function Get-JsonValue {
+    param([string]$Json, [string]$Key)
+    $pattern = '"' + [regex]::Escape($Key) + '"\s*:\s*"((?:\\.|[^"\\])*)"'
+    if ($Json -match $pattern) {
+        # Unescape JSON string escapes
+        # Order matters: \\ must be replaced last to avoid corrupting sequences like \\n
+        # We use a placeholder to avoid double-replacement issues
+        $val = $matches[1]
+        $val = $val.Replace('\\', "`0BACKSLASH`0")
+        $val = $val.Replace('\"', '"')
+        $val = $val.Replace('\/', '/')
+        $val = $val.Replace('\n', "`n")
+        $val = $val.Replace('\r', "`r")
+        $val = $val.Replace('\t', "`t")
+        $val = $val.Replace('\b', "`b")
+        $val = $val.Replace('\f', [char]0x0C)
+        $val = $val.Replace("`0BACKSLASH`0", '\')
+        # Unescape \uXXXX sequences (including surrogate pairs)
+        $val = [regex]::Replace($val, '\\u([0-9a-fA-F]{4})(?:\\u([0-9a-fA-F]{4}))?', {
+            param($m)
+            $cp1 = [int]('0x' + $m.Groups[1].Value)
+            if ($m.Groups[2].Success) {
+                $cp2 = [int]('0x' + $m.Groups[2].Value)
+                # Check if this is a surrogate pair (high surrogate + low surrogate)
+                if ($cp1 -ge 0xD800 -and $cp1 -le 0xDBFF -and $cp2 -ge 0xDC00 -and $cp2 -le 0xDFFF) {
+                    return [char]::ConvertFromUtf32((($cp1 - 0xD800) * 0x400) + ($cp2 - 0xDC00) + 0x10000)
+                } else {
+                    # Not a surrogate pair, decode independently (second \uXXXX will be re-matched)
+                    return [char]$cp1 + [char]$cp2
+                }
+            } else {
+                # Single code unit - reject lone surrogates, decode normally
+                if ($cp1 -ge 0xD800 -and $cp1 -le 0xDFFF) {
+                    return $m.Value  # Leave lone surrogate escaped
+                }
+                return [char]$cp1
+            }
+        })
+        return $val
+    }
+    return ""
+}
+
 function Send-CollectionMarker {
     param(
         [string]$MarkerType,
@@ -316,18 +596,34 @@ function Send-CollectionMarker {
         [hashtable]$Stats = $null
     )
     $MarkerUrl = "$BaseUrl/api/collection"
-    $SourceVal = if ($ThunderstormSource) { $ThunderstormSource } else { $env:COMPUTERNAME }
-    $Body = @{
-        type      = $MarkerType
-        source    = $SourceVal
-        collector = "powershell2/1.0"
-        timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+    $SourceVal = $Source
+    if (-not $SourceVal) { $SourceVal = $env:COMPUTERNAME }
+    $Timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+
+    # Build JSON manually for PS 2.0 compatibility
+    $JsonParts = New-Object System.Collections.ArrayList
+    $JsonParts.Add(('"type":"{0}"' -f (Escape-JsonString $MarkerType))) | Out-Null
+    $JsonParts.Add(('"source":"{0}"' -f (Escape-JsonString $SourceVal))) | Out-Null
+    $JsonParts.Add('"collector":"powershell2/1.0"') | Out-Null
+    $JsonParts.Add(('"timestamp":"{0}"' -f (Escape-JsonString $Timestamp))) | Out-Null
+    if ($ScanId) {
+        $JsonParts.Add(('"scan_id":"{0}"' -f (Escape-JsonString $ScanId))) | Out-Null
     }
-    if ($ScanId) { $Body["scan_id"] = $ScanId }
-    if ($Stats)  { $Body["stats"]   = $Stats  }
+    if ($Stats) {
+        $StatParts = New-Object System.Collections.ArrayList
+        foreach ($key in $Stats.Keys) {
+            $val = $Stats[$key]
+            if ($val -is [int] -or $val -is [long] -or $val -is [double]) {
+                $StatParts.Add(('"' + (Escape-JsonString $key) + '":' + $val.ToString())) | Out-Null
+            } else {
+                $StatParts.Add(('"' + (Escape-JsonString $key) + '":"' + (Escape-JsonString ([string]$val)) + '"')) | Out-Null
+            }
+        }
+        $JsonParts.Add(('"stats":{{{0}}}' -f ($StatParts -join ','))) | Out-Null
+    }
+    $JsonBody = '{' + ($JsonParts -join ',') + '}'
 
     try {
-        $JsonBody = $Body | ConvertTo-Json -Compress
         $JsonBytes = [System.Text.Encoding]::UTF8.GetBytes($JsonBody)
         $Req = [System.Net.HttpWebRequest]::Create($MarkerUrl)
         $Req.Method = "POST"
@@ -338,12 +634,51 @@ function Send-CollectionMarker {
         $Stream.Write($JsonBytes, 0, $JsonBytes.Length)
         $Stream.Close()
         $Resp = $Req.GetResponse()
+        $httpStatus = [int]$Resp.StatusCode
         $Reader = New-Object System.IO.StreamReader($Resp.GetResponseStream())
         $RespBody = $Reader.ReadToEnd()
         $Reader.Close()
-        $RespObj = $RespBody | ConvertFrom-Json
-        return $RespObj.scan_id
+        $Resp.Close()
+
+        # Validate HTTP success first, then attempt scan_id extraction
+        if ($httpStatus -lt 200 -or $httpStatus -ge 300) {
+            Write-Log "Collection marker '$MarkerType' returned unexpected HTTP $httpStatus" -Level "Error"
+            Write-Log "Response body: $RespBody" -Level "Debug"
+            return ""
+        }
+
+        $scanIdResult = Get-JsonValue -Json $RespBody -Key "scan_id"
+        if (-not $scanIdResult) {
+            Write-Log "Collection marker '$MarkerType' HTTP $httpStatus OK but no scan_id found in response" -Level "Warning"
+            Write-Log "Response body: $RespBody" -Level "Debug"
+            # Return a sentinel value to distinguish "HTTP success but no scan_id" from total failure
+            # This allows the caller to know the server was reached successfully
+            return "__NO_SCAN_ID__"
+        }
+        return $scanIdResult
+    } catch [System.Net.WebException] {
+        $ex = $_.Exception
+        if ($ex.Response -ne $null) {
+            $errCode = [int]$ex.Response.StatusCode
+            # 404 or 501 means the server doesn't support collection markers — continue without scan_id
+            if ($errCode -eq 404 -or $errCode -eq 501) {
+                Write-Log "Collection marker '$MarkerType' not supported (HTTP $errCode) — server does not implement /api/collection" -Level "Debug"
+                return ""
+            }
+            Write-Log "Collection marker '$MarkerType' failed with HTTP $errCode" -Level "Error"
+            try {
+                $errReader = New-Object System.IO.StreamReader($ex.Response.GetResponseStream())
+                $errBody = $errReader.ReadToEnd()
+                $errReader.Close()
+                Write-Log "Error response body: $errBody" -Level "Debug"
+            } catch {}
+            $ex.Response.Close()
+        } else {
+            Write-Log "Collection marker '$MarkerType' failed: $($ex.Message)" -Level "Error"
+        }
+        return ""
     } catch {
+        Write-Log "Collection marker '$MarkerType' failed: $_" -Level "Error"
         return ""
     }
 }
@@ -352,30 +687,157 @@ function Send-CollectionMarker {
 # Run THOR Thunderstorm Collector -------------------------------------
 # ---------------------------------------------------------------------
 
-$SubmittedCount = 0
-$ErrorCount = 0
-$ScannedCount = 0
-$SkippedCount = 0
+$global:SubmittedCount = 0
+$global:ErrorCount = 0
+$global:ScannedCount = 0
+$global:SkippedCount = 0
 
-# Send collection begin marker
-$ScanId = Send-CollectionMarker -MarkerType "begin"
-if ($ScanId) {
-    Write-Log "Collection scan_id: $ScanId"
-    $Url = "$Url&scan_id=$([uri]::EscapeDataString($ScanId))"
+# Send collection begin marker with single retry on failure
+$global:ScanId = Send-CollectionMarker -MarkerType "begin"
+if (-not $global:ScanId) {
+    Write-Log "Begin marker failed - retrying in 2 seconds..." -Level "Warning"
+    Start-Sleep -Seconds 2
+    $global:ScanId = Send-CollectionMarker -MarkerType "begin"
+}
+if (-not $global:ScanId) {
+    Write-Log "Could not connect to Thunderstorm server at $BaseUrl - exiting" -Level "Error"
+    exit 2
+}
+# Handle case where server responded OK but did not return a scan_id
+if ($global:ScanId -eq "__NO_SCAN_ID__") {
+    Write-Log "Begin marker succeeded but server did not return a scan_id - retrying..." -Level "Warning"
+    Start-Sleep -Seconds 2
+    $global:ScanId = Send-CollectionMarker -MarkerType "begin"
+    if (-not $global:ScanId -or $global:ScanId -eq "__NO_SCAN_ID__") {
+        Write-Log "Server did not provide a scan_id after retry - protocol error, exiting" -Level "Error"
+        exit 2
+    }
+}
+if ($global:ScanId) {
+    Write-Log "Collection scan_id: $($global:ScanId)"
+    # First parameter uses '?' so subsequent ones use '&'
+    if ($SourceParam -ne "") {
+        $Url = "$Url&scan_id=$([uri]::EscapeDataString($global:ScanId))"
+    } else {
+        $Url = "$Url`?scan_id=$([uri]::EscapeDataString($global:ScanId))"
+    }
+}
+
+# Signal handling: register handler to send interrupted marker on Ctrl+C / SIGTERM
+$global:Interrupted = $false
+$global:InterruptedMarkerSent = $false
+
+# Function to send interrupted marker exactly once
+function Send-InterruptedMarkerOnce {
+    if ($global:InterruptedMarkerSent) { return }
+    $global:InterruptedMarkerSent = $true
+    $global:Interrupted = $true
+    try {
+        Write-Log "Sending interrupted collection marker" -Level "Warning"
+        Send-CollectionMarker -MarkerType "interrupted" -ScanId $global:ScanId -Stats @{
+            scanned         = $global:ScannedCount
+            submitted       = $global:SubmittedCount
+            skipped         = $global:SkippedCount
+            failed          = $global:ErrorCount
+            elapsed_seconds = [int]((Get-Date) - $global:StartTime).TotalSeconds
+        } | Out-Null
+    } catch {
+        # Best-effort: don't let marker send failure prevent shutdown
+    }
+}
+
+
+# PS 2.0 compatible Ctrl+C handling via Register-ObjectEvent on [Console]::CancelKeyPress
+try {
+    [Console]::TreatControlCAsInput = $false
+    Register-ObjectEvent -InputObject ([Console]) -EventName CancelKeyPress -Action {
+        $Event.SourceEventArgs.Cancel = $true
+        $global:Interrupted = $true
+        Send-InterruptedMarkerOnce
+    } | Out-Null
+    Write-Log "Registered Ctrl+C handler via Register-ObjectEvent" -Level "Debug"
+} catch {
+    # Fallback: try direct .NET event subscription
+    try {
+        $handler = [System.ConsoleCancelEventHandler]{
+            param($sender, $e)
+            $e.Cancel = $true
+            $global:Interrupted = $true
+            Send-InterruptedMarkerOnce
+        }
+        [Console]::add_CancelKeyPress($handler)
+        Write-Log "Registered Ctrl+C handler via add_CancelKeyPress" -Level "Debug"
+    } catch {
+        Write-Log "Could not register Ctrl+C handler - interrupted markers on SIGINT not available" -Level "Debug"
+    }
+}
+
+# Note: PowerShell.Exiting fires on ALL exits (including normal completion),
+# so we do NOT register it — it would incorrectly send an "interrupted" marker
+# on clean runs. SIGTERM handling in PS 2.0 is a known limitation.
+
+# trap statement for catchable terminating errors within the script scope
+trap {
+    Send-InterruptedMarkerOnce
+    break
 }
 
 # PS 2 compatible file enumeration (Get-ChildItem -File not available in PS 2)
-$files = Get-ChildItem -Path $Folder -Recurse -ErrorAction SilentlyContinue | Where-Object { -not $_.PSIsContainer }
+# Use incremental enumeration to avoid loading entire file tree into memory.
+# When progress is enabled, do a lightweight count pass first; otherwise process incrementally.
+Write-Log "Scanning files in $Folder ..."
+$TotalFiles = 0
+if ($ShowProgress) {
+    Write-Log "Counting files for progress reporting ..."
+    # Count pass: use Measure-Object to avoid storing all FileInfo objects
+    $countResult = Get-ChildItem -Path $Folder -Recurse -ErrorAction SilentlyContinue | Where-Object { -not $_.PSIsContainer } | Measure-Object
+    $TotalFiles = $countResult.Count
+    Write-Log "Found $TotalFiles files to evaluate in $Folder"
+}
 
-foreach ( $file in $files ) {
+# Use GetEnumerator on the pipeline output to allow 'break' without materializing all results
+$fileEnumerator = $null
+try {
+    $fileEnumerator = (Get-ChildItem -Path $Folder -Recurse -ErrorAction SilentlyContinue | Where-Object { -not $_.PSIsContainer }).GetEnumerator()
+} catch {
+    # GetEnumerator may fail if result is $null (empty folder) or a single item
+    $singleResult = Get-ChildItem -Path $Folder -Recurse -ErrorAction SilentlyContinue | Where-Object { -not $_.PSIsContainer }
+    if ($singleResult -eq $null) {
+        $fileEnumerator = @().GetEnumerator()
+    } else {
+        $fileEnumerator = @($singleResult).GetEnumerator()
+    }
+}
+
+while ($fileEnumerator.MoveNext()) {
+    $file = $fileEnumerator.Current
+
+    # Check for interruption
+    if ($global:Interrupted) {
+        Write-Log "Interrupted by user signal" -Level "Warning"
+        break
+    }
+
     # -----------------------------------------------------------------
     # Filter ----------------------------------------------------------
 
-    $ScannedCount++
+    $global:ScannedCount++
+
+    # -----------------------------------------------------------------
+    # Progress --------------------------------------------------------
+    if ($ShowProgress -and $TotalFiles -gt 0) {
+        $Pct = [int](($global:ScannedCount / $TotalFiles) * 100)
+        if ($Pct -gt 100) { $Pct = 100 }
+        Write-Host -NoNewline ("`r[{0}/{1}] {2}%  " -f $global:ScannedCount, $TotalFiles, $Pct)
+    } elseif ($ShowProgress) {
+        # No total count available; show scanned count only
+        Write-Host -NoNewline ("`r[{0}] scanning...  " -f $global:ScannedCount)
+    }
+
     # Size Check
     if ( ( $file.Length / 1MB ) -gt $MaxSize ) {
         Write-Log "$($file.Name) skipped due to size filter" -Level "Debug"
-        $SkippedCount++
+        $global:SkippedCount++
         continue
     }
 
@@ -383,7 +845,7 @@ foreach ( $file in $files ) {
     if ( $MaxAge -gt 0 ) {
         if ( $file.LastWriteTime -lt (Get-Date).AddDays(-$MaxAge) ) {
             Write-Log "$($file.Name) skipped due to age filter" -Level "Debug"
-            $SkippedCount++
+            $global:SkippedCount++
             continue
         }
     }
@@ -396,7 +858,7 @@ foreach ( $file in $files ) {
         }
         if ( -not $match ) {
             Write-Log "$($file.Name) skipped due to extension filter" -Level "Debug"
-            $SkippedCount++
+            $global:SkippedCount++
             continue
         }
     }
@@ -406,43 +868,56 @@ foreach ( $file in $files ) {
 
     Write-Log "Processing $($file.FullName) ..." -Level "Debug"
 
-    # Read file as raw bytes
-    try {
-        $fileBytes = [System.IO.File]::ReadAllBytes($file.FullName)
-    } catch {
-        Write-Log "Read Error: $_" -Level "Error"
-        $ErrorCount++
-        continue
-    }
-
-    # Submit with retry logic
+    # Submit with retry logic (file is streamed from disk, not loaded into memory)
     $StatusCode = 0
     $Retries = 0
     $MaxRetries = 3
     $Max503Retries = 10
     $Retries503 = 0
     $script:LastRetryAfter = $null
+    $FileSubmitted = $false
+    $FileRetryStart = Get-Date
+    $MaxRetrySeconds = 300  # Cap total retry time per file at 5 minutes
 
     while ( $StatusCode -ne 200 ) {
+        if ($global:Interrupted) { break }
+        # Check total elapsed retry time for this file
+        if (((Get-Date) - $FileRetryStart).TotalSeconds -gt $MaxRetrySeconds) {
+            Write-Log "Total retry time exceeded ${MaxRetrySeconds}s - giving up on $($file.FullName)" -Level "Error"
+            $global:ErrorCount++
+            break
+        }
 
         Write-Log "Submitting to Thunderstorm server: $($file.FullName) ..." -Level "Info"
-        $StatusCode = Submit-File -Url $Url -FilePath $file.FullName -FileBytes $fileBytes
+        $StatusCode = Submit-File -Url $Url -FilePath $file.FullName -FileSize $file.Length
 
         if ( $StatusCode -eq 200 ) {
-            $SubmittedCount++
+            $global:SubmittedCount++
+            $FileSubmitted = $true
+            break
+        }
+        elseif ( $StatusCode -eq -1 ) {
+            # File could not be opened (missing, locked, permission denied) — no retry
+            Write-Log "Skipping file due to open failure: $($file.FullName)" -Level "Error"
+            $global:ErrorCount++
             break
         }
         elseif ( $StatusCode -eq 503 ) {
             $Retries503++
             if ( $Retries503 -ge $Max503Retries ) {
                 Write-Log "503: Server still busy after $Max503Retries retries - giving up on $($file.FullName)" -Level "Warning"
+                $global:ErrorCount++
                 break
             }
             $WaitSecs = 3
             if ( $script:LastRetryAfter -ne $null ) {
-                try { $WaitSecs = [int]$script:LastRetryAfter } catch { $WaitSecs = 3 }
+                try {
+                    $WaitSecs = [int]$script:LastRetryAfter
+                    if ($WaitSecs -lt 1) { $WaitSecs = 3 }
+                    if ($WaitSecs -gt 60) { $WaitSecs = 60 }
+                } catch { $WaitSecs = 3 }
             }
-            Write-Log "503: Server seems busy - retrying in $WaitSecs seconds ($Retries503/$Max503Retries)"
+            Write-Log "503: Server seems busy - retrying in $WaitSecs seconds ($Retries503/$Max503Retries)" -Level "Warning"
             Start-Sleep -Seconds $WaitSecs
         }
         elseif ( $StatusCode -eq 0 ) {
@@ -450,40 +925,62 @@ foreach ( $file in $files ) {
             $Retries++
             if ( $Retries -ge $MaxRetries ) {
                 Write-Log "Connection failed after $MaxRetries retries - giving up on $($file.FullName)" -Level "Error"
-                $ErrorCount++
+                $global:ErrorCount++
                 break
             }
-            $SleepTime = 2 * [Math]::Pow(2, $Retries)
-            Write-Log "Connection failed - retrying in $SleepTime seconds ($Retries/$MaxRetries)"
+            $SleepTime = [int](2 * [Math]::Pow(2, $Retries - 1))
+            Write-Log "Connection failed - retrying in $SleepTime seconds ($Retries/$MaxRetries)" -Level "Warning"
             Start-Sleep -Seconds $SleepTime
         }
         else {
             $Retries++
             if ( $Retries -ge $MaxRetries ) {
                 Write-Log "$($StatusCode): Server error after $MaxRetries retries - giving up on $($file.FullName)" -Level "Error"
-                $ErrorCount++
+                $global:ErrorCount++
                 break
             }
-            $SleepTime = 2 * [Math]::Pow(2, $Retries)
-            Write-Log "$($StatusCode): Server has problems - retrying in $SleepTime seconds ($Retries/$MaxRetries)"
+            $SleepTime = [int](2 * [Math]::Pow(2, $Retries - 1))
+            Write-Log "$($StatusCode): Server has problems - retrying in $SleepTime seconds ($Retries/$MaxRetries)" -Level "Warning"
             Start-Sleep -Seconds $SleepTime
         }
     }
 }
 
+# Clear progress line if it was shown
+if ($ShowProgress -and $TotalFiles -gt 0) {
+    Write-Host ("`r" + (" " * 60) + "`r") -NoNewline
+}
+
 # ---------------------------------------------------------------------
 # End -----------------------------------------------------------------
 # ---------------------------------------------------------------------
-$ElapsedTime = (Get-Date) - $StartTime
+$ElapsedTime = (Get-Date) - $global:StartTime
 $TotalTime = "{0:HH:mm:ss}" -f ([datetime]$ElapsedTime.Ticks)
-Write-Log "Submitted $SubmittedCount files ($ErrorCount errors) in $TotalTime" -Level "Info"
-Write-Log "Results: scanned=$ScannedCount submitted=$SubmittedCount skipped=$SkippedCount failed=$ErrorCount"
+Write-Log "Submitted $($global:SubmittedCount) files ($($global:ErrorCount) errors) in $TotalTime" -Level "Info"
+Write-Log "Results: scanned=$($global:ScannedCount) submitted=$($global:SubmittedCount) skipped=$($global:SkippedCount) failed=$($global:ErrorCount)"
 
-# Send collection end marker with stats
-Send-CollectionMarker -MarkerType "end" -ScanId $ScanId -Stats @{
-    scanned         = $ScannedCount
-    submitted       = $SubmittedCount
-    skipped         = $SkippedCount
-    failed          = $ErrorCount
-    elapsed_seconds = [int]$ElapsedTime.TotalSeconds
-} | Out-Null
+# Send collection end or interrupted marker with stats
+# If interrupted marker was already sent by signal handler, skip duplicate
+if ($global:InterruptedMarkerSent) {
+    Write-Log "Interrupted marker already sent by signal handler - skipping end marker"
+} else {
+    $EndMarkerType = "end"
+    if ($global:Interrupted) {
+        $EndMarkerType = "interrupted"
+        Write-Log "Sending interrupted collection marker" -Level "Warning"
+    }
+    Send-CollectionMarker -MarkerType $EndMarkerType -ScanId $global:ScanId -Stats @{
+        scanned         = $global:ScannedCount
+        submitted       = $global:SubmittedCount
+        skipped         = $global:SkippedCount
+        failed          = $global:ErrorCount
+        elapsed_seconds = [int]$ElapsedTime.TotalSeconds
+    } | Out-Null
+}
+
+# Exit codes: 0 = success, 1 = partial failure, 2 = fatal error
+if ($global:ErrorCount -gt 0) {
+    exit 1
+} else {
+    exit 0
+}

--- a/scripts/thunderstorm-collector-py2.py
+++ b/scripts/thunderstorm-collector-py2.py
@@ -21,6 +21,7 @@ import httplib
 import json
 import os
 import re
+import signal
 import socket
 import ssl
 import time
@@ -45,11 +46,13 @@ skip_elements = [
     r"\.vmsd$",
     r"\.lck$",
 ]
-hard_skips = [
-    "/proc", "/dev", "/sys", "/run",
-    "/snap", "/.snapshots",
-    "/sys/kernel/debug", "/sys/kernel/slab", "/sys/kernel/tracing",
-]
+hard_skips = set(
+    os.path.normpath(p) for p in [
+        "/proc", "/dev", "/sys", "/run",
+        "/snap", "/.snapshots",
+        "/sys/kernel/debug", "/sys/kernel/slab", "/sys/kernel/tracing",
+    ]
+)
 
 NETWORK_FS_TYPES = set(["nfs", "nfs4", "cifs", "smbfs", "smb3", "sshfs", "fuse.sshfs",
                         "afp", "webdav", "davfs2", "fuse.rclone", "fuse.s3fs"])
@@ -96,37 +99,171 @@ current_date = time.time()
 # Stats
 num_submitted = 0
 num_processed = 0
+num_failed = 0
 
-# URL to use for submission
-api_endpoint = ""
+# Path+query to use for submission (just the path portion, not full URL)
+api_endpoint = None
 
-# Original args
-args = {}
+# scan_id for collection markers
+scan_id = None
+
+# Whether we were interrupted
+interrupted = False
+
+# Original args — use a namespace with defaults so signal_handler won't crash
+# if triggered before argparse runs
+class _DefaultArgs(object):
+    server = "localhost"
+    port = 8080
+    tls = False
+    insecure = False
+    ca_cert = None
+    source = None
+    debug = False
+
+args = _DefaultArgs()
+
+# Progress reporting
+progress_enabled = None  # None = auto-detect TTY
+
+
+def make_connection(server, port, use_tls, insecure, ca_cert=None, timeout=30):
+    """Create an HTTP(S) connection with proper TLS settings."""
+    if use_tls:
+        if insecure:
+            if hasattr(ssl, '_create_unverified_context'):
+                context = ssl._create_unverified_context()
+            else:
+                context = None  # pre-2.7.9: no verification by default
+        else:
+            if hasattr(ssl, 'create_default_context'):
+                context = ssl.create_default_context()
+                if ca_cert:
+                    context.load_verify_locations(ca_cert)
+            else:
+                if ca_cert:
+                    print_stderr("[ERROR] Python runtime lacks ssl.create_default_context(); "
+                                 "cannot enforce --ca-cert verification.")
+                    sys.exit(2)
+                context = None  # pre-2.7.9: limited TLS, no SNI
+        if context is not None:
+            conn = httplib.HTTPSConnection(server, port, context=context, timeout=timeout)
+        else:
+            conn = httplib.HTTPSConnection(server, port, timeout=timeout)
+    else:
+        conn = httplib.HTTPConnection(server, port, timeout=timeout)
+    return conn
+
+
+def print_stderr(msg):
+    """Print error messages to stderr."""
+    if progress_enabled:
+        sys.stderr.write("\r" + " " * 80 + "\r")
+    sys.stderr.write(msg + "\n")
+    sys.stderr.flush()
+
+
+def show_progress(current, filepath):
+    """Show progress indicator if enabled."""
+    if not progress_enabled:
+        return
+    # We don't know total ahead of time, so show count
+    display_path = filepath[-60:] if len(filepath) > 60 else filepath
+    try:
+        sys.stderr.write("\r[{0} scanned] Processing: {1} ...{2}".format(
+            current, display_path, " " * 10))
+        sys.stderr.flush()
+    except (UnicodeEncodeError, UnicodeDecodeError):
+        # Skip progress display for paths with encoding issues
+        pass
+
+
+def send_interrupted_marker():
+    """Send an interrupted collection marker with current stats."""
+    global interrupted
+    if interrupted:
+        return
+    interrupted = True
+    end_date = time.time()
+    elapsed = int(end_date - current_date)
+    collection_marker(
+        args.server, args.port, args.tls, args.insecure,
+        getattr(args, 'ca_cert', None),
+        args.source or socket.gethostname(), "0.1",
+        "interrupted",
+        scan_id=scan_id,
+        stats={
+            "scanned": num_processed,
+            "submitted": num_submitted,
+            "failed": num_failed,
+            "elapsed_seconds": elapsed,
+        }
+    )
+
+
+def signal_handler(signum, frame):
+    """Handle SIGINT/SIGTERM gracefully."""
+    if interrupted:
+        # Already handling a signal; avoid re-entrance
+        sys.exit(1)
+    # Ignore further signals while we clean up
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    sig_name = "SIGINT" if signum == signal.SIGINT else "SIGTERM"
+    print_stderr("\n[INFO] Received {}, sending interrupted marker...".format(sig_name))
+    try:
+        send_interrupted_marker()
+    except Exception as e:
+        print_stderr("[ERROR] Failed to send interrupted marker: {}".format(e))
+    if progress_enabled:
+        sys.stderr.write("\n")
+    print("Thunderstorm Collector Run interrupted (Checked: {} Submitted: {} Failed: {})".format(
+        num_processed, num_submitted, num_failed
+    ))
+    sys.exit(1)
 
 
 def process_dir(workdir):
+    global num_processed
+
+    # Skip if the workdir itself is in hard_skips
+    if os.path.normpath(workdir) in hard_skips:
+        if args.debug:
+            print("[DEBUG] Skipping hard-skipped directory {}".format(workdir))
+        return
+
     for dirpath, dirnames, filenames in os.walk(workdir, followlinks=False):
         # Hard skip directories (modify in-place to prevent descent)
-        dirnames[:] = [
-            d for d in dirnames
-            if os.path.join(dirpath, d) not in hard_skips
-            and not os.path.islink(os.path.join(dirpath, d))
-            and not is_cloud_path(os.path.join(dirpath, d))
-        ]
+        filtered = []
+        for d in dirnames:
+            full = os.path.join(dirpath, d)
+            if os.path.normpath(full) in hard_skips:
+                continue
+            if os.path.islink(full):
+                continue
+            if is_cloud_path(full):
+                continue
+            filtered.append(d)
+        dirnames[:] = filtered
 
         for name in filenames:
             filepath = os.path.join(dirpath, name)
 
-            # Skip symlinks
-            if os.path.islink(filepath):
+            try:
+                # Skip symlinks
+                if os.path.islink(filepath):
+                    continue
+            except (OSError, IOError):
                 continue
 
             if args.debug:
                 print("[DEBUG] Checking {} ...".format(filepath))
 
             # Count
-            global num_processed
             num_processed += 1
+
+            # Show progress
+            show_progress(num_processed, filepath)
 
             # Skip files
             if skip_file(filepath):
@@ -150,7 +287,7 @@ def skip_file(filepath):
         mtime = os.path.getmtime(filepath)
     except (OSError, IOError):
         if args.debug:
-            print("[DEBUG] Skipping unreadable file {}".format(filepath))
+            print_stderr("[DEBUG] Skipping unreadable file {}".format(filepath))
         return True
 
     if file_size > max_size_kb * 1024:
@@ -158,8 +295,8 @@ def skip_file(filepath):
             print("[DEBUG] Skipping file due to size {}".format(filepath))
         return True
 
-    # Age
-    if mtime < current_date - (max_age * 86400):
+    # Age (max_age=0 means no age filtering)
+    if max_age > 0 and mtime < current_date - (max_age * 86400):
         if args.debug:
             print("[DEBUG] Skipping file due to age {}".format(filepath))
         return True
@@ -168,99 +305,174 @@ def skip_file(filepath):
 
 
 def submit_sample(filepath):
+    global num_submitted, num_failed
+
     if dry_run:
         print("[DRY-RUN] Would submit {} ...".format(filepath))
-        global num_submitted
         num_submitted += 1
         return
 
     print("[SUBMIT] Submitting {} ...".format(filepath))
 
-    try:
-        with open(filepath, "rb") as f:
-            data = f.read()
-    except Exception as e:
-        print("[ERROR] Could not read '{}' - {}".format(filepath, e))
+    if not api_endpoint:
+        print_stderr("[ERROR] API endpoint not configured; cannot submit.")
+        num_failed += 1
         return
+
+    HARD_MAX_BYTES = 200 * 1024 * 1024
 
     boundary = str(uuid.uuid4())
 
-    # Sanitize filename for multipart header safety
-    safe_filename = filepath.replace('"', '_').replace(';', '_').replace('\r', '_').replace('\n', '_')
+    # Sanitize filename for multipart header safety — use basename only for the
+    # multipart filename; the full path is already sent in the source_path field.
+    safe_filename = os.path.basename(filepath)
+    # Remove/replace characters unsafe for Content-Disposition header
+    for ch in ['\\', '"', ';', '\r', '\n', '\x00', '\t']:
+        safe_filename = safe_filename.replace(ch, '_')
+    # Ensure filename is not empty after sanitization
+    if not safe_filename or safe_filename.strip('.') == '':
+        safe_filename = 'unnamed_file'
 
-    # Build multipart/form-data payload manually (no external libs)
-    payload = (
-        "--{boundary}\r\n"
-        "Content-Disposition: form-data; name=\"file\"; filename=\"{filename}\"\r\n"
-        "Content-Type: application/octet-stream\r\n\r\n"
-    ).format(boundary=boundary, filename=safe_filename).encode("utf-8")
-    payload += data
-    payload += "\r\n--{}--\r\n".format(boundary).encode("utf-8")
+    hostname = socket.gethostname()
+    source = args.source or hostname
+
+    # Build multipart preamble and epilogue (metadata + file header/footer)
+    # In Python 2, keep everything as byte strings to avoid UnicodeDecodeError
+    # when hostname or filepath contains non-ASCII bytes.
+    boundary_bytes = boundary.encode('ascii') if isinstance(boundary, unicode) else boundary
+
+    def _form_field(name, value):
+        if isinstance(value, unicode):
+            value = value.encode('utf-8', 'replace')
+        elif not isinstance(value, bytes):
+            value = str(value)
+        part = b"--" + boundary_bytes + b"\r\n"
+        part += b"Content-Disposition: form-data; name=\"" + name.encode('ascii') + b"\"\r\n\r\n"
+        part += value + b"\r\n"
+        return part
+
+    preamble = b""
+    preamble += _form_field("hostname", hostname)
+    preamble += _form_field("source", source)
+    preamble += _form_field("source_path", filepath)
+
+    safe_filename_bytes = safe_filename.encode('utf-8', 'replace') if isinstance(safe_filename, unicode) else safe_filename
+    file_header = b"--" + boundary_bytes + b"\r\n"
+    file_header += b"Content-Disposition: form-data; name=\"file\"; filename=\"" + safe_filename_bytes + b"\"\r\n"
+    file_header += b"Content-Type: application/octet-stream\r\n\r\n"
+    preamble += file_header
+
+    epilogue = b"\r\n--" + boundary_bytes + b"--\r\n"
+
+    # Read entire file into memory (capped at HARD_MAX_BYTES) so we know the exact
+    # length before sending, avoiding Content-Length mismatches if the file changes.
+    try:
+        with open(filepath, "rb") as f:
+            file_data = f.read(HARD_MAX_BYTES + 1)
+    except (OSError, IOError) as e:
+        print_stderr("[ERROR] Could not read '{}' - {}".format(filepath, e))
+        num_failed += 1
+        return
+
+    if len(file_data) > HARD_MAX_BYTES:
+        print_stderr("[ERROR] File '{}' exceeds hard size limit (>{}B)".format(
+            filepath, HARD_MAX_BYTES))
+        num_failed += 1
+        return
+
+    if len(file_data) == 0:
+        if args.debug:
+            print("[DEBUG] Skipping empty file {}".format(filepath))
+        return
+
+    content_length = len(preamble) + len(file_data) + len(epilogue)
 
     headers = {
         "Content-Type": "multipart/form-data; boundary={}".format(boundary),
+        "Content-Length": str(content_length),
     }
 
     attempt = 0
+    max_retry_after = 300  # Cap Retry-After at 5 minutes
     while attempt < retries:
+        conn = None
+        resp = None
         try:
-            if args.tls:
-                # ssl.create_default_context() requires Python 2.7.9+
-                # ssl._create_unverified_context() also requires 2.7.9+
-                # Fall back to bare HTTPSConnection for older Python 2.7
-                if args.insecure:
-                    if hasattr(ssl, '_create_unverified_context'):
-                        context = ssl._create_unverified_context()
-                    else:
-                        context = None  # pre-2.7.9: no verification by default
-                else:
-                    if hasattr(ssl, 'create_default_context'):
-                        context = ssl.create_default_context()
-                    else:
-                        context = None  # pre-2.7.9: limited TLS, no SNI
-                if context is not None:
-                    conn = httplib.HTTPSConnection(args.server, args.port, context=context)
-                else:
-                    conn = httplib.HTTPSConnection(args.server, args.port)
-            else:
-                conn = httplib.HTTPConnection(args.server, args.port)
-            conn.request("POST", api_endpoint, body=payload, headers=headers)
+            conn = make_connection(args.server, args.port, args.tls, args.insecure,
+                                   getattr(args, 'ca_cert', None))
+            conn.putrequest("POST", api_endpoint)
+            for hdr, val in headers.items():
+                conn.putheader(hdr, val)
+            conn.endheaders()
+
+            # Send: preamble
+            conn.send(preamble)
+
+            # Send: file data
+            conn.send(file_data)
+
+            # Send: epilogue
+            conn.send(epilogue)
+
             resp = conn.getresponse()
+            resp.read()  # Drain response body to allow connection reuse
 
         except Exception as e:
-            print("[ERROR] Could not submit '{}' - {}".format(filepath, e))
+            print_stderr("[ERROR] Could not submit '{}' - {}".format(filepath, e))
             attempt += 1
-            time.sleep(2 << attempt)
+            if attempt < retries:
+                backoff = min(2 ** attempt, 60)
+                time.sleep(backoff)
+            continue
+        finally:
+            if conn is not None:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+
+        if resp is None:
+            attempt += 1
             continue
 
         if resp.status == 503:
             attempt += 1
             if attempt >= retries:
-                print("[ERROR] Server busy after {} retries, giving up on '{}'".format(retries, filepath))
+                print_stderr("[ERROR] Server busy after {} attempts, giving up on '{}'".format(retries, filepath))
                 break
             retry_after = resp.getheader("Retry-After", "30")
             try:
-                retry_time = int(retry_after)
+                retry_time = min(int(retry_after), max_retry_after)
+                if retry_time < 0:
+                    retry_time = 30
             except (ValueError, TypeError):
                 retry_time = 30
+            print_stderr("[WARN] Server busy (503), retrying after {}s ...".format(retry_time))
             time.sleep(retry_time)
             continue
         elif resp.status == 200:
             num_submitted += 1
-            break
+            return
         else:
-            print("[ERROR] HTTP return status: {}, reason: {}".format(resp.status, resp.reason))
+            print_stderr("[ERROR] HTTP return status: {}, reason: {}".format(resp.status, resp.reason))
             attempt += 1
-            time.sleep(2 << attempt)
+            if attempt < retries:
+                backoff = min(2 ** attempt, 60)
+                time.sleep(backoff)
             continue
 
+    # All retries exhausted
+    num_failed += 1
 
-def collection_marker(server, port, use_tls, insecure, source, collector_version, marker_type, scan_id=None, stats=None):
-    """POST a begin/end collection marker to /api/collection.
-    Returns the scan_id from the response, or None if unsupported/failed."""
+
+def collection_marker(server, port, use_tls, insecure, ca_cert, source, collector_version, marker_type, scan_id=None, stats=None):  # noqa: E501
+    """POST a begin/end/interrupted collection marker to /api/collection.
+    Returns a tuple (scan_id, success). scan_id may be None even on success.
+    For 'begin' markers, retries once after 2s on failure."""
     body = {
         "type": marker_type,
         "source": source,
+        "hostname": socket.gethostname(),
         "collector": "python2/{}".format(collector_version),
         "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
     }
@@ -269,24 +481,51 @@ def collection_marker(server, port, use_tls, insecure, source, collector_version
     if stats:
         body["stats"] = stats
 
-    try:
-        if use_tls:
-            if hasattr(ssl, "create_default_context"):
-                ctx = ssl._create_unverified_context() if insecure else ssl.create_default_context()
-                conn = httplib.HTTPSConnection(server, port, context=ctx, timeout=10)
+    max_attempts = 2 if marker_type == "begin" else 1
+
+    for attempt in range(max_attempts):
+        conn = None
+        try:
+            conn = make_connection(server, port, use_tls, insecure, ca_cert, timeout=10)
+            payload = json.dumps(body)
+            conn.request("POST", "/api/collection", body=payload,
+                         headers={"Content-Type": "application/json"})
+            resp = conn.getresponse()
+            resp_body = resp.read()
+        except Exception as e:
+            if attempt < max_attempts - 1:
+                print_stderr("[WARN] Collection marker '{}' failed: {}, retrying in 2s...".format(marker_type, e))
+                time.sleep(2)
+                continue
             else:
-                conn = httplib.HTTPSConnection(server, port, timeout=10)
+                print_stderr("[ERROR] Collection marker '{}' failed: {}".format(marker_type, e))
+                return (None, False)
+        finally:
+            if conn is not None:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+
+        if resp.status == 200:
+            if resp_body and resp_body.strip():
+                try:
+                    data = json.loads(resp_body)
+                    return (data.get("scan_id"), True)
+                except (ValueError, TypeError):
+                    if marker_type == "begin":
+                        print_stderr("[WARN] Collection marker 'begin' returned non-JSON 200 response")
+                    return (None, True)
+            else:
+                return (None, True)
         else:
-            conn = httplib.HTTPConnection(server, port, timeout=10)
-        payload = json.dumps(body)
-        conn.request("POST", "/api/collection", body=payload,
-                     headers={"Content-Type": "application/json"})
-        resp = conn.getresponse()
-        resp_body = resp.read()
-        data = json.loads(resp_body)
-        return data.get("scan_id")
-    except Exception:
-        return None
+            print_stderr("[WARN] Collection marker '{}' returned HTTP {}".format(marker_type, resp.status))
+            if attempt < max_attempts - 1:
+                time.sleep(2)
+                continue
+            return (None, False)
+
+    return (None, False)  # should never reach here
 
 
 # Main
@@ -297,7 +536,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "-d", "--dirs",
-        nargs="*",
+        nargs="+",
         default=["/"],
         help="Directories that should be scanned. (Default: /)",
     )
@@ -324,8 +563,8 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "-S", "--source",
-        default=socket.gethostname(),
-        help="Source identifier to be used in the Thunderstorm submission.",
+        default=None,
+        help="Source identifier to be used in the Thunderstorm submission. (Default: hostname)",
     )
     parser.add_argument(
         "--max-age", type=int, default=14,
@@ -347,6 +586,24 @@ if __name__ == "__main__":
         "--retries", type=int, default=3,
         help="Retry attempts per file (default: 3)"
     )
+    parser.add_argument(
+        "--ca-cert",
+        default=None,
+        help="Path to custom CA certificate bundle for TLS verification."
+    )
+    progress_group = parser.add_mutually_exclusive_group()
+    progress_group.add_argument(
+        "--progress",
+        action="store_true",
+        default=False,
+        help="Force enable progress reporting."
+    )
+    progress_group.add_argument(
+        "--no-progress",
+        action="store_true",
+        default=False,
+        help="Force disable progress reporting."
+    )
     parser.add_argument("--debug", action="store_true", help="Enable debug logging.")
 
     args = parser.parse_args()
@@ -358,15 +615,47 @@ if __name__ == "__main__":
     retries = args.retries
     sync_mode = args.sync
 
+    if max_age < 0:
+        print_stderr("[ERROR] --max-age must be non-negative")
+        sys.exit(2)
+    if max_size_kb <= 0:
+        print_stderr("[ERROR] --max-size-kb must be positive")
+        sys.exit(2)
+    if retries < 1:
+        print_stderr("[ERROR] --retries must be at least 1")
+        sys.exit(2)
+
     if args.tls:
         schema = "https"
 
-    source = ""
+    # Validate --ca-cert
+    if args.ca_cert:
+        if not os.path.isfile(args.ca_cert):
+            print_stderr("[ERROR] CA certificate file not found: {}".format(args.ca_cert))
+            sys.exit(2)
+
+    # Determine progress reporting mode
+    if args.progress:
+        progress_enabled = True
+    elif args.no_progress:
+        progress_enabled = False
+    else:
+        progress_enabled = sys.stderr.isatty()
+
+    # Install signal handlers
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    # Build the API path+query (path only, not full URL — httplib needs just the path)
+    source_query = ""
     if args.source:
-        source = "?source={}".format(quote(args.source))
+        source_query = "?source={}".format(quote(args.source, safe=''))
 
     api_path = "/api/check" if sync_mode else "/api/checkAsync"
-    api_endpoint = "{}://{}:{}{}{}".format(schema, args.server, args.port, api_path, source)
+    api_endpoint = "{}{}".format(api_path, source_query)
+
+    # Full URL for display only
+    display_url = "{}://{}:{}{}".format(schema, args.server, args.port, api_endpoint)
 
     print("=" * 80)
     print("   Python Thunderstorm Collector (Python 2)")
@@ -374,52 +663,77 @@ if __name__ == "__main__":
     print()
     print("=" * 80)
     print("Target Directory: {}".format(", ".join(args.dirs)))
-    print("Thunderstorm Server: {}".format(args.server))
     # Extend hard_skips with mount points of network/special filesystems
     for mp in get_excluded_mounts():
-        if mp not in hard_skips:
-            hard_skips.append(mp)
+        norm_mp = os.path.normpath(mp)
+        hard_skips.add(norm_mp)
 
+    print("Thunderstorm Server: {}".format(args.server))
     print("Thunderstorm Port: {}".format(args.port))
-    print("Using API Endpoint: {}".format(api_endpoint))
+    print("Using API Endpoint: {}".format(display_url))
     print("Maximum Age of Files: {} days".format(max_age))
     print("Maximum File Size: {} KB".format(max_size_kb))
-    print("Excluded directories: {}".format(", ".join(hard_skips[:10]) + (" ..." if len(hard_skips) > 10 else "")))
+    sorted_skips = sorted(hard_skips)
+    print("Excluded directories: {}".format(", ".join(sorted_skips[:10]) + (" ..." if len(sorted_skips) > 10 else "")))
     if args.source:
         print("Source Identifier: {}".format(args.source))
     print()
 
     print("Starting the walk at: {} ...".format(", ".join(args.dirs)))
 
-    # Send collection begin marker
-    scan_id = collection_marker(
+    # Send collection begin marker (with single retry on failure)
+    scan_id, begin_success = collection_marker(
         args.server, args.port, args.tls, args.insecure,
+        args.ca_cert,
         args.source or socket.gethostname(), "0.1",
         "begin"
     )
+    if not begin_success:
+        print_stderr("[ERROR] Failed to establish collection session with server {}:{}. Exiting.".format(
+            args.server, args.port))
+        sys.exit(2)
     if scan_id:
         print("[INFO] Collection scan_id: {}".format(scan_id))
-        api_endpoint = "{}&scan_id={}".format(api_endpoint, quote(scan_id))
+        # Append scan_id to the endpoint (URL-encoded)
+        separator = "&" if "?" in api_endpoint else "?"
+        api_endpoint = "{}{}scan_id={}".format(api_endpoint, separator, quote(str(scan_id), safe=''))
 
     for walkdir in args.dirs:
+        if not os.path.isdir(walkdir):
+            print_stderr("[WARN] Directory does not exist or is not accessible: {}".format(walkdir))
+            continue
         process_dir(walkdir)
+
+    # Clear progress line if needed
+    if progress_enabled:
+        sys.stderr.write("\r" + " " * 80 + "\r")
+        sys.stderr.flush()
 
     # Send collection end marker with stats
     end_date = time.time()
     elapsed = int(end_date - current_date)
     minutes = elapsed // 60
-    collection_marker(
+    _end_scan_id, _end_ok = collection_marker(
         args.server, args.port, args.tls, args.insecure,
+        args.ca_cert,
         args.source or socket.gethostname(), "0.1",
         "end",
         scan_id=scan_id,
         stats={
             "scanned": num_processed,
             "submitted": num_submitted,
+            "failed": num_failed,
             "elapsed_seconds": elapsed,
         }
     )
+    if not _end_ok:
+        print_stderr("[WARN] Failed to send collection end marker")
 
-    print("Thunderstorm Collector Run finished (Checked: {} Submitted: {} Minutes: {})".format(
-        num_processed, num_submitted, minutes
+    print("Thunderstorm Collector Run finished (Checked: {} Submitted: {} Failed: {} Minutes: {})".format(
+        num_processed, num_submitted, num_failed, minutes
     ))
+
+    # Exit codes: 0 = success, 1 = partial failure, 2 = fatal error
+    if num_failed > 0:
+        sys.exit(1)
+    sys.exit(0)

--- a/scripts/thunderstorm-collector.bat
+++ b/scripts/thunderstorm-collector.bat
@@ -21,6 +21,21 @@ SETLOCAL EnableDelayedExpansion
 :: Curl 8.x requires the Universal C Runtime (KB2999226 or KB3118401).
 :: Install the Visual C++ 2015 Redistributable or the UCRT update,
 :: then place the curl.exe + libcurl DLL in the script folder.
+::
+:: Known Limitations (cmd.exe platform constraints):
+:: - No --ca-cert / --cacert support: Custom CA bundle validation is not
+::   supported due to limited argument parsing in batch. Use the system
+::   certificate store or set CURL_CA_BUNDLE environment variable instead.
+:: - No --insecure / -k support: TLS verification skip is not supported
+::   for the same reason. Set URL_SCHEME=http as a workaround for testing.
+:: - No signal handling: Ctrl+C will not send an "interrupted" collection
+::   marker. The end marker will be missing if the script is interrupted.
+:: - No TTY detection / progress reporting: cmd.exe cannot detect
+::   interactive terminals. Progress percentage is not displayed.
+:: - Limited JSON escaping: Only backslash and double-quote are escaped.
+::   Control characters (CR, LF, TAB) are stripped but not \uXXXX-escaped.
+:: - Locale-dependent FORFILES date: The /D date filter format depends on
+::   the system locale and may not work correctly on all configurations.
 :: ----------------------------------------------------------------
 
 :: CONFIGURATION -------------------------------------------------
@@ -32,14 +47,18 @@ SET _SCHEME=%URL_SCHEME%
 IF "%_TS%"=="" SET _TS=ygdrasil.nextron
 IF "%_TP%"=="" SET _TP=8080
 IF "%_SCHEME%"=="" SET _SCHEME=http
+IF /I NOT "%_SCHEME%"=="http" IF /I NOT "%_SCHEME%"=="https" (
+    ECHO [ERROR] Invalid URL_SCHEME: %_SCHEME%. Must be http or https. 1>&2
+    EXIT /b 2
+)
 
 :: SELECTION
 SET _DIRS=%COLLECT_DIRS%
 SET _EXTS=%RELEVANT_EXTENSIONS%
 SET _MAXSZ=%COLLECT_MAX_SIZE%
 SET _MAXAGE=%MAX_AGE%
-IF "%_DIRS%"=="" SET _DIRS=C:\Users C:\Temp C:\Windows
-IF "%_EXTS%"=="" SET _EXTS=.vbs .ps .ps1 .rar .tmp .bat .chm .dll .exe .hta .js .lnk .sct .war .jsp .jspx .php .asp .aspx .log .dmp .txt .jar .job
+IF "%_DIRS%"=="" SET "_DIRS=C:\Users;C:\Temp;C:\Windows"
+IF "%_EXTS%"=="" SET _EXTS=.vbs .ps1 .rar .tmp .bat .chm .dll .exe .hta .js .lnk .sct .war .jsp .jspx .php .asp .aspx .log .dmp .txt .jar .job
 IF "%_MAXSZ%"=="" SET _MAXSZ=3000000
 IF "%_MAXAGE%"=="" SET _MAXAGE=30
 
@@ -47,6 +66,28 @@ IF "%_MAXAGE%"=="" SET _MAXAGE=30
 SET _DBG=%DEBUG%
 SET _SRC=%SOURCE%
 IF "%_DBG%"=="" SET _DBG=0
+
+:: Basic server hostname validation: reject empty and values containing characters
+:: outside the allowed set (alphanumeric, hyphens, dots, colons, brackets for IPv6).
+:: Full URL validation is delegated to curl.
+IF "!_TS!"=="" (
+    ECHO [ERROR] Server hostname is empty. Set THUNDERSTORM_SERVER. 1>&2
+    EXIT /b 2
+)
+ECHO !_TS!| FINDSTR /R "[^a-zA-Z0-9.\-\[\]:]" >nul 2>&1
+IF NOT ERRORLEVEL 1 (
+    ECHO [ERROR] Server hostname contains invalid characters: !_TS! 1>&2
+    EXIT /b 2
+)
+
+:: Validate numeric parameters
+SET /A _TP=%_TP% 2>nul
+SET /A _MAXSZ=%_MAXSZ% 2>nul
+SET /A _MAXAGE=%_MAXAGE% 2>nul
+IF !_TP! LEQ 0 SET _TP=8080
+IF !_TP! GTR 65535 SET _TP=8080
+IF !_MAXSZ! LEQ 0 SET _MAXSZ=3000000
+IF !_MAXAGE! LSS 0 SET _MAXAGE=30
 
 :: Counters
 SET /A _SUBMITTED=0
@@ -86,9 +127,9 @@ IF NOT ERRORLEVEL 1 (
     )
     GOTO :CURLOK
 )
-ECHO [!] Cannot find curl in PATH or the script directory.
-ECHO     Download from https://curl.se/windows/ and place curl.exe next to this script.
-EXIT /b 1
+ECHO [ERROR] Cannot find curl in PATH or the script directory. 1>&2
+ECHO     Download from https://curl.se/windows/ and place curl.exe next to this script. 1>&2
+EXIT /b 2
 :CURLOK
 ECHO [+] Curl found: %_CURL%
 
@@ -98,24 +139,123 @@ IF "%_SRC%"=="" (
     ECHO [+] Source: !_SRC!
 )
 
+:: Create temp files atomically via PowerShell to avoid predictable names
+:: PowerShell is required for secure temp file creation and other core features
+where /q powershell.exe
+IF ERRORLEVEL 1 (
+    ECHO [ERROR] PowerShell is required but not found in PATH. 1>&2
+    EXIT /b 2
+)
+FOR /F "usebackq tokens=*" %%T IN (`powershell -NoProfile -Command "[System.IO.Path]::GetTempFileName()"`) DO SET "_FILELIST=%%T"
+IF NOT DEFINED _FILELIST (
+    ECHO [ERROR] Failed to create secure temp file via PowerShell. 1>&2
+    EXIT /b 2
+)
+FOR /F "usebackq tokens=*" %%T IN (`powershell -NoProfile -Command "[System.IO.Path]::GetTempFileName()"`) DO SET "_RESPTMP=%%T"
+IF NOT DEFINED _RESPTMP (
+    ECHO [ERROR] Failed to create secure temp file via PowerShell. 1>&2
+    IF EXIST "!_FILELIST!" DEL "!_FILELIST!" 2>nul
+    EXIT /b 2
+)
+
+:: URL-encode the source for use in query strings via PowerShell
+SET "_SRCURL="
+SET "SRC_FOR_PS=!_SRC!"
+FOR /F "usebackq tokens=*" %%U IN (`powershell -NoProfile -Command "[Uri]::EscapeDataString($env:SRC_FOR_PS)"`) DO SET "_SRCURL=%%U"
+:: Fail if URL encoding failed — raw source in query strings can corrupt URLs
+IF NOT DEFINED _SRCURL (
+    ECHO [ERROR] Failed to URL-encode source identifier. PowerShell is required. 1>&2
+    IF EXIST "!_FILELIST!" DEL "!_FILELIST!" 2>nul
+    IF EXIST "!_RESPTMP!" DEL "!_RESPTMP!" 2>nul
+    EXIT /b 2
+)
+
+:: Restrict temp file permissions (best-effort, ignore errors)
+IF NOT "%USERNAME%"=="" (
+    IF EXIST "!_FILELIST!" icacls "!_FILELIST!" /inheritance:r /grant:r "%USERNAME%:F" >nul 2>&1
+    IF EXIST "!_RESPTMP!" icacls "!_RESPTMP!" /inheritance:r /grant:r "%USERNAME%:F" >nul 2>&1
+)
+
 :: COLLECTION MARKERS --------------------------------------------
 :: POST begin marker to /api/collection (forward-compatible: 404 = continue)
+:: Retry once after 2s on connection failure
+
+:: Escape source and hostname for JSON payloads (backslashes and quotes)
+:: NOTE: Only basic JSON escaping (backslash, double-quote) is performed.
+:: Control characters (CR, LF, TAB) are stripped. Full JSON escaping is a
+:: known batch limitation — see script header.
+SET "_JSRC=!_SRC!"
+:: Strip TAB from source before escaping (CR/LF already handled by cmd.exe line processing)
+SET "_JSRC=!_JSRC:	=!"
+SET "_JSRC=!_JSRC:\=\\!"
+SET "_JSRC=!_JSRC:"=\"!"
+SET "_JHOST=%COMPUTERNAME%"
+SET "_JHOST=!_JHOST:	=!"
+SET "_JHOST=!_JHOST:\=\\!"
+SET "_JHOST=!_JHOST:"=\"!"
+
 SET _SCANID=
-FOR /F "usebackq tokens=*" %%R IN (`"%_CURL%" -s -X POST -H "Content-Type: application/json" -d "{\"type\":\"begin\",\"source\":\"%_SRC%\",\"collector\":\"batch/0.5\"}" %_SCHEME%://%_TS%:%_TP%/api/collection 2^>nul`) DO (
-    SET _RESP=%%R
+SET _RESP=
+SET _BEGIN_HTTP=
+SET _BEGIN_RC=0
+:: Use -o to capture body, -w for HTTP status code
+"%_CURL%" -s -o "!_RESPTMP!" -w "%%{http_code}" -X POST -H "Content-Type: application/json" -d "{\"type\":\"begin\",\"source\":\"!_JSRC!\",\"hostname\":\"!_JHOST!\",\"collector\":\"batch/0.5\"}" "!_SCHEME!://!_TS!:!_TP!/api/collection" >"!_RESPTMP!.code" 2>nul
+SET _BEGIN_RC=!ERRORLEVEL!
+IF !_BEGIN_RC! NEQ 0 (
+    ECHO [!] Begin marker failed ^(curl exit: !_BEGIN_RC!^), retrying in 2s... 1>&2
+    :: PING -n 3 = 2 one-second intervals = ~2s delay
+    PING -n 3 127.0.0.1 >nul 2>&1
+    SET _RESP=
+    "%_CURL%" -s -o "!_RESPTMP!" -w "%%{http_code}" -X POST -H "Content-Type: application/json" -d "{\"type\":\"begin\",\"source\":\"!_JSRC!\",\"hostname\":\"!_JHOST!\",\"collector\":\"batch/0.5\"}" "!_SCHEME!://!_TS!:!_TP!/api/collection" >"!_RESPTMP!.code" 2>nul
+    SET _BEGIN_RC=!ERRORLEVEL!
 )
-IF DEFINED _RESP (
-    :: Extract scan_id from JSON response (simple pattern match)
-    FOR /F "tokens=2 delims=:}" %%A IN ('ECHO !_RESP! ^| FIND /I "scan_id"') DO (
-        SET _SCANID=%%~A
-        :: Remove surrounding quotes and spaces
-        SET _SCANID=!_SCANID:"=!
-        SET _SCANID=!_SCANID: =!
+SET _BEGIN_OK=0
+SET _BEGIN_SUPPORTED=0
+IF !_BEGIN_RC! == 0 (
+    SET /P _BEGIN_HTTP=<"!_RESPTMP!.code"
+    :: Accept 2xx or 404 (forward-compatible: 404 = server doesn't support markers yet)
+    IF DEFINED _BEGIN_HTTP (
+        IF "!_BEGIN_HTTP:~0,1!"=="2" (
+            :: Success - parse scan_id from response file below
+            SET _PARSE_RESP=1
+            SET _BEGIN_OK=1
+            SET _BEGIN_SUPPORTED=1
+        ) ELSE IF "!_BEGIN_HTTP!"=="404" (
+            :: Server doesn't support collection markers, continue without scan_id
+            SET _PARSE_RESP=0
+            SET _BEGIN_OK=1
+            SET _BEGIN_SUPPORTED=0
+        ) ELSE (
+            ECHO [!] Begin marker returned HTTP !_BEGIN_HTTP!, continuing without scan_id 1>&2
+            SET _PARSE_RESP=0
+        )
+    ) ELSE (
+        SET _PARSE_RESP=0
+    )
+) ELSE (
+    ECHO [!] Begin marker connection failed after retry ^(curl exit: !_BEGIN_RC!^), continuing without scan_id 1>&2
+    SET _PARSE_RESP=0
+)
+DEL "!_RESPTMP!.code" 2>nul
+IF "!_PARSE_RESP!"=="1" IF EXIST "!_RESPTMP!" (
+    :: Extract scan_id from JSON response file using PowerShell for robust parsing
+    :: Pass file path via environment variable to avoid injection; read full file content
+    SET "RESPTMP_FOR_PS=!_RESPTMP!"
+    FOR /F "usebackq tokens=*" %%A IN (`powershell -NoProfile -Command "$r=[System.IO.File]::ReadAllText($env:RESPTMP_FOR_PS); if($r -match '\"scan_id\"\s*:\s*\"([^\"]*?)\"'){$matches[1]}elseif($r -match '\"scan_id\"\s*:\s*([^,}\s]+)'){$matches[1].Trim('\"')}"`) DO (
+        IF NOT DEFINED _SCANID SET "_SCANID=%%A"
     )
 )
+DEL "!_RESPTMP!" 2>nul
 IF DEFINED _SCANID (
     ECHO [+] Collection started, scan_id: !_SCANID!
-    SET _IDPARAM=^&scan_id=!_SCANID!
+    :: URL-encode scan_id for query string via PowerShell (use env var to avoid injection)
+    SET "SCANID_FOR_PS=!_SCANID!"
+    SET "_SCANIDURL="
+    FOR /F "usebackq tokens=*" %%U IN (`powershell -NoProfile -Command "[Uri]::EscapeDataString($env:SCANID_FOR_PS)"`) DO SET "_SCANIDURL=%%U"
+    IF NOT DEFINED _SCANIDURL SET "_SCANIDURL=!_SCANID!"
+    :: NOTE: _IDPARAM must always be used within double-quoted URL strings
+    :: to prevent cmd.exe from interpreting the & as a command separator.
+    SET _IDPARAM=^&scan_id=!_SCANIDURL!
 ) ELSE (
     SET _IDPARAM=
 )
@@ -124,90 +264,256 @@ IF DEFINED _SCANID (
 :: Phase 1: Use FORFILES to generate a filtered file list.
 :: FORFILES does NOT follow junctions/reparse points, solving the infinite loop issue.
 
-SET _FILELIST=%TEMP%\thunderstorm_files_%RANDOM%.txt
-IF EXIST "%_FILELIST%" DEL "%_FILELIST%" 2>nul
-
 :: Calculate cutoff date for age filter (today minus _MAXAGE days)
 :: FORFILES /D +MM/DD/YYYY selects files modified on or after that date
 SET _DATEFILTER=
-IF %_MAXAGE% GTR 0 (
+
+:: Validate _MAXAGE is a positive integer (prevent injection)
+SET /A _MAXAGE_VALIDATED=%_MAXAGE% 2>nul
+IF !_MAXAGE_VALIDATED! GTR 0 (
     :: Use PowerShell to compute the date (available on Vista+)
-    FOR /F "usebackq tokens=*" %%D IN (`powershell -NoProfile -Command "(Get-Date).AddDays(-%_MAXAGE%).ToString('MM/dd/yyyy')"`) DO SET _DATEFILTER=/D +%%D
+    :: _MAXAGE_VALIDATED is guaranteed numeric by SET /A above
+    SET "MAXAGE_FOR_PS=!_MAXAGE_VALIDATED!"
+    FOR /F "usebackq tokens=*" %%D IN (`powershell -NoProfile -Command "(Get-Date).AddDays(-[int]$env:MAXAGE_FOR_PS).ToString([System.Globalization.CultureInfo]::CurrentCulture.DateTimeFormat.ShortDatePattern)"`) DO SET _DATEFILTER=/D +%%D
 )
 
-ECHO [+] Scanning %_DIRS% ...
+ECHO [+] Scanning !_DIRS! ...
 ECHO [+] Filters: MAX_SIZE=%_MAXSZ% bytes, MAX_AGE=%_MAXAGE% days, EXTENSIONS=%_EXTS%
 
-FOR %%T IN (%_DIRS%) DO (
-    IF NOT EXIST "%%T" (
-        ECHO [!] Warning: %%T does not exist, skipping.
-    ) ELSE (
-        IF %_DBG% == 1 ECHO [D] Scanning %%T ...
-        :: FORFILES /S = recurse (skips junctions), /C = command per file
-        :: @path outputs quoted full path, @isdir filters out directories
-        IF DEFINED _DATEFILTER (
-            FORFILES /P "%%T" /S !_DATEFILTER! /C "cmd /c if @isdir==FALSE echo @path" >>"%_FILELIST%" 2>nul
-        ) ELSE (
-            FORFILES /P "%%T" /S /C "cmd /c if @isdir==FALSE echo @path" >>"%_FILELIST%" 2>nul
-        )
+:: Iterate directories using semicolon delimiter (supports paths with spaces)
+:: COLLECT_DIRS can be semicolon-separated, e.g. "C:\Program Files;C:\Temp"
+:: Write directory list to a temp file, then iterate with delayed expansion off
+:: to protect paths containing '!' characters.
+SET "_DIRLIST=!_FILELIST!.dirs"
+:: Use PowerShell to split the semicolon-separated list into lines (safe from ! issues)
+SET "DIRS_FOR_PS=!_DIRS!"
+powershell -NoProfile -Command "$env:DIRS_FOR_PS -split ';' | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne '' }" >"!_DIRLIST!" 2>nul
+IF NOT EXIST "!_DIRLIST!" (
+    :: Fallback: write _DIRS splitting on semicolons via cmd
+    FOR %%T IN ("!_DIRS:;=" "!") DO (
+        IF NOT "%%~T"=="" ECHO %%~T>>"!_DIRLIST!"
     )
 )
+FOR /F "usebackq delims=" %%T IN ("!_DIRLIST!") DO (
+    CALL :SCANDIR "%%T"
+)
+DEL "!_DIRLIST!" 2>nul
+GOTO :SCANDONE
+
+:SCANDIR
+SETLOCAL DisableDelayedExpansion
+SET "_TDIR=%~1"
+SETLOCAL EnableDelayedExpansion
+IF "!_TDIR!"=="" (
+    ENDLOCAL & ENDLOCAL
+    GOTO :EOF
+)
+IF NOT EXIST "!_TDIR!" (
+    ECHO [ERROR] Warning: !_TDIR! does not exist, skipping. 1>&2
+    ENDLOCAL & ENDLOCAL
+    GOTO :EOF
+)
+IF !_DBG! == 1 ECHO [D] Scanning !_TDIR! ...
+:: FORFILES /S = recurse (skips junctions), /C = command per file
+:: @path outputs quoted full path, @isdir filters out directories
+IF DEFINED _DATEFILTER (
+    FORFILES /P "!_TDIR!" /S !_DATEFILTER! /C "cmd /c if @isdir==FALSE echo @path" >>"!_FILELIST!" 2>nul
+) ELSE (
+    FORFILES /P "!_TDIR!" /S /C "cmd /c if @isdir==FALSE echo @path" >>"!_FILELIST!" 2>nul
+)
+ENDLOCAL & ENDLOCAL
+GOTO :EOF
+
+:SCANDONE
 
 :: Count total files found
 SET /A _TOTAL=0
-IF EXIST "%_FILELIST%" (
-    FOR /F "usebackq" %%C IN (`type "%_FILELIST%" ^| find /c /v ""`) DO SET /A _TOTAL=%%C
+IF EXIST "!_FILELIST!" (
+    FOR /F "usebackq" %%C IN (`type "!_FILELIST!" ^| find /c /v ""`) DO SET /A _TOTAL=%%C
 )
-ECHO [+] Found %_TOTAL% files within age limit.
+ECHO [+] Found !_TOTAL! files within age limit.
 
 :: PHASE 2: FILTER AND UPLOAD ------------------------------------
-IF %_TOTAL% == 0 GOTO :DONE
+IF !_TOTAL! == 0 GOTO :DONE
 
-FOR /F "usebackq delims=" %%F IN ("%_FILELIST%") DO (
-    SET /A _SCANNED+=1
-    :: %%~F strips surrounding quotes from FORFILES output
-    SET "_FILE=%%~F"
+:: Disable delayed expansion for the file-processing loop so paths
+:: containing '!' characters are not corrupted during %%F expansion.
+SET "_FILELIST_SAVED=!_FILELIST!"
+SETLOCAL DisableDelayedExpansion
+FOR /F "usebackq delims=" %%F IN ("%_FILELIST_SAVED%") DO (
+    CALL :PROCESSFILE "%%~F"
+)
+ENDLOCAL
+GOTO :DONE
 
-    :: Extension check
-    SET _EXTMATCH=0
-    FOR %%E IN (%_EXTS%) DO (
-        IF /I "%%~xF"=="%%E" SET _EXTMATCH=1
+:: ---------------------------------------------------------------
+:: Subroutine: PROCESSFILE
+:: Processes a single file path passed as %1.
+:: Uses SETLOCAL/ENDLOCAL to toggle delayed expansion, protecting
+:: file paths that contain '!' characters from being corrupted.
+:: ---------------------------------------------------------------
+:PROCESSFILE
+:: First, capture the raw path with delayed expansion OFF so '!' is preserved
+SETLOCAL DisableDelayedExpansion
+SET "_FILE=%~1"
+:: Now re-enable delayed expansion for counter logic and comparisons
+SETLOCAL EnableDelayedExpansion
+
+:: Extension check — use a nested FOR to get file attributes from the filesystem
+SET _EXTMATCH=0
+SET _SZ=
+SET "_FEXT="
+FOR %%S IN ("!_FILE!") DO (
+    SET "_SZ=%%~zS"
+    SET "_FEXT=%%~xS"
+)
+FOR %%E IN (%_EXTS%) DO (
+    IF /I "!_FEXT!"=="%%E" SET _EXTMATCH=1
+)
+IF !_EXTMATCH! == 0 (
+    IF !_DBG! == 1 ECHO [D] Skip: !_FILE! ^(extension^)
+    SET /A _SKIPPED+=1
+    :: Propagate all counters back to parent scope
+    FOR /F "tokens=1-4" %%A IN ("!_SCANNED! !_SUBMITTED! !_SKIPPED! !_FAILED!") DO (
+        ENDLOCAL & ENDLOCAL
+        SET /A _SCANNED=%%A
+        SET /A _SUBMITTED=%%B
+        SET /A _SKIPPED=%%C
+        SET /A _FAILED=%%D
     )
-    IF !_EXTMATCH! == 0 (
-        IF %_DBG% == 1 ECHO [D] Skip: !_FILE! ^(extension^)
-        SET /A _SKIPPED+=1
-    ) ELSE (
-        :: Size check
-        SET "_SZ=%%~zF"
-        IF !_SZ! GTR %_MAXSZ% (
-            IF %_DBG% == 1 ECHO [D] Skip: !_FILE! ^(size: !_SZ!^)
-            SET /A _SKIPPED+=1
-        ) ELSE (
-            :: Upload
-            ECHO [+] Uploading: !_FILE!
-            "%_CURL%" -s -o nul -F "file=@!_FILE!" %_SCHEME%://%_TS%:%_TP%/api/checkAsync?source=%_SRC%%_IDPARAM%
-            IF !ERRORLEVEL! == 0 (
-                SET /A _SUBMITTED+=1
-            ) ELSE (
-                ECHO [-] Failed: !_FILE! ^(curl exit: !ERRORLEVEL!^)
-                SET /A _FAILED+=1
+    GOTO :EOF
+)
+:: Size check (file may have been deleted since listing)
+IF "!_SZ!"=="" (
+    IF !_DBG! == 1 ECHO [D] Skip: !_FILE! ^(file not found^)
+    SET /A _SKIPPED+=1
+    FOR /F "tokens=1-4" %%A IN ("!_SCANNED! !_SUBMITTED! !_SKIPPED! !_FAILED!") DO (
+        ENDLOCAL & ENDLOCAL
+        SET /A _SCANNED=%%A
+        SET /A _SUBMITTED=%%B
+        SET /A _SKIPPED=%%C
+        SET /A _FAILED=%%D
+    )
+    GOTO :EOF
+)
+IF !_SZ! GTR !_MAXSZ! (
+    IF !_DBG! == 1 ECHO [D] Skip: !_FILE! ^(size: !_SZ!^)
+    SET /A _SKIPPED+=1
+    FOR /F "tokens=1-4" %%A IN ("!_SCANNED! !_SUBMITTED! !_SKIPPED! !_FAILED!") DO (
+        ENDLOCAL & ENDLOCAL
+        SET /A _SCANNED=%%A
+        SET /A _SUBMITTED=%%B
+        SET /A _SKIPPED=%%C
+        SET /A _FAILED=%%D
+    )
+    GOTO :EOF
+)
+:: Upload — increment _SCANNED only for files that pass filters
+SET /A _SCANNED+=1
+ECHO [+] Uploading: !_FILE!
+SET _HTTPCODE=
+"%_CURL%" -s -o nul -D "!_RESPTMP!.hdr" -w "%%{http_code}" -F "file=@!_FILE!" --form-string "hostname=%COMPUTERNAME%" --form-string "source_path=!_FILE!" "%_SCHEME%://%_TS%:%_TP%/api/checkAsync?source=!_SRCURL!!_IDPARAM!" >"!_RESPTMP!" 2>nul
+SET _CURLRC=!ERRORLEVEL!
+IF !_CURLRC! == 0 (
+    SET /P _HTTPCODE=<"!_RESPTMP!"
+    DEL "!_RESPTMP!" 2>nul
+    IF "!_HTTPCODE!"=="" (
+        ECHO [ERROR] Failed: !_FILE! ^(empty response^) 1>&2
+        SET /A _FAILED+=1
+    ) ELSE IF "!_HTTPCODE!"=="503" (
+        :: Respect Retry-After header, capped at 60s, default 5s
+        SET _RETRYWAIT=5
+        IF EXIST "!_RESPTMP!.hdr" (
+            FOR /F "tokens=2 delims=: " %%H IN ('FINDSTR /I "^Retry-After:" "!_RESPTMP!.hdr"') DO (
+                SET /A _RETRYWAIT=%%H 2>nul
+                IF !_RETRYWAIT! LEQ 0 SET _RETRYWAIT=5
+                IF !_RETRYWAIT! GTR 60 SET _RETRYWAIT=60
             )
         )
+        DEL "!_RESPTMP!.hdr" 2>nul
+        ECHO [!] Server busy ^(503^), waiting !_RETRYWAIT!s before retry... 1>&2
+        SET /A _PINGCOUNT=!_RETRYWAIT!+1
+        PING -n !_PINGCOUNT! 127.0.0.1 >nul 2>&1
+        SET _HTTPCODE2=
+        "!_CURL!" -s -o nul -D "!_RESPTMP!.hdr" -w "%%{http_code}" -F "file=@!_FILE!" --form-string "hostname=%COMPUTERNAME%" --form-string "source_path=!_FILE!" "!_SCHEME!://!_TS!:!_TP!/api/checkAsync?source=!_SRCURL!!_IDPARAM!" >"!_RESPTMP!" 2>nul
+        SET _CURLRC2=!ERRORLEVEL!
+        IF !_CURLRC2! == 0 (
+            SET /P _HTTPCODE2=<"!_RESPTMP!"
+            DEL "!_RESPTMP!" 2>nul
+            DEL "!_RESPTMP!.hdr" 2>nul
+            IF "!_HTTPCODE2!"=="503" (
+                ECHO [ERROR] Failed: !_FILE! ^(server still busy^) 1>&2
+                SET /A _FAILED+=1
+            ) ELSE IF "!_HTTPCODE2:~0,1!"=="2" (
+                SET /A _SUBMITTED+=1
+            ) ELSE (
+                ECHO [ERROR] Failed: !_FILE! ^(HTTP !_HTTPCODE2! on retry^) 1>&2
+                SET /A _FAILED+=1
+            )
+        ) ELSE (
+            DEL "!_RESPTMP!" 2>nul
+            DEL "!_RESPTMP!.hdr" 2>nul
+            ECHO [ERROR] Failed: !_FILE! ^(curl exit: !_CURLRC2!^) 1>&2
+            SET /A _FAILED+=1
+        )
+    ) ELSE IF "!_HTTPCODE:~0,1!"=="2" (
+        DEL "!_RESPTMP!.hdr" 2>nul
+        SET /A _SUBMITTED+=1
+    ) ELSE (
+        DEL "!_RESPTMP!.hdr" 2>nul
+        ECHO [ERROR] Failed: !_FILE! ^(HTTP !_HTTPCODE!^) 1>&2
+        SET /A _FAILED+=1
     )
+) ELSE (
+    DEL "!_RESPTMP!" 2>nul
+    DEL "!_RESPTMP!.hdr" 2>nul
+    ECHO [ERROR] Failed: !_FILE! ^(curl exit: !_CURLRC!^) 1>&2
+    SET /A _FAILED+=1
 )
+:: Clean up any leftover temp files from this iteration
+IF EXIST "!_RESPTMP!" DEL "!_RESPTMP!" 2>nul
+IF EXIST "!_RESPTMP!.hdr" DEL "!_RESPTMP!.hdr" 2>nul
+:: Propagate all counters back to parent scope
+FOR /F "tokens=1-4" %%A IN ("!_SCANNED! !_SUBMITTED! !_SKIPPED! !_FAILED!") DO (
+    ENDLOCAL & ENDLOCAL
+    SET /A _SCANNED=%%A
+    SET /A _SUBMITTED=%%B
+    SET /A _SKIPPED=%%C
+    SET /A _FAILED=%%D
+)
+GOTO :EOF
 
 :DONE
 :: COLLECTION END MARKER -----------------------------------------
-IF DEFINED _SCANID (
-    "%_CURL%" -s -o nul -X POST -H "Content-Type: application/json" -d "{\"type\":\"end\",\"source\":\"%_SRC%\",\"collector\":\"batch/0.5\",\"scan_id\":\"%_SCANID%\",\"stats\":{\"scanned\":%_SCANNED%,\"submitted\":%_SUBMITTED%,\"skipped\":%_SKIPPED%,\"failed\":%_FAILED%}}" %_SCHEME%://%_TS%:%_TP%/api/collection 2>nul
+:: Only send end marker if the server supports collection markers (2xx on begin)
+IF !_BEGIN_SUPPORTED! == 1 (
+    :: JSON-escape scan_id (backslashes and quotes)
+    SET "_JSCANID=!_SCANID!"
+    IF DEFINED _JSCANID (
+        SET "_JSCANID=!_JSCANID:\=\\!"
+        SET "_JSCANID=!_JSCANID:"=\"!"
+    )
+    IF DEFINED _SCANID (
+        "%_CURL%" -s -o nul -X POST -H "Content-Type: application/json" -d "{\"type\":\"end\",\"source\":\"!_JSRC!\",\"hostname\":\"!_JHOST!\",\"collector\":\"batch/0.5\",\"scan_id\":\"!_JSCANID!\",\"stats\":{\"scanned\":!_SCANNED!,\"submitted\":!_SUBMITTED!,\"skipped\":!_SKIPPED!,\"failed\":!_FAILED!}}" "!_SCHEME!://!_TS!:!_TP!/api/collection" 2>nul
+    ) ELSE (
+        "%_CURL%" -s -o nul -X POST -H "Content-Type: application/json" -d "{\"type\":\"end\",\"source\":\"!_JSRC!\",\"hostname\":\"!_JHOST!\",\"collector\":\"batch/0.5\",\"stats\":{\"scanned\":!_SCANNED!,\"submitted\":!_SUBMITTED!,\"skipped\":!_SKIPPED!,\"failed\":!_FAILED!}}" "!_SCHEME!://!_TS!:!_TP!/api/collection" 2>nul
+    )
 )
 
 :: CLEANUP -------------------------------------------------------
-IF EXIST "%_FILELIST%" DEL "%_FILELIST%" 2>nul
+IF EXIST "!_FILELIST!" DEL "!_FILELIST!" 2>nul
+IF EXIST "!_RESPTMP!" DEL "!_RESPTMP!" 2>nul
+IF EXIST "!_RESPTMP!.hdr" DEL "!_RESPTMP!.hdr" 2>nul
+IF EXIST "!_RESPTMP!.code" DEL "!_RESPTMP!.code" 2>nul
 
 :: SUMMARY -------------------------------------------------------
 ECHO.
-ECHO [+] Done. scanned=%_SCANNED% submitted=%_SUBMITTED% skipped=%_SKIPPED% failed=%_FAILED%
+ECHO [+] Done. scanned=!_SCANNED! submitted=!_SUBMITTED! skipped=!_SKIPPED! failed=!_FAILED!
 
+:: EXIT CODE: 1 if any uploads failed, 0 otherwise
+IF !_FAILED! GTR 0 (
+    ENDLOCAL
+    EXIT /b 1
+)
 ENDLOCAL
 EXIT /b 0

--- a/scripts/thunderstorm-collector.pl
+++ b/scripts/thunderstorm-collector.pl
@@ -19,6 +19,7 @@ use strict;
 use Getopt::Long;
 use LWP::UserAgent;
 use File::Spec::Functions qw( catfile );
+use File::Basename qw( basename );
 use Sys::Hostname;
 use POSIX qw(strftime);
 
@@ -33,11 +34,14 @@ my $scheme = "http";
 my $source = "";
 my $ssl = 0;
 my $insecure = 0;
+my $ca_cert = "";
 my $sync_mode = 0;
 my $dry_run = 0;
 my $retries_opt = 3;
+my $progress_opt;       # undef = auto-detect, 1 = force on, 0 = force off
 our $max_age = 14;      # in days (harmonized with bash/ash)
 our $max_size_kb = 2048; # in KB (harmonized with bash/ash)
+our $interrupted = 0;
 # Note: size checks use $max_size_kb directly (in KB)
 our @skipElements = map { qr{$_} } ('^\/proc', '^\/mnt', '\.dat$', '\.npm');
 our @hardSkips = ('/proc', '/dev', '/sys', '/run', '/snap', '/.snapshots');
@@ -88,19 +92,47 @@ GetOptions(
     "source=s"       => \$source,       # --source (no short option to avoid conflict)
     "ssl"            => \$ssl,          # --ssl (use HTTPS)
     "insecure|k"     => \$insecure,     # --insecure or -k (skip TLS verify)
+    "ca-cert=s"      => \$ca_cert,      # --ca-cert PATH (custom CA bundle)
     "sync"           => \$sync_mode,    # --sync (use /api/check)
     "dry-run"        => \$dry_run,      # --dry-run
     "retries=i"      => \$retries_opt,  # --retries N
     "max-age=i"      => \$max_age,      # --max-age N (days)
     "max-size-kb=i"  => \$max_size_kb,  # --max-size-kb N
+    "progress"       => sub { $progress_opt = 1; },   # --progress
+    "no-progress"    => sub { $progress_opt = 0; },   # --no-progress
     "debug"          => \$debug         # --debug
 );
 $scheme = "https" if $ssl;
+
+# Validate numeric options
+if ($retries_opt < 0) {
+    print STDERR "[ERROR] --retries must be non-negative (got $retries_opt)\n";
+    exit 2;
+}
+if ($max_age < 0) {
+    print STDERR "[ERROR] --max-age must be non-negative (got $max_age)\n";
+    exit 2;
+}
+if ($max_size_kb < 0) {
+    print STDERR "[ERROR] --max-size-kb must be non-negative (got $max_size_kb)\n";
+    exit 2;
+}
+
+# Progress reporting: auto-detect TTY unless overridden
+our $show_progress;
+if (defined $progress_opt) {
+    $show_progress = $progress_opt;
+} else {
+    $show_progress = (-t STDERR) ? 1 : 0;
+}
 
 # Use Hostname as Source if not set
 if ( $source eq "" ) {
     $source = hostname;
 }
+# Preserve raw source for use in collection markers
+our $source_raw = $source;
+
 # URL-encode source parameter
 sub urlencode {
     my $s = shift;
@@ -108,42 +140,78 @@ sub urlencode {
     return $s;
 }
 
+# Track whether URL has query parameters
+our $url_has_query = 0;
+
 # Add Source to URL if available
+my $source_query = "";
 if ( $source ne "" ) {
     print "[DEBUG] Using source identifier: $source\n" if $debug;
-    $source = "?source=" . urlencode($source);
+    $source_query = "?source=" . urlencode($source);
+    $url_has_query = 1;
 }
 
 # Composed Values
 our $base_url = "$scheme://$server:$port";
 my $api_path = $sync_mode ? "/api/check" : "/api/checkAsync";
-our $api_endpoint = "$base_url$api_path$source";
+our $api_endpoint = "$base_url$api_path$source_query";
 our $current_date = time;
 our $SCAN_ID = "";
 
 # Stats
 our $num_submitted = 0;
 our $num_processed = 0;
+our $num_failed = 0;
+our $collection_started = 0;
 
 # Objects
 our $ua;
 
+# Properly escape a string for JSON (control chars, backslashes, quotes)
+sub json_escape {
+    my ($s) = @_;
+    $s =~ s/\\/\\\\/g;
+    $s =~ s/"/\\"/g;
+    $s =~ s/\n/\\n/g;
+    $s =~ s/\r/\\r/g;
+    $s =~ s/\t/\\t/g;
+    $s =~ s/\x08/\\b/g;
+    $s =~ s/\x0c/\\f/g;
+    # Escape remaining control characters (U+0000 to U+001F)
+    $s =~ s/([\x00-\x1f])/sprintf("\\u%04x", ord($1))/ge;
+    return $s;
+}
+
 # Send a begin/end collection marker to /api/collection
-# Returns scan_id from response, or "" if unsupported/failed
+# Returns ($scan_id, $http_success) where:
+#   $scan_id = scan_id from response or ""
+#   $http_success = 1 if HTTP request succeeded, 0 if transport/HTTP failure
 sub collection_marker {
     my ($marker_type, $scan_id, $stats_ref) = @_;
     my $marker_url = "$base_url/api/collection";
+    $marker_url .= "?source=" . urlencode($source_raw) if $source_raw ne "";
 
     my $timestamp = POSIX::strftime("%Y-%m-%dT%H:%M:%SZ", gmtime());
-    my $src_escaped = $source;
-    $src_escaped =~ s/[\\"]/\\$&/g;
+    my $timestamp_esc = json_escape($timestamp);
+    # Use the preserved raw source value (user-provided or hostname)
+    my $src_escaped = json_escape($source_raw);
 
-    my $body = "{\"type\":\"$marker_type\",\"source\":\"$src_escaped\",\"collector\":\"perl/0.2\",\"timestamp\":\"$timestamp\"";
-    $body .= ",\"scan_id\":\"$scan_id\"" if $scan_id;
+    my $type_esc = json_escape($marker_type);
+    my $body = "{\"type\":\"$type_esc\",\"source\":\"$src_escaped\",\"collector\":\"perl/0.2\",\"timestamp\":\"$timestamp_esc\"";
+    $body .= ",\"scan_id\":\"" . json_escape($scan_id) . "\"" if (defined $scan_id && $scan_id ne '');
     if ($stats_ref) {
         $body .= ",\"stats\":{";
         my @pairs;
-        for my $k (keys %$stats_ref) { push @pairs, "\"$k\":$stats_ref->{$k}"; }
+        for my $k (keys %$stats_ref) {
+            my $ek = json_escape($k);
+            my $v = $stats_ref->{$k};
+            if (defined $v && $v =~ /^-?\d+(?:\.\d+)?$/) {
+                push @pairs, qq{"$ek":$v};
+            } else {
+                my $ev = json_escape(defined $v ? $v : "");
+                push @pairs, qq{"$ek":"$ev"};
+            }
+        }
         $body .= join(",", @pairs) . "}";
     }
     $body .= "}";
@@ -154,91 +222,191 @@ sub collection_marker {
             Content => $body,
         );
     };
-    return "" unless $resp && $resp->is_success;
+    return ("", 0) unless $resp;
+    # 404 = endpoint not supported, continue without scan_id but success
+    if ($resp->code == 404) {
+        print STDERR "[WARN] Collection marker '$marker_type' not supported (HTTP 404) — server does not implement /api/collection\n";
+        return ("", 1);
+    }
+    return ("", 0) unless $resp->is_success;
 
     my $resp_body = $resp->content;
     my $returned_id = "";
-    if ($resp_body =~ /"scan_id"\s*:\s*"([^"]+)"/) {
-        $returned_id = $1;
+    # Parse scan_id from JSON, handling escaped characters
+    if ($resp_body =~ /"scan_id"\s*:\s*"((?:[^"\\]|\\.)*)"/) {
+        my $raw_id = $1;
+        # Unescape JSON string escapes
+        $raw_id =~ s/\\(["\\\/])/$1/g;
+        $raw_id =~ s/\\n/\n/g;
+        $raw_id =~ s/\\r/\r/g;
+        $raw_id =~ s/\\t/\t/g;
+        $raw_id =~ s/\\u([0-9a-fA-F]{4})/chr(hex($1))/ge;
+        # Validate: scan_id should be alphanumeric/dash/underscore/dot (reject suspicious values)
+        if ($raw_id =~ /^[A-Za-z0-9\-_.]+$/) {
+            $returned_id = $raw_id;
+        } else {
+            print STDERR "[WARN] Received scan_id with unexpected characters, ignoring\n";
+        }
     }
-    return $returned_id;
+    return ($returned_id, 1);
 }
 
-# Process Folders
-sub processDir {
-    my ($workdir) = shift;
-    my ($startdir) = &cwd;
-    # keep track of where we began
-    chdir($workdir) or do { print "[ERROR] Unable to enter dir $workdir:$!\n"; return; };
-    opendir(DIR, ".") or do { print "[ERROR] Unable to open $workdir:$!\n"; return; };
+# Count eligible files in a directory tree (for progress reporting)
+our $total_eligible = 0;
 
-    my @names = readdir(DIR) or do { print "[ERROR] Unable to read $workdir:$!\n"; return; };
-    closedir(DIR);
-
-    foreach my $name (@names){
-        next if ($name eq ".");
-        next if ($name eq "..");
-
-        #print("Workdir: $workdir Name: $name\n");
-        my $filepath = catfile($workdir, $name);
-        # Hard directory skips
-        my $skipHard = 0;
-        foreach ( @hardSkips ) {
-            $skipHard = 1 if ( $filepath eq $_ );
+sub is_hard_skip {
+    my ($path) = @_;
+    foreach (@hardSkips) {
+        if ($path eq $_ || (index($path, $_) == 0 && substr($path, length($_), 1) eq '/')) {
+            return 1;
         }
-        next if $skipHard;
+    }
+    return 0;
+}
 
-        # Skip cloud storage paths
-        next if is_cloud_path($filepath);
+sub countDir {
+    my ($start) = @_;
+    my @stack = ($start);
 
-        # Is a Directory
-        if (-d $filepath){
-            # Skip symbolic links
-            if (-l $filepath) { next; }
-            # Process Dir
-            &processDir($filepath);
-            next;
-        } else {
-            # Skip symbolic links to files
-            if (-l $filepath) { next; }
-            if ( $debug ) { print "[DEBUG] Checking $filepath ...\n"; }
-        }
+    while (@stack) {
+        last if $interrupted;
+        my $workdir = pop @stack;
 
-        # Characteristics
-        my $size = (stat($filepath))[7];
-        my $mdate = (stat($filepath))[9];
-        #print("SIZE: $size MDATE: $mdate\n");
+        opendir(my $dh, $workdir) or next;
+        my @names = readdir($dh);
+        closedir($dh);
 
-        # Count
-        $num_processed++;
+        foreach my $name (@names) {
+            next if ($name eq "." || $name eq "..");
+            last if $interrupted;
 
-        # Skip some files ----------------------------------------
-        # Skip Folders / elements
-        my $skipRegex = 0;
-        # Regex Checks
-        foreach ( @skipElements ) {
-            if ( $filepath =~ $_ ) {
-                if ( $debug ) { print "[DEBUG] Skipping file due to configured exclusion $filepath\n"; }
-                $skipRegex = 1;
+            my $filepath = catfile($workdir, $name);
+            # Hard directory skips
+            next if is_hard_skip($filepath);
+            next if is_cloud_path($filepath);
+
+            # Use lstat consistently to avoid following symlinks (mirrors processDir)
+            my @st = lstat($filepath);
+            next unless @st;
+            # Skip symlinks
+            next if -l _;
+
+            if (-d _) {
+                push @stack, $filepath;
+                next;
             }
-        }
-        next if $skipRegex;
-        # Size
-        if ( ( $size / 1024 ) > $max_size_kb ) {
-            if ( $debug ) { print "[DEBUG] Skipping file due to file size $filepath\n"; }
-            next;
-        }
-        # Age
-        #print("MDATE: $mdate CURR_DATE: $current_date\n");
-        if ( $mdate < ( $current_date - ($max_age * 86400) ) ) {
-            if ( $debug ) { print "[DEBUG] Skipping file due to age $filepath\n"; }
-            next;
-        }
 
-        # Submit
-        &submitSample($filepath);
+            # Only process regular files
+            next unless -f _;
 
-        chdir($startdir) or die "Unable to change back to dir $startdir:$!\n";
+            my $size = $st[7];
+            my $mdate = $st[9];
+
+            # Apply same skip logic as processDir
+            my $skipRegex = 0;
+            foreach (@skipElements) {
+                if ($filepath =~ $_) { $skipRegex = 1; last; }
+            }
+            next if $skipRegex;
+            next if (defined $size && ($size / 1024) > $max_size_kb);
+            next if (defined $mdate && $mdate < ($current_date - ($max_age * 86400)));
+
+            $total_eligible++;
+        }
+    }
+}
+
+# Process Folders (iterative to avoid stack overflow on deep trees)
+sub processDir {
+    my ($start) = @_;
+    my @stack = ($start);
+
+    while (@stack) {
+        last if $interrupted;
+        my $workdir = pop @stack;
+
+        opendir(my $dh, $workdir) or do { print STDERR "[ERROR] Unable to open $workdir:$!\n"; next; };
+
+        my @names = readdir($dh);
+        closedir($dh);
+
+        next if !@names;
+
+        foreach my $name (@names){
+            next if ($name eq ".");
+            next if ($name eq "..");
+
+            # Check for interruption
+            last if $interrupted;
+
+            my $filepath = catfile($workdir, $name);
+            # Hard directory skips (prefix match)
+            next if is_hard_skip($filepath);
+
+            # Skip cloud storage paths
+            next if is_cloud_path($filepath);
+
+            # Use lstat to avoid following symlinks; use _ for cached results
+            my @st = lstat($filepath);
+            next unless @st;  # skip if stat fails
+
+            # Check symlinks using cached lstat result
+            next if -l _;
+
+            # Is a Directory
+            if (-d _){
+                push @stack, $filepath;
+                next;
+            }
+
+            # Only process regular files
+            next unless -f _;
+
+            # Is a file
+            if ( $debug ) { print "[DEBUG] Checking $filepath ...\n"; }
+
+            my $size = $st[7];
+            my $mdate = $st[9];
+
+            # Skip some files ----------------------------------------
+            # Skip Folders / elements
+            my $skipRegex = 0;
+            # Regex Checks
+            foreach ( @skipElements ) {
+                if ( $filepath =~ $_ ) {
+                    if ( $debug ) { print "[DEBUG] Skipping file due to configured exclusion $filepath\n"; }
+                    $skipRegex = 1;
+                }
+            }
+            next if $skipRegex;
+            # Size
+            if ( defined $size && ( $size / 1024 ) > $max_size_kb ) {
+                if ( $debug ) { print "[DEBUG] Skipping file due to file size $filepath\n"; }
+                next;
+            }
+            # Age
+            if ( defined $mdate && $mdate < ( $current_date - ($max_age * 86400) ) ) {
+                if ( $debug ) { print "[DEBUG] Skipping file due to age $filepath\n"; }
+                next;
+            }
+
+            # Count (after all skip checks, so only eligible files are counted)
+            $num_processed++;
+
+            # Progress reporting with [N/total] X% format
+            if ($show_progress) {
+                if ($total_eligible > 0) {
+                    my $pct = int(($num_processed / $total_eligible) * 100);
+                    $pct = 100 if $pct > 100;
+                    print STDERR "\r[$num_processed/$total_eligible] $pct%   ";
+                } else {
+                    print STDERR "\r[PROGRESS] Processed: $num_processed Submitted: $num_submitted   ";
+                }
+            }
+
+            # Submit
+            &submitSample($filepath);
+        }
     }
 }
 
@@ -249,72 +417,102 @@ sub submitSample {
         $num_submitted++;
         return;
     }
-    print "[SUBMIT] Submitting $filepath ...\n";
+    print STDERR "[SUBMIT] Submitting $filepath ...\n";
     my $retry = 0;
-    for ($retry = 0; $retry < $retries_opt; $retry++) {
-        if ($retry > 0) {
-            my $sleep_time = 2 << $retry;
-            print "[SUBMIT] Waiting $sleep_time seconds to retry submitting $filepath ...\n";
-            sleep($sleep_time)
+    my $successful = 0;
+    my $next_sleep = 0;  # sleep time before next attempt (0 = no sleep for first attempt)
+    for ($retry = 0; $retry <= $retries_opt; $retry++) {
+        if ($next_sleep > 0) {
+            print STDERR "[SUBMIT] Waiting $next_sleep seconds to retry submitting $filepath ...\n";
+            sleep($next_sleep);
         }
-        my $successful = 0;
-        my $is_503 = 0;
-        my $retry_after = 30;
+        $successful = 0;
+        $next_sleep = 0;
         eval {
-            my $req = $ua->post($api_endpoint,
+            # Sanitize sourcePath: encode to UTF-8 with replacement, strip control chars
+        my $safe_path = $filepath;
+        if ($] >= 5.008) {
+            require Encode;
+            # Decode byte string as UTF-8, replacing invalid sequences
+            $safe_path = Encode::decode('UTF-8', $safe_path, Encode::FB_DEFAULT());
+            $safe_path = Encode::encode('UTF-8', $safe_path);
+        }
+        # Remove control characters except tab
+        $safe_path =~ s/[\x00-\x08\x0b\x0c\x0e-\x1f]//g;
+        my $req = $ua->post($api_endpoint,
                 Content_Type => 'form-data',
                 Content => [
-                    # Second element overrides the filename sent in Content-Disposition
-                    "file" => [ $filepath, $filepath ],
+                    # Use basename for the transmitted filename; include full path as metadata
+                    "file" => [ $filepath, basename($filepath) ],
+                    "sourcePath" => $safe_path,
                 ],
             );
             $successful = $req->is_success;
             if (!$successful) {
                 if ($req->code == 503) {
-                    $is_503 = 1;
+                    my $retry_after = 30;
                     my $ra = $req->header('Retry-After');
                     if (defined $ra && $ra =~ /^\d+$/) {
                         $retry_after = int($ra);
+                        $retry_after = 300 if $retry_after > 300;  # cap at 5 minutes
                     }
-                    print "[SUBMIT] Server busy (503), retrying in ${retry_after}s ...\n";
+                    $next_sleep = $retry_after;
+                    print STDERR "[SUBMIT] Server busy (503), retrying in ${retry_after}s ...\n";
                 } else {
-                    print "\nError: ", $req->status_line, "\n";
+                    # Exponential backoff for non-503 errors: 2, 4, 8, 16, ...
+                    my $backoff = 2 ** ($retry + 1);
+                    $backoff = 300 if $backoff > 300;
+                    $next_sleep = $backoff;
+                    print STDERR "[ERROR] Upload failed for '$filepath': ", $req->status_line, "\n";
                 }
             }
         } or do {
             my $error = $@ || 'Unknown failure';
-            warn "Could not submit '$filepath' - $error";
+            print STDERR "[ERROR] Could not submit '$filepath' - $error\n";
+            # Exponential backoff on exception
+            my $backoff = 2 ** ($retry + 1);
+            $backoff = 300 if $backoff > 300;
+            $next_sleep = $backoff;
         };
         if ($successful) {
             $num_submitted++;
             last;
         }
-        # For 503, use server-specified wait time instead of exponential backoff
-        if ($is_503) {
-            sleep($retry_after);
-            next;
-        }
+    }
+    my $total_attempts = $retries_opt + 1;
+    if (!$successful) {
+        $num_failed++;
+        print STDERR "[ERROR] Failed to submit '$filepath' after $total_attempts attempts\n";
     }
 }
 
 # MAIN ----------------------------------------------------------------
 # Default Values
-print "==============================================================\n";
-print "    ________                __            __                  \n";
-print "   /_  __/ /  __ _____  ___/ /__ _______ / /____  ______ _    \n";
-print "    / / / _ \\/ // / _ \\/ _  / -_) __(_--/ __/ _ \\/ __/  ' \\   \n";
-print "   /_/ /_//_/\\_,_/_//_/\\_,_/\\__/_/ /___/\\__/\\___/_/ /_/_/_/   \n";
-print "                                                              \n";
-print "   Florian Roth, Nextron Systems GmbH, 2021                   \n";
-print "                                                              \n";
-print "==============================================================\n";
-print "Target Directory: '$targetdir'\n";
-print "Thunderstorm Server: '$server'\n";
-print "Thunderstorm Port: '$port'\n";
-print "Using API Endpoint: $api_endpoint\n";
-print "Maximum Age of Files: $max_age days\n";
-print "Maximum File Size: $max_size_kb KB\n";
-print "\n";
+print STDERR "==============================================================\n";
+print STDERR "    ________                __            __                  \n";
+print STDERR "   /_  __/ /  __ _____  ___/ /__ _______ / /____  ______ _    \n";
+print STDERR "    / / / _ \\/ // / _ \\/ _  / -_) __(_--/ __/ _ \\/ __/  ' \\   \n";
+print STDERR "   /_/ /_//_/\\_,_/_//_/\\_,_/\\__/_/ /___/\\__/\\___/_/ /_/_/_/   \n";
+print STDERR "                                                              \n";
+print STDERR "   Florian Roth, Nextron Systems GmbH, 2021                   \n";
+print STDERR "                                                              \n";
+print STDERR "==============================================================\n";
+if ($server eq "") {
+    print STDERR "[ERROR] No Thunderstorm server specified. Use --server or -s.\n";
+    exit 2;
+}
+# Validate server as hostname, IPv4, or bracketed IPv6 — reject URI delimiters
+if ($server !~ /^(?:\[[0-9a-fA-F:]+\]|[A-Za-z0-9](?:[A-Za-z0-9\-]*[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9\-]*[A-Za-z0-9])?)*)$/) {
+    print STDERR "[ERROR] Invalid server value '$server'. Must be a hostname, IPv4 address, or bracketed IPv6 address.\n";
+    exit 2;
+}
+print STDERR "Target Directory: '$targetdir'\n";
+print STDERR "Thunderstorm Server: '$server'\n";
+print STDERR "Thunderstorm Port: '$port'\n";
+print STDERR "Using API Endpoint: $api_endpoint\n";
+print STDERR "Maximum Age of Files: $max_age days\n";
+print STDERR "Maximum File Size: $max_size_kb KB\n";
+print STDERR "\n";
 
 # Extend hardSkips with mount points of network/special filesystems
 {
@@ -324,32 +522,120 @@ print "\n";
     }
 }
 
-# Instantiate an object
-$ua = LWP::UserAgent->new;
-if ($ssl && $insecure) {
-    $ua->ssl_opts(verify_hostname => 0, SSL_verify_mode => 0x00);
+# Auto-enable SSL if TLS options specified without --ssl
+if (!$ssl && ($ca_cert ne "" || $insecure)) {
+    print STDERR "[WARN] TLS option specified without --ssl, auto-enabling SSL\n";
+    $ssl = 1;
+    $scheme = "https";
+    $base_url = "$scheme://$server:$port";
+    $api_endpoint = "$base_url$api_path$source_query";
 }
 
-print "Starting the walk at: $targetdir ...\n";
+# Instantiate an object
+$ua = LWP::UserAgent->new;
+if ($ssl) {
+    if ($insecure) {
+        $ua->ssl_opts(verify_hostname => 0, SSL_verify_mode => 0x00);
+    } elsif ($ca_cert ne "") {
+        if (! -f $ca_cert) {
+            print STDERR "[ERROR] CA certificate file not found: $ca_cert\n";
+            exit 2;
+        }
+        $ua->ssl_opts(SSL_ca_file => $ca_cert);
+    }
+}
 
-# Send collection begin marker
-$SCAN_ID = collection_marker("begin", "", undef);
+# Signal handling: set flag only (async-signal-safe), defer network I/O to main loop
+$SIG{INT} = $SIG{TERM} = sub {
+    my $sig = shift;
+    $interrupted = 1;
+    print STDERR "\n[WARN] Caught SIG$sig, will send interrupted collection marker and exit ...\n";
+};
+
+# Pre-scan to count eligible files for progress reporting
+if ($show_progress) {
+    print STDERR "[INFO] Counting eligible files for progress reporting ...\n";
+    countDir($targetdir);
+    print STDERR "[INFO] Found $total_eligible eligible files\n" if !$interrupted;
+}
+
+print STDERR "Starting the walk at: $targetdir ...\n";
+
+# Send collection begin marker (with single retry after 2s on failure)
+my ($begin_id, $begin_ok) = collection_marker("begin", "", undef);
+if (!$begin_ok) {
+    print STDERR "[WARN] Initial connection to collection API failed, retrying in 2s ...\n";
+    sleep(2);
+    ($begin_id, $begin_ok) = collection_marker("begin", "", undef);
+}
+if (!$begin_ok) {
+    print STDERR "[ERROR] Cannot connect to Thunderstorm server at $base_url/api/collection after retry. Aborting.\n";
+    exit 2;
+}
+$collection_started = 1;
+$SCAN_ID = $begin_id;
 if ($SCAN_ID) {
-    print "[INFO] Collection scan_id: $SCAN_ID\n";
-    $api_endpoint .= "&scan_id=" . urlencode($SCAN_ID);
+    print STDERR "[INFO] Collection scan_id: $SCAN_ID\n";
+    # Determine separator based on whether URL already has query params
+    my $sep = $url_has_query ? "&" : "?";
+    $api_endpoint .= "${sep}scan_id=" . urlencode($SCAN_ID);
+    $url_has_query = 1;
 }
 
 # Start the walk
 &processDir($targetdir);
 
+# If interrupted, send interrupted marker and exit from normal execution context
+if ($interrupted) {
+    if ($collection_started) {
+        my $int_date = time;
+        my $int_elapsed = $int_date - $current_date;
+        my ($int_id, $int_ok) = eval {
+            collection_marker("interrupted", $SCAN_ID, {
+                scanned  => $num_processed,
+                submitted => $num_submitted,
+                failed   => $num_failed,
+                elapsed_seconds => $int_elapsed,
+            });
+        };
+    if (!$int_ok) {
+        print STDERR "[ERROR] Failed to send interrupted collection marker\n";
+    }
+    }
+    # Clear progress line if we were showing progress
+    if ($show_progress) {
+        print STDERR "\r" . (" " x 60) . "\r";
+    }
+    my $int_minutes = int((time - $current_date) / 60);
+    print STDERR "Thunderstorm Collector Run interrupted (Checked: $num_processed Submitted: $num_submitted Failed: $num_failed Minutes: $int_minutes)\n";
+    exit 1;
+}
+
 # Send collection end marker with stats
 my $end_date = time;
 my $elapsed = $end_date - $current_date;
-collection_marker("end", $SCAN_ID, {
+my $marker_failed = 0;
+my ($end_id, $end_ok) = collection_marker("end", $SCAN_ID, {
     scanned  => $num_processed,
     submitted => $num_submitted,
+    failed   => $num_failed,
     elapsed_seconds => $elapsed,
 });
+if (!$end_ok) {
+    print STDERR "[ERROR] Failed to send end collection marker\n";
+    $marker_failed = 1;
+}
+
+# Clear progress line if we were showing progress
+if ($show_progress) {
+    print STDERR "\r" . (" " x 60) . "\r";
+}
 
 my $minutes = int( $elapsed / 60 );
-print "Thunderstorm Collector Run finished (Checked: $num_processed Submitted: $num_submitted Minutes: $minutes)\n";
+print STDERR "Thunderstorm Collector Run finished (Checked: $num_processed Submitted: $num_submitted Failed: $num_failed Minutes: $minutes)\n";
+
+# Exit codes: 0 = success, 1 = partial failure, 2 = fatal error
+if ($num_failed > 0 || $marker_failed) {
+    exit 1;
+}
+exit 0;

--- a/scripts/thunderstorm-collector.pl
+++ b/scripts/thunderstorm-collector.pl
@@ -466,6 +466,7 @@ sub submitSample {
                     print STDERR "[ERROR] Upload failed for '$filepath': ", $req->status_line, "\n";
                 }
             }
+            1;  # Return truthy so the 'or do { }' block doesn't execute on success
         } or do {
             my $error = $@ || 'Unknown failure';
             print STDERR "[ERROR] Could not submit '$filepath' - $error\n";

--- a/scripts/thunderstorm-collector.ps1
+++ b/scripts/thunderstorm-collector.ps1
@@ -94,11 +94,26 @@ param
         [Alias('SSL')]
         [switch]$UseSSL = $False,
 
+    [Parameter(HelpMessage='Path to custom CA certificate bundle for TLS verification')]
+        [string]$CACert = "",
+
+    [Parameter(HelpMessage='Skip TLS certificate verification (insecure)')]
+        [Alias('k')]
+        [switch]$Insecure = $False,
+
     [Parameter(HelpMessage='Enables debug output and skips cleanup at the end of the scan')]
+
         [ValidateNotNullOrEmpty()]
         [Alias('D')]
-        [switch]$Debugging = $False
+        [switch]$Debugging = $False,
+
+    [Parameter(HelpMessage='Force enable progress reporting')]
+        [switch]$Progress = $False,
+
+    [Parameter(HelpMessage='Force disable progress reporting')]
+        [switch]$NoProgress = $False
 )
+
 
 # Fixing Certain Platform Environments --------------------------------
 $AutoDetectPlatform = ""
@@ -135,6 +150,11 @@ if ( $OutputPath -eq "" -or $OutputPath.Contains("Advanced Threat Protection") )
 if (-not $PSBoundParameters.ContainsKey('MaxSize')) {
     [int]$MaxSize = 20
 }
+# Enforce hard upper bound on MaxSize to prevent out-of-memory conditions
+if ($MaxSize -gt 200) {
+    Write-Host "[!] MaxSize capped to 200 MB to prevent excessive memory usage"
+    $MaxSize = 200
+}
 
 # Extensions
 # -AllExtensions overrides any -Extensions value
@@ -143,7 +163,12 @@ if (-not $PSBoundParameters.ContainsKey('MaxSize')) {
 if ($AllExtensions) {
     [string[]]$ActiveExtensions = @()
 } elseif ($PSBoundParameters.ContainsKey('Extensions')) {
-    [string[]]$ActiveExtensions = $Extensions
+    # Normalize user-supplied extensions: lowercase and ensure leading dot
+    [string[]]$ActiveExtensions = $Extensions | ForEach-Object {
+        $ext = $_.ToLowerInvariant().Trim()
+        if ($ext -ne '' -and -not $ext.StartsWith('.')) { $ext = '.' + $ext }
+        $ext
+    }
 } else {
     # Apply recommended preset only when no -Extensions parameter was explicitly passed
     [string[]]$ActiveExtensions = @('.asp','.vbs','.ps','.ps1','.rar','.tmp','.bas','.bat','.chm','.cmd','.com','.cpl','.crt','.dll','.exe','.hta','.js','.lnk','.msc','.ocx','.pcd','.pif','.pot','.reg','.scr','.sct','.sys','.url','.vb','.vbe','.vbs','.wsc','.wsf','.wsh','.ct','.t','.input','.war','.jsp','.php','.asp','.aspx','.doc','.docx','.pdf','.xls','.xlsx','.ppt','.pptx','.tmp','.log','.dump','.pwd','.w','.txt','.conf','.cfg','.conf','.config','.psd1','.psm1','.ps1xml','.clixml','.psc1','.pssc','.pl','.www','.rdp','.jar','.docm','.ace','.job','.temp','.plg','.asm')
@@ -154,11 +179,12 @@ $Debug = $Debugging
 
 # Show Help -----------------------------------------------------------
 # No Thunderstorm server 
-if ( $Args.Count -eq 0 -and $ThunderstormServer -eq "" ) {
+if ( $ThunderstormServer -eq "" ) {
     Get-Help $MyInvocation.MyCommand.Definition -Detailed
-    Write-Host -ForegroundColor Yellow 'Note: You must at least define an Thunderstorm server (-ThunderstormServer)'
-    return
+    Write-Host -ForegroundColor Yellow 'Note: You must at least define a Thunderstorm server (-ThunderstormServer)'
+    exit 2
 }
+
 
 # #####################################################################
 # Functions -----------------------------------------------------------
@@ -173,7 +199,8 @@ function Write-Log {
         [Parameter(Position=1, HelpMessage="Log file to write into")]
             [ValidateNotNullOrEmpty()]
             [Alias('SS')]
-            [IO.FileInfo]$LogFile = "thunderstorm-collector.log",
+            [IO.FileInfo]$LogFile = (Join-Path $OutputPath "thunderstorm-collector.log"),
+
 
         [Parameter(Position=3, HelpMessage="Level")]
             [ValidateNotNullOrEmpty()]
@@ -196,7 +223,8 @@ function Write-Log {
     if ( $Level -eq "Warning" ) {
         Write-Warning -Message "$($Indicator) $($Entry)"
     } elseif ( $Level -eq "Error" ) {
-        Write-Host "$($Indicator) $($Entry)" -ForegroundColor Red
+        [Console]::Error.WriteLine("$($Indicator) $($Entry)")
+
     } elseif ( $Level -eq "Debug" -and $Debug -eq $False ) {
         return
     } else {
@@ -204,7 +232,8 @@ function Write-Log {
     }
 
     # Log File
-    if ( $global:NoLog -eq $False ) {
+    if ( -not $global:NoLog ) {
+
         "$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss.fff') $($env:COMPUTERNAME): $Entry" | Out-File -FilePath $LogFile -Append
     }
 }
@@ -226,6 +255,13 @@ Write-Host "=============================================================="
 # Measure time
 $DateStamp = Get-Date -f yyyy-MM-dd
 $StartTime = $(Get-Date)
+
+# Validate folder exists
+if (-not (Test-Path -Path $Folder -PathType Container)) {
+    Write-Log "Folder not found: $Folder" -Level "Error"
+    exit 2
+}
+
 
 Write-Log "Started Thunderstorm Collector with PowerShell v$($PSVersionTable.PSVersion)"
 
@@ -259,6 +295,149 @@ if ( $UseSSL ) {
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     }
     Write-Log "HTTPS mode enabled (TLS 1.2+)"
+
+    if ($Insecure) {
+        Write-Log "TLS certificate verification DISABLED (insecure mode)" -Level "Warning"
+        # Use ServerCertificateValidationCallback (works on .NET 4.5+ / PS 3+)
+        try {
+            [System.Net.ServicePointManager]::ServerCertificateValidationCallback = [System.Net.Security.RemoteCertificateValidationCallback]{
+                param($sender, $certificate, $chain, $sslPolicyErrors)
+                return $true
+            }
+        } catch {
+            # Fallback: try legacy ICertificatePolicy for older .NET
+            try {
+                if (-not ([System.Management.Automation.PSTypeName]'TrustAllCertsPolicy').Type) {
+                    Add-Type @"
+using System.Net;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+public class TrustAllCertsPolicy : ICertificatePolicy {
+    public bool CheckValidationResult(
+        ServicePoint srvPoint, X509Certificate certificate,
+        WebRequest request, int certificateProblem) { return true; }
+}
+"@
+                }
+                [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
+            } catch {
+                Write-Log "Failed to set insecure certificate policy: $_" -Level "Warning"
+            }
+        }
+    } elseif ($CACert -ne "") {
+        if (-not (Test-Path $CACert)) {
+            Write-Log "CA certificate file not found: $CACert" -Level "Error"
+            exit 2
+        }
+        Write-Log "Using custom CA certificate: $CACert"
+        try {
+            # Load custom CA and set up validation callback with hostname verification
+            $script:CustomCACert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($CACert)
+            $script:ExpectedHost = $ThunderstormServer
+            if (-not ([System.Management.Automation.PSTypeName]'CustomCACertValidator').Type) {
+                Add-Type @"
+using System;
+using System.Net;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+using System.Text.RegularExpressions;
+
+public static class CustomCACertValidator {
+    private static X509Certificate2 _ca;
+    private static string _expectedHost;
+
+    public static void Configure(X509Certificate2 ca, string expectedHost) {
+        _ca = ca;
+        _expectedHost = expectedHost;
+    }
+
+    public static bool ValidateCallback(
+        object sender, X509Certificate certificate,
+        X509Chain chain, SslPolicyErrors sslPolicyErrors) {
+        // If the platform says everything is fine, accept
+        if (sslPolicyErrors == SslPolicyErrors.None) return true;
+
+        X509Certificate2 cert2 = new X509Certificate2(certificate);
+
+        // Build chain with our custom CA
+        X509Chain customChain = new X509Chain();
+        customChain.ChainPolicy.ExtraStore.Add(_ca);
+        customChain.ChainPolicy.VerificationFlags = X509VerificationFlags.AllowUnknownCertificateAuthority;
+        customChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+        bool chainValid = customChain.Build(cert2);
+        if (!chainValid) return false;
+
+        // Verify the chain actually roots at our CA
+        bool rootedAtCA = false;
+        foreach (var element in customChain.ChainElements) {
+            if (element.Certificate.Thumbprint == _ca.Thumbprint) {
+                rootedAtCA = true;
+                break;
+            }
+        }
+        if (!rootedAtCA) return false;
+
+        // Hostname verification: check SAN and CN
+        if (!MatchesHost(cert2, _expectedHost)) return false;
+
+        return true;
+    }
+
+    private static bool MatchesHost(X509Certificate2 cert, string host) {
+        // Check Subject Alternative Names (OID 2.5.29.17)
+        foreach (var ext in cert.Extensions) {
+            if (ext.Oid.Value == "2.5.29.17") {
+                string san = ext.Format(true);
+                // Parse DNS Name entries
+                foreach (string line in san.Split(new char[]{'\r','\n'}, StringSplitOptions.RemoveEmptyEntries)) {
+                    string trimmed = line.Trim();
+                    if (trimmed.StartsWith("DNS Name=", StringComparison.OrdinalIgnoreCase)) {
+                        string dnsName = trimmed.Substring(9).Trim();
+                        if (HostMatchesPattern(host, dnsName)) return true;
+                    }
+                    // Also handle "DNS:" format
+                    if (trimmed.StartsWith("DNS:", StringComparison.OrdinalIgnoreCase)) {
+                        string dnsName = trimmed.Substring(4).Trim();
+                        if (HostMatchesPattern(host, dnsName)) return true;
+                    }
+                }
+            }
+        }
+        // Fallback to CN in Subject
+        string subject = cert.Subject;
+        var match = Regex.Match(subject, @"CN\s*=\s*([^,]+)");
+        if (match.Success) {
+            string cn = match.Groups[1].Value.Trim();
+            if (HostMatchesPattern(host, cn)) return true;
+        }
+        return false;
+    }
+
+    private static bool HostMatchesPattern(string host, string pattern) {
+        if (string.Equals(host, pattern, StringComparison.OrdinalIgnoreCase))
+            return true;
+        // Wildcard matching: *.example.com matches foo.example.com
+        if (pattern.StartsWith("*.")) {
+            string suffix = pattern.Substring(1); // .example.com
+            int dotIndex = host.IndexOf('.');
+            if (dotIndex > 0) {
+                string hostSuffix = host.Substring(dotIndex);
+                if (string.Equals(hostSuffix, suffix, StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+        }
+        return false;
+    }
+}
+"@
+            }
+            [CustomCACertValidator]::Configure($script:CustomCACert, $script:ExpectedHost)
+            [System.Net.ServicePointManager]::ServerCertificateValidationCallback = [System.Net.Security.RemoteCertificateValidationCallback]([CustomCACertValidator].GetMethod('ValidateCallback'))
+        } catch {
+            Write-Log "Failed to configure custom CA certificate: $_" -Level "Error"
+            exit 2
+        }
+    }
 }
 $BaseUrl = "$($Protocol)://$($ThunderstormServer):$($ThunderstormPort)"
 $Url = "$BaseUrl/api/checkAsync$($SourceParam)"
@@ -269,12 +448,14 @@ function Send-CollectionMarker {
     param(
         [string]$MarkerType,
         [string]$ScanId = "",
-        [hashtable]$Stats = $null
+        [hashtable]$Stats = $null,
+        [switch]$Fatal = $False
     )
     $MarkerUrl = "$BaseUrl/api/collection"
+    # Let ConvertTo-Json handle proper JSON escaping of all characters including control chars
     $Body = @{
         type      = $MarkerType
-        source    = $ThunderstormSource
+        source    = $Source
         collector = "powershell3/1.0"
         timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
     }
@@ -289,7 +470,20 @@ function Send-CollectionMarker {
         $ResponseData = $Response.Content | ConvertFrom-Json
         return $ResponseData.scan_id
     } catch {
-        # Silently ignore — server may not support this endpoint yet
+        $HttpStatus = $null
+        if ($_.Exception.Response) {
+            $HttpStatus = $_.Exception.Response.StatusCode.value__
+        }
+        # 404 or 501 means the server doesn't support collection markers — not fatal
+        if ($HttpStatus -eq 404 -or $HttpStatus -eq 501) {
+            Write-Log "Collection marker endpoint not supported by server (HTTP $HttpStatus)" -Level "Debug"
+            return ""
+        }
+        # For other errors, log and optionally treat as fatal
+        Write-Log "Collection marker '$MarkerType' failed: $_" -Level "Warning"
+        if ($Fatal) {
+            throw $_
+        }
         return ""
     }
 }
@@ -302,69 +496,243 @@ $FilesScanned = 0
 $FilesSubmitted = 0
 $FilesSkipped = 0
 $FilesFailed = 0
+# Use a reference object for cross-runspace signal communication
+$script:InterruptSignal = New-Object PSObject -Property @{ Value = $False }
+$global:Interrupted = $False
 
-# Send collection begin marker
-$ScanId = Send-CollectionMarker -MarkerType "begin"
-if ($ScanId) {
-    Write-Log "Collection scan_id: $ScanId"
-    $Url = "$Url&scan_id=$([uri]::EscapeDataString($ScanId))"
+# Progress reporting: auto-detect TTY unless overridden
+$ShowProgress = $False
+if ($Progress) {
+    $ShowProgress = $True
+} elseif ($NoProgress) {
+    $ShowProgress = $False
+} else {
+    try {
+        # Auto-detect: show progress if stdout is a terminal
+        if ([Environment]::UserInteractive -and [Console]::WindowWidth -gt 0) {
+            $ShowProgress = $True
+        }
+    } catch {
+        $ShowProgress = $False
+    }
+}
+$TotalFiles = 0
+if ($ShowProgress) {
+    # Pre-count files for progress percentage (best effort)
+    # Skip pre-count for root/large directories to avoid long startup delay
+    $SkipPreCount = $False
+    try {
+        $FolderNormalized = (Resolve-Path $Folder -ErrorAction SilentlyContinue).Path
+        # Skip pre-count for drive roots (e.g. C:\, D:\)
+        if ($FolderNormalized -match '^[A-Za-z]:\\?$') {
+            $SkipPreCount = $True
+        }
+    } catch {
+        $SkipPreCount = $True
+    }
+    if (-not $SkipPreCount) {
+        try {
+            $PreCountErrors = @()
+            $TotalFiles = @(Get-ChildItem -Path $Folder -Recurse -Force -ErrorAction SilentlyContinue -ErrorVariable PreCountErrors | Where-Object { -not $_.PSIsContainer }).Count
+        } catch {
+            $TotalFiles = 0
+        }
+    }
 }
 
+
+# Register handler for Ctrl+C (SIGINT) using a C# helper for static event subscription
+[Console]::TreatControlCAsInput = $False
 try {
-    Get-ChildItem -Path $Folder -File -Recurse -ErrorAction SilentlyContinue |
-    ForEach-Object {
+    if (-not ([System.Management.Automation.PSTypeName]'SigIntHandler').Type) {
+        Add-Type @"
+using System;
+public static class SigIntHandler {
+    public static volatile bool Interrupted = false;
+    private static bool _registered = false;
+    public static void Register() {
+        if (_registered) return;
+        _registered = true;
+        Console.CancelKeyPress += delegate(object sender, ConsoleCancelEventArgs e) {
+            e.Cancel = true;
+            Interrupted = true;
+        };
+    }
+}
+"@
+    }
+    [SigIntHandler]::Register()
+} catch {
+    # CancelKeyPress registration not available on all platforms (e.g. non-interactive)
+    Write-Log "SIGINT handler registration not available: $_" -Level "Debug"
+}
+
+
+# Send collection begin marker (with single retry after 2s on connection failure)
+$ScanId = ""
+$BeginMarkerSuccess = $False
+try {
+    $ScanId = Send-CollectionMarker -MarkerType "begin" -Fatal
+    $BeginMarkerSuccess = $True
+} catch {
+    # Check if this is a connection error (no HTTP response) vs an HTTP error from a reachable server
+    $BeginHttpStatus = $null
+    $BeginWebException = $null
+    # Unwrap to find the WebException
+    if ($_.Exception -is [System.Net.WebException]) {
+        $BeginWebException = $_.Exception
+    } elseif ($_.Exception.InnerException -is [System.Net.WebException]) {
+        $BeginWebException = $_.Exception.InnerException
+    }
+    if ($BeginWebException -and $BeginWebException.Response) {
+        $BeginHttpStatus = [int]$BeginWebException.Response.StatusCode
+    }
+    # Treat as connection failure if no HTTP status was obtained
+    $IsConnectionFailure = ($null -eq $BeginHttpStatus -or $BeginHttpStatus -eq 0)
+    # Also treat WebException transport-level statuses as connection failures
+    if (-not $IsConnectionFailure -and $BeginWebException) {
+        $WeStatus = $BeginWebException.Status
+        if ($WeStatus -eq [System.Net.WebExceptionStatus]::ConnectFailure -or
+            $WeStatus -eq [System.Net.WebExceptionStatus]::NameResolutionFailure -or
+            $WeStatus -eq [System.Net.WebExceptionStatus]::Timeout -or
+            $WeStatus -eq [System.Net.WebExceptionStatus]::ConnectionClosed -or
+            $WeStatus -eq [System.Net.WebExceptionStatus]::SendFailure) {
+            $IsConnectionFailure = $True
+        }
+    }
+    if ($IsConnectionFailure) {
+        # Connection failure — retry once after 2s
+        Write-Log "Begin marker failed (connection error), retrying in 2 seconds..." -Level "Warning"
+        Start-Sleep -Seconds 2
+        try {
+            $ScanId = Send-CollectionMarker -MarkerType "begin" -Fatal
+            $BeginMarkerSuccess = $True
+        } catch {
+            Write-Log "Cannot connect to Thunderstorm server at $BaseUrl : $_" -Level "Error"
+            exit 2
+        }
+    } else {
+        # Server is reachable but returned an HTTP error — log warning and continue without scan_id
+        Write-Log "Begin marker returned HTTP $BeginHttpStatus — continuing without scan_id" -Level "Warning"
+    }
+}
+if ($ScanId) {
+    Write-Log "Collection scan_id: $ScanId"
+    if ($Url.Contains("?")) {
+        $Url = "$Url&scan_id=$([uri]::EscapeDataString($ScanId))"
+    } else {
+        $Url = "$Url`?scan_id=$([uri]::EscapeDataString($ScanId))"
+    }
+}
+
+
+
+$EnumErrors = @()
+try {
+    $FileList = @(Get-ChildItem -Path $Folder -Recurse -Force -ErrorAction SilentlyContinue -ErrorVariable EnumErrors | Where-Object { -not $_.PSIsContainer })
+    # Set total file count from actual enumeration for accurate progress reporting
+    if ($ShowProgress) {
+        $TotalFiles = $FileList.Count
+    }
+    if ($EnumErrors.Count -gt 0) {
+        foreach ($enumErr in $EnumErrors) {
+            Write-Log "Traversal error: $($enumErr.Exception.Message)" -Level "Warning"
+        }
+        Write-Log "Directory traversal encountered $($EnumErrors.Count) error(s) - some paths may not have been scanned" -Level "Warning"
+        $FilesFailed += $EnumErrors.Count
+    }
+
+    foreach ($CurrentFile in $FileList) {
+        # Check for interruption (from C# SIGINT handler or direct flag)
+        $SigIntFired = $False
+        try { $SigIntFired = [SigIntHandler]::Interrupted } catch {}
+        if ($SigIntFired -or $global:Interrupted) {
+            $global:Interrupted = $True
+            Write-Log "Interrupted by user signal" -Level "Warning"
+            break
+        }
+
         # -------------------------------------------------------------
         # Filter ------------------------------------------------------
         $FilesScanned++
+        # Progress reporting
+        if ($ShowProgress -and $TotalFiles -gt 0) {
+            $Pct = [math]::Round(($FilesScanned / $TotalFiles) * 100, 0)
+            Write-Host -NoNewline "`r[${FilesScanned}/${TotalFiles}] ${Pct}%   "
+        }
+
+
         # Size Check
-        if ( ( $_.Length / 1MB ) -gt $($MaxSize) ) {
-            Write-Log "$_ skipped due to size filter" -Level "Debug"
+        if ( ( $CurrentFile.Length / 1MB ) -gt $($MaxSize) ) {
+            Write-Log "$CurrentFile skipped due to size filter" -Level "Debug"
             $FilesSkipped++
-            return
+            continue
         }
-        # Age Check
-        if ( $($MaxAge) -gt 0 ) {
-            if ( $_.LastWriteTime -lt (Get-Date).AddDays(-$($MaxAge)) ) {
-                Write-Log "$_ skipped due to age filter" -Level "Debug"
+        # Age Check (file passes if either created or modified within MaxAge days)
+        if ( $MaxAge -gt 0 ) {
+            $AgeThreshold = (Get-Date).AddDays(-$MaxAge)
+            $NewestTime = if ($CurrentFile.CreationTime -gt $CurrentFile.LastWriteTime) { $CurrentFile.CreationTime } else { $CurrentFile.LastWriteTime }
+            if ( $NewestTime -lt $AgeThreshold ) {
+                Write-Log "$CurrentFile skipped due to age filter" -Level "Debug"
                 $FilesSkipped++
-                return
+                continue
             }
         }
-        # Extensions Check
+
+        # Extensions Check (case-insensitive)
         if ( $ActiveExtensions.Length -gt 0 ) {
-            if ( $ActiveExtensions -contains $_.extension ) { } else {
-                Write-Log "$_ skipped due to extension filter" -Level "Debug"
+            $FileExt = $CurrentFile.Extension.ToLowerInvariant()
+            if ( -not ($ActiveExtensions -contains $FileExt) ) {
+                Write-Log "$CurrentFile skipped due to extension filter" -Level "Debug"
                 $FilesSkipped++
-                return
+                continue
             }
         }
+
 
         # -------------------------------------------------------------
         # Submission --------------------------------------------------
 
-        Write-Log "Processing $($_.FullName) ..." -Level "Debug"
-        # Reading the file data & preparing the request
+        Write-Log "Processing $($CurrentFile.FullName) ..." -Level "Debug"
+        $boundary = "----ThunderstormBoundary" + [System.Guid]::NewGuid().ToString("N")
+
+        $CRLF = "`r`n"
+        $SafeFileName = $CurrentFile.FullName -replace '[\r\n]','' -replace '"','\"'
+        $SafeSourcePath = $CurrentFile.FullName -replace '[\r\n]','' -replace '"','\"'
+        $SafeHostname = $Hostname -replace '[\r\n]','' -replace '"','\"'
+        $SafeSource = $Source -replace '[\r\n]','' -replace '"','\"'
+
+        # Metadata parts: hostname and source_path
+        $metadataText = "--$boundary$CRLF" +
+            "Content-Disposition: form-data; name=`"hostname`"$CRLF$CRLF$SafeHostname$CRLF" +
+            "--$boundary$CRLF" +
+            "Content-Disposition: form-data; name=`"source`"$CRLF$CRLF$SafeSource$CRLF" +
+            "--$boundary$CRLF" +
+            "Content-Disposition: form-data; name=`"source_path`"$CRLF$CRLF$SafeSourcePath$CRLF"
+
+        # File part
+        $headerText = "--$boundary$CRLF" +
+            "Content-Disposition: form-data; name=`"file`"; filename=`"$SafeFileName`"$CRLF" +
+            "Content-Type: application/octet-stream$CRLF$CRLF"
+
+        $footerText = "$CRLF--$boundary--$CRLF"
+
+        $metadataBytes = [System.Text.Encoding]::UTF8.GetBytes($metadataText)
+        $headerBytes = [System.Text.Encoding]::UTF8.GetBytes($headerText)
+        $footerBytes = [System.Text.Encoding]::UTF8.GetBytes($footerText)
+
+        # Pre-check file readability before attempting upload
+        $fileLength = 0
         try {
-            $fileBytes = [System.IO.File]::ReadAllBytes("$($_.FullName)");
+            $fileLength = $CurrentFile.Length
+            # Quick open/close to verify readability
+            $testStream = [System.IO.File]::OpenRead($CurrentFile.FullName)
+            $testStream.Dispose()
         } catch {
             Write-Log "Read Error: $_" -Level "Error"
-            return
+            $FilesFailed++
+            continue
         }
-        $boundary = [System.Guid]::NewGuid().ToString()
-        $LF = "`r`n"
-        $headerText = "--$boundary$LF" +
-            "Content-Disposition: form-data; name=`"file`"; filename=`"$($_.FullName)`"$LF" +
-            "Content-Type: application/octet-stream$LF$LF"
-        $footerText = "$LF--$boundary--$LF"
-
-        $headerBytes = [System.Text.Encoding]::ASCII.GetBytes($headerText)
-        $footerBytes = [System.Text.Encoding]::ASCII.GetBytes($footerText)
-        $bodyStream = New-Object System.IO.MemoryStream
-        $bodyStream.Write($headerBytes, 0, $headerBytes.Length)
-        $bodyStream.Write($fileBytes, 0, $fileBytes.Length)
-        $bodyStream.Write($footerBytes, 0, $footerBytes.Length)
-        $bodyBytes = $bodyStream.ToArray()
-        $bodyStream.Dispose()
 
         # Submitting the request
         $StatusCode = 0
@@ -372,36 +740,110 @@ try {
         $MaxRetries = 3
         $Max503Retries = 10
         $Retries503 = 0
+
         while ( $($StatusCode) -ne 200 ) {
+            $fileStream = $null
+            $requestStream = $null
             try {
-                Write-Log "Submitting to Thunderstorm server: $($_.FullName) ..." -Level "Info"
-                $Response = Invoke-WebRequest -uri $($Url) -Method Post -ContentType "multipart/form-data; boundary=$boundary" -Body $bodyBytes -UseBasicParsing
-                $StatusCode = [int]$Response.StatusCode
+                Write-Log "Submitting to Thunderstorm server: $($CurrentFile.FullName) ..." -Level "Info"
+
+                # Stream the multipart body directly to the request to avoid double-buffering
+                $ContentLength = $metadataBytes.Length + $headerBytes.Length + $fileLength + $footerBytes.Length
+                $WebRequest = [System.Net.HttpWebRequest]::Create($Url)
+                $WebRequest.Method = "POST"
+                $WebRequest.ContentType = "multipart/form-data; boundary=$boundary"
+                $WebRequest.ContentLength = $ContentLength
+                $WebRequest.Timeout = 300000
+                $WebRequest.AllowWriteStreamBuffering = $False
+
+                $requestStream = $WebRequest.GetRequestStream()
+                $requestStream.Write($metadataBytes, 0, $metadataBytes.Length)
+                $requestStream.Write($headerBytes, 0, $headerBytes.Length)
+
+                # Stream file content directly to request stream
+                $fileStream = [System.IO.File]::OpenRead($CurrentFile.FullName)
+                $copyBuffer = New-Object byte[] 81920
+                $bytesRead = 0
+                while (($bytesRead = $fileStream.Read($copyBuffer, 0, $copyBuffer.Length)) -gt 0) {
+                    $requestStream.Write($copyBuffer, 0, $bytesRead)
+                }
+                $fileStream.Dispose()
+                $fileStream = $null
+
+                $requestStream.Write($footerBytes, 0, $footerBytes.Length)
+                $requestStream.Dispose()
+                $requestStream = $null
+
+                $WebResponse = $WebRequest.GetResponse()
+                $StatusCode = [int]$WebResponse.StatusCode
+                $WebResponse.Close()
                 $FilesSubmitted++
             }
-            # Catch all non 200 status codes
             catch {
-                $StatusCode = $_.Exception.Response.StatusCode.value__
+                if ($fileStream) { try { $fileStream.Dispose() } catch {} }
+                if ($requestStream) { try { $requestStream.Dispose() } catch {} }
+
+                $ErrorResponse = $null
+                $StatusCode = 0
+                if ($_.Exception -is [System.Net.WebException]) {
+                    $ErrorResponse = $_.Exception.Response
+                    if ($ErrorResponse) {
+                        $StatusCode = [int]$ErrorResponse.StatusCode
+                    }
+                } elseif ($_.Exception.InnerException -is [System.Net.WebException]) {
+                    $ErrorResponse = $_.Exception.InnerException.Response
+                    if ($ErrorResponse) {
+                        $StatusCode = [int]$ErrorResponse.StatusCode
+                    }
+                }
+
                 if ( $StatusCode -eq 503 ) {
                     $Retries503 = $Retries503 + 1
+                    # Reset non-503 retry counter since server is reachable (just busy)
+                    $Retries = 0
                     if ( $Retries503 -ge $Max503Retries ) {
                         $FilesFailed++
-                        Write-Log "503: Server still busy after $Max503Retries retries - giving up on $($_.FullName)" -Level "Warning"
+                        Write-Log "503: Server still busy after $Max503Retries retries - giving up on $($CurrentFile.FullName)" -Level "Warning"
                         break
                     }
                     $WaitSecs = 3
-                    if ( $_.Exception.Response.Headers['Retry-After'] ) {
-                        $WaitSecs = [int]$_.Exception.Response.Headers['Retry-After']
+                    try {
+                        $RetryAfterVal = $null
+                        if ($ErrorResponse) {
+                            $RetryAfterVal = $ErrorResponse.Headers['Retry-After']
+                        }
+                        if ($RetryAfterVal) {
+                            $WaitSecs = [int]$RetryAfterVal
+                            if ($WaitSecs -lt 1) { $WaitSecs = 3 }
+                            if ($WaitSecs -gt 300) { $WaitSecs = 300 }
+                        }
+                    } catch {
+                        $WaitSecs = 3
                     }
+
                     Write-Log "503: Server seems busy - retrying in $($WaitSecs) seconds ($Retries503/$Max503Retries)"
                     Start-Sleep -Seconds $($WaitSecs)
-                } else {
-                    if ( $Retries -eq $MaxRetries ) {
-                        Write-Log "$($StatusCode): Server still has problems - giving up"
+                } elseif ( $StatusCode -eq 0 ) {
+                    # Connection/transport error (no HTTP response)
+                    $Retries = $Retries + 1
+                    if ( $Retries -gt $MaxRetries ) {
+                        $FilesFailed++
+                        Write-Log "Connection error: giving up on $($CurrentFile.FullName) after $MaxRetries retries - $_" -Level "Warning"
                         break
                     }
+                    $SleepTime = [Math]::Pow(2, $Retries)
+                    Write-Log "Connection error - retrying in $SleepTime seconds ($Retries/$MaxRetries): $_"
+                    Start-Sleep -Seconds $($SleepTime)
+                } else {
                     $Retries = $Retries + 1
-                    $SleepTime = 2 * [Math]::Pow(2, $Retries)
+                    if ( $Retries -gt $MaxRetries ) {
+                        $FilesFailed++
+                        Write-Log "$($StatusCode): Server still has problems - giving up on $($CurrentFile.FullName)" -Level "Warning"
+                        break
+                    }
+
+                    $SleepTime = [Math]::Pow(2, $Retries)
+
                     Write-Log "$($StatusCode): Server has problems - retrying in $SleepTime seconds"
                     Start-Sleep -Seconds $($SleepTime)
                 }
@@ -409,22 +851,61 @@ try {
         }
      }
 } catch {
-    Write-Log "Unknown error during Thunderstorm Collection $_" -Level "Error"
+    Write-Log "Fatal error during Thunderstorm Collection: $_" -Level "Error"
+    # Send interrupted marker on fatal error
+    try {
+        Send-CollectionMarker -MarkerType "interrupted" -ScanId $ScanId -Stats @{
+            scanned   = $FilesScanned
+            submitted = $FilesSubmitted
+            skipped   = $FilesSkipped
+            failed    = $FilesFailed
+        } | Out-Null
+    } catch {
+        Write-Log "Failed to send interrupted marker: $_" -Level "Warning"
+    }
+    exit 2
 }
+
+
 
 # ---------------------------------------------------------------------
 # End -----------------------------------------------------------------
 # ---------------------------------------------------------------------
+# Clear progress line if active
+if ($ShowProgress -and $TotalFiles -gt 0) {
+    Write-Host "`r$(' ' * 40)`r" -NoNewline
+}
 $ElapsedTime = $(get-date) - $StartTime
+
 $TotalTime = "{0:HH:mm:ss}" -f ([datetime]$elapsedTime.Ticks)
-Write-Log "Scan took $($TotalTime) to complete" -Level "Information"
+Write-Log "Scan took $($TotalTime) to complete" -Level "Info"
 Write-Log "Results: scanned=$FilesScanned submitted=$FilesSubmitted skipped=$FilesSkipped failed=$FilesFailed"
 
-# Send collection end marker with stats
-Send-CollectionMarker -MarkerType "end" -ScanId $ScanId -Stats @{
+# Send collection marker with stats
+$EndStats = @{
     scanned          = $FilesScanned
     submitted        = $FilesSubmitted
     skipped          = $FilesSkipped
     failed           = $FilesFailed
     elapsed_seconds  = [int]$ElapsedTime.TotalSeconds
-} | Out-Null
+}
+
+$SigIntFired = $False
+try { $SigIntFired = [SigIntHandler]::Interrupted } catch {}
+if ($SigIntFired -or $global:Interrupted) {
+    $global:Interrupted = $True
+    Send-CollectionMarker -MarkerType "interrupted" -ScanId $ScanId -Stats $EndStats | Out-Null
+    Write-Log "Collection was interrupted by user" -Level "Warning"
+    exit 1
+} else {
+
+    Send-CollectionMarker -MarkerType "end" -ScanId $ScanId -Stats $EndStats | Out-Null
+}
+
+# Exit with appropriate code
+if ($FilesFailed -gt 0) {
+    exit 1
+} else {
+    exit 0
+}
+

--- a/scripts/thunderstorm-collector.py
+++ b/scripts/thunderstorm-collector.py
@@ -6,7 +6,9 @@ import http.client
 import json
 import os
 import re
+import signal
 import ssl
+import sys
 import time
 import uuid
 import socket
@@ -88,22 +90,121 @@ current_date = time.time()
 # Stats
 num_submitted = 0
 num_processed = 0
+num_failed = 0
+total_files_estimate = 0
+upload_in_flight = None  # Path of file currently being uploaded, or None
 
 # URL to use for submission
 api_endpoint = ""
 
+# scan_id at module level for signal handler
+scan_id = None
+
 # Original args
-args = {}
+args = None
+
+# Progress reporting
+show_progress = None  # None = auto-detect TTY
+
+
+def print_error(msg):
+    """Print error messages to stderr."""
+    sys.stderr.write(msg + "\n")
+    sys.stderr.flush()
+
+
+def print_progress(processed, total):
+    """Print progress indicator if enabled. Shows files examined (not just submitted)."""
+    if not show_progress:
+        return
+    if total > 0 and processed <= total:
+        pct = min(100, int(processed * 100 / total))
+        sys.stderr.write("\r[{}/{} examined] {}%".format(processed, total, pct))
+        sys.stderr.flush()
+    else:
+        # Total is zero or processed exceeded estimate; show count only
+        sys.stderr.write("\r[{} examined]".format(processed))
+        sys.stderr.flush()
+
+
+def is_under_excluded(path):
+    """Check if a normalized path is equal to or under any hard_skips entry."""
+    norm = os.path.normpath(path)
+    for excluded in hard_skips:
+        if norm == excluded or norm.startswith(excluded + os.sep):
+            return True
+    return False
+
+
+def should_prune_dir(dirpath, dirname):
+    """Determine if a subdirectory should be pruned from traversal."""
+    full = os.path.join(dirpath, dirname)
+    if os.path.islink(full):
+        return True
+    if is_under_excluded(full):
+        return True
+    if is_cloud_path(full):
+        return True
+    return False
+
+
+def count_files(dirs):
+    """Quick count of files for progress reporting."""
+    count = 0
+    for d in dirs:
+        for dirpath, dirnames, filenames in os.walk(d, followlinks=False):
+            dirnames[:] = [
+                dn for dn in dirnames
+                if not should_prune_dir(dirpath, dn)
+            ]
+            for name in filenames:
+                filepath = os.path.join(dirpath, name)
+                if os.path.islink(filepath):
+                    continue
+                count += 1
+    return count
 
 # Functions
+def send_interrupted_marker():
+    """Send an interrupted collection marker with current stats."""
+    global scan_id, num_processed, num_submitted, num_failed, current_date, upload_in_flight
+    try:
+        end_date = time.time()
+        elapsed = int(end_date - current_date)
+        stats = {
+            "scanned": num_processed,
+            "submitted": num_submitted,
+            "failed": num_failed,
+            "elapsed_seconds": elapsed,
+        }
+        if upload_in_flight is not None:
+            stats["in_flight"] = upload_in_flight
+        collection_marker(
+            args.server, args.port, args.tls, args.insecure,
+            args.source, "0.1",
+            "interrupted",
+            scan_id=scan_id,
+            ca_cert=getattr(args, 'ca_cert', None),
+            stats=stats,
+        )
+    except Exception:
+        pass
+
+
+def signal_handler(signum, frame):
+    """Handle SIGINT/SIGTERM: send interrupted marker and exit."""
+    print_error("\n[INFO] Signal received, sending interrupted marker...")
+    send_interrupted_marker()
+    sys.exit(1)
+
+
 def process_dir(workdir):
+
     for dirpath, dirnames, filenames in os.walk(workdir, followlinks=False):
         # Hard skip directories (modify in-place to prevent descent)
         dirnames[:] = [
             d for d in dirnames
-            if os.path.join(dirpath, d) not in hard_skips
-            and not os.path.islink(os.path.join(dirpath, d))
-            and not is_cloud_path(os.path.join(dirpath, d))
+            if not should_prune_dir(dirpath, d)
         ]
 
         for name in filenames:
@@ -114,70 +215,100 @@ def process_dir(workdir):
                 continue
 
             if args.debug:
-                print("[DEBUG] Checking {} ...".format(filepath))
+                print_error("[DEBUG] Checking {} ...".format(filepath))
 
             # Count
             global num_processed
             num_processed += 1
 
+            # Progress
+            print_progress(num_processed, total_files_estimate)
+
             # Skip files
-            if skip_file(filepath):
+            skip, file_stat = skip_file(filepath)
+            if skip:
                 continue
 
             # Submit
-            submit_sample(filepath)
+            submit_sample(filepath, file_stat)
 
 
 def skip_file(filepath):
+    """Check if a file should be skipped. Returns (True, None) to skip,
+    or (False, stat_result) to process."""
     # Regex skips
     for pattern in skip_elements:
         if re.search(pattern, filepath):
             if args.debug:
-                print(
+                print_error(
                     "[DEBUG] Skipping file due to configured skip_file exclusion {}".format(
                         filepath
                     )
                 )
-            return True
+            return True, None
 
-    # Size (max_size is in KB)
+    # Stat the file once to avoid TOCTOU races
     try:
-        file_size = os.path.getsize(filepath)
-        mtime = os.path.getmtime(filepath)
+        st = os.stat(filepath)
     except (OSError, IOError):
         if args.debug:
-            print("[DEBUG] Skipping unreadable file {}".format(filepath))
-        return True
+            print_error("[DEBUG] Skipping unreadable file {}".format(filepath))
+        return True, None
 
+    file_size = st.st_size
+    mtime = st.st_mtime
+
+    # Size (max_size is in KB)
     if file_size > max_size * 1024:
         if args.debug:
-            print("[DEBUG] Skipping file due to size {}".format(filepath))
-        return True
+            print_error("[DEBUG] Skipping file due to size {}".format(filepath))
+        return True, None
 
     # Age
     if mtime < current_date - (max_age * 86400):
         if args.debug:
-            print("[DEBUG] Skipping file due to age {}".format(filepath))
-        return True
+            print_error("[DEBUG] Skipping file due to age {}".format(filepath))
+        return True, None
 
-    return False
+    return False, st
 
 
-def submit_sample(filepath):
+def _make_connection(server, port, tls, insecure, ca_cert=None, timeout=30):
+    """Create an HTTP(S) connection with proper TLS settings."""
+    if tls:
+        if insecure:
+            context = ssl._create_unverified_context()
+        elif ca_cert:
+            context = ssl.create_default_context(cafile=ca_cert)
+        else:
+            context = ssl.create_default_context()
+        return http.client.HTTPSConnection(server, port, context=context, timeout=timeout)
+    else:
+        return http.client.HTTPConnection(server, port, timeout=timeout)
+
+
+def submit_sample(filepath, file_stat=None):
+    global num_submitted, num_failed, upload_in_flight
+
     if dry_run:
-        print("[DRY-RUN] Would submit {} ...".format(filepath))
-        global num_submitted
+        sys.stderr.write("[DRY-RUN] Would submit {} ...\n".format(filepath))
         num_submitted += 1
         return
 
-    print("[SUBMIT] Submitting {} ...".format(filepath))
+    sys.stderr.write("[SUBMIT] Submitting {} ...\n".format(filepath))
+    upload_in_flight = filepath
 
-    try:
-        with open(filepath, "rb") as f:
-            data = f.read()
-    except Exception as e:
-        print("[ERROR] Could not read '{}' - {}".format(filepath, e))
-        return
+    # Get file size for streaming upload (use cached stat if available)
+    if file_stat is not None:
+        file_size = file_stat.st_size
+    else:
+        try:
+            file_size = os.path.getsize(filepath)
+        except (OSError, IOError) as e:
+            print_error("[ERROR] Could not stat '{}' - {}".format(filepath, e))
+            num_failed += 1
+            upload_in_flight = None
+            return
 
     boundary = str(uuid.uuid4())
     headers = {
@@ -187,92 +318,211 @@ def submit_sample(filepath):
     # Sanitize filename for multipart header safety
     safe_filename = filepath.replace('"', '_').replace(';', '_').replace('\r', '_').replace('\n', '_')
 
-    # Create multipart/form-data payload
-    payload = (
+    hostname = socket.gethostname()
+    # Sanitize hostname to prevent CRLF injection in multipart body
+    safe_hostname = hostname.replace('\r', ' ').replace('\n', ' ')
+
+    # Sanitize source_path to prevent CRLF injection / boundary collision in multipart body
+    safe_source_path = filepath.replace('\r', ' ').replace('\n', ' ')
+
+    # Build multipart preamble (metadata fields + file header) and epilogue
+    preamble = b""
+
+    # hostname field
+    preamble += (
+        "--{boundary}\r\n"
+        "Content-Disposition: form-data; name=\"hostname\"\r\n\r\n"
+        "{hostname}\r\n"
+    ).format(boundary=boundary, hostname=safe_hostname).encode("utf-8")
+
+    # source_path field
+    preamble += (
+        "--{boundary}\r\n"
+        "Content-Disposition: form-data; name=\"source_path\"\r\n\r\n"
+        "{source_path}\r\n"
+    ).format(boundary=boundary, source_path=safe_source_path).encode("utf-8")
+
+    # file field header
+    preamble += (
         "--{boundary}\r\n"
         "Content-Disposition: form-data; name=\"file\"; filename=\"{filename}\"\r\n"
         "Content-Type: application/octet-stream\r\n\r\n"
     ).format(boundary=boundary, filename=safe_filename).encode("utf-8")
-    payload += data
-    payload += "\r\n--{}--\r\n".format(boundary).encode("utf-8")
+
+    epilogue = "\r\n--{}--\r\n".format(boundary).encode("utf-8")
+
+    content_length = len(preamble) + file_size + len(epilogue)
+    headers["Content-Length"] = str(content_length)
+
+    CHUNK_SIZE = 65536
 
     attempt = 0
     while attempt < retries:
+        resp_status = None
+        resp_reason = None
+        resp_retry_after = None
+        file_fully_sent = False
         try:
-            if args.tls:
-                if args.insecure:
-                    context = ssl._create_unverified_context()
-                else:
-                    context = ssl.create_default_context()
-                conn = http.client.HTTPSConnection(args.server, args.port, context=context)
-            else:
-                conn = http.client.HTTPConnection(args.server, args.port)
-            conn.request("POST", api_endpoint, body=payload, headers=headers)
-
+            conn = _make_connection(
+                args.server, args.port, args.tls, args.insecure,
+                ca_cert=getattr(args, 'ca_cert', None)
+            )
+            conn.putrequest("POST", api_endpoint)
+            for hdr_name, hdr_val in headers.items():
+                conn.putheader(hdr_name, hdr_val)
+            conn.endheaders()
+            # Send preamble (metadata fields + file header)
+            conn.send(preamble)
+            # Stream file content in chunks
+            with open(filepath, "rb") as f:
+                while True:
+                    chunk = f.read(CHUNK_SIZE)
+                    if not chunk:
+                        break
+                    conn.send(chunk)
+            # Send epilogue
+            conn.send(epilogue)
+            file_fully_sent = True
             resp = conn.getresponse()
-
+            # Read response body to allow connection reuse / proper close
+            resp.read()
+            # Store response info before closing connection
+            resp_status = resp.status
+            resp_reason = resp.reason
+            resp_retry_after = resp.getheader("Retry-After", "30")
         except Exception as e:
-            print("[ERROR] Could not submit '{}' - {}".format(filepath, e))
+            print_error("[ERROR] Could not submit '{}' - {}".format(filepath, e))
             attempt += 1
-            time.sleep(2 << attempt)
+            if attempt < retries:
+                backoff = min(2 ** (attempt - 1), 60)
+                time.sleep(backoff)
             continue
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
 
         # pylint: disable=no-else-continue
-        if resp.status == 503: # Service unavailable
+        if resp_status == 503:  # Service unavailable
             attempt += 1
             if attempt >= retries:
-                print("[ERROR] Server busy after {} retries, giving up on '{}'".format(retries, filepath))
-                break
-            retry_after = resp.headers.get("Retry-After", "30")
+                print_error("[ERROR] Server busy after {} retries, giving up on '{}'".format(retries, filepath))
+                num_failed += 1
+                upload_in_flight = None
+                return
             try:
-                retry_time = int(retry_after)
+                retry_time = min(int(resp_retry_after), 300)  # Cap at 5 minutes
             except (ValueError, TypeError):
+                retry_time = 30
+            if retry_time < 0:
                 retry_time = 30
             time.sleep(retry_time)
             continue
-        elif resp.status == 200:
-            num_submitted += 1
-            break
+        elif 200 <= resp_status < 300:
+            if file_fully_sent:
+                num_submitted += 1
+            else:
+                print_error("[ERROR] File '{}' was not fully sent but server returned {}".format(filepath, resp_status))
+                num_failed += 1
+            upload_in_flight = None
+            return
         else:
-            print(
+            print_error(
                 "[ERROR] HTTP return status: {}, reason: {}".format(
-                    resp.status, resp.reason
+                    resp_status, resp_reason
                 )
             )
             attempt += 1
-            time.sleep(2 << attempt)
+            if attempt < retries:
+                backoff = min(2 ** (attempt - 1), 60)
+                time.sleep(backoff)
             continue
 
+    # All retries exhausted
+    num_failed += 1
+    upload_in_flight = None
 
-def collection_marker(server, port, tls, insecure, source, collector_version, marker_type, scan_id=None, stats=None):
-    """POST a begin/end collection marker to /api/collection.
-    Returns the scan_id from the response, or None if unsupported/failed."""
+
+def collection_marker(server, port, tls, insecure, source, collector_version, marker_type, scan_id=None, stats=None, ca_cert=None, retry_on_fail=False):
+    """POST a begin/end/interrupted collection marker to /api/collection.
+    Returns the scan_id from the response, or None if unsupported/failed.
+    If retry_on_fail is True, retries once after 2s on failure (for begin marker)."""
     body = {
         "type": marker_type,
         "source": source,
+        "hostname": socket.gethostname(),
         "collector": "python3/{}".format(collector_version),
         "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
     }
+    # scan_id: None = failure, "" = success with no id, non-empty = valid id
     if scan_id:
         body["scan_id"] = scan_id
     if stats:
         body["stats"] = stats
 
-    try:
-        if tls:
-            ctx = ssl._create_unverified_context() if insecure else ssl.create_default_context()
-            conn = http.client.HTTPSConnection(server, port, context=ctx, timeout=10)
-        else:
-            conn = http.client.HTTPConnection(server, port, timeout=10)
-        payload = json.dumps(body).encode("utf-8")
-        conn.request("POST", "/api/collection", body=payload,
-                     headers={"Content-Type": "application/json"})
-        resp = conn.getresponse()
-        resp_body = resp.read().decode("utf-8", errors="replace")
-        data = json.loads(resp_body)
-        return data.get("scan_id")
-    except Exception:
-        return None
+    attempts = 2 if retry_on_fail else 1
+    for attempt in range(attempts):
+        try:
+            conn = _make_connection(server, port, tls, insecure, ca_cert=ca_cert, timeout=10)
+            payload = json.dumps(body).encode("utf-8")
+            conn.request("POST", "/api/collection", body=payload,
+                         headers={"Content-Type": "application/json"})
+            resp = conn.getresponse()
+            resp_body = resp.read().decode("utf-8", errors="replace")
+            conn.close()
+            if 200 <= resp.status < 300:
+                if resp_body.strip():
+                    try:
+                        data = json.loads(resp_body)
+                        return data.get("scan_id", "")
+                    except (ValueError, KeyError):
+                        # Non-JSON or missing scan_id; acceptable for end/interrupted markers
+                        return ""
+                else:
+                    return ""
+            elif resp.status == 503 and attempt < attempts - 1:
+                retry_after = None
+                # Try to get Retry-After header
+                if hasattr(resp, 'getheader'):
+                    retry_after = resp.getheader("Retry-After")
+                if retry_after:
+                    try:
+                        wait_time = min(int(retry_after), 300)
+                        if wait_time < 0:
+                            wait_time = 2
+                    except (ValueError, TypeError):
+                        wait_time = 2
+                else:
+                    wait_time = 2
+                print_error("[WARN] Collection marker '{}' got 503, retrying in {}s...".format(marker_type, wait_time))
+                time.sleep(wait_time)
+                continue
+            elif 400 <= resp.status < 500:
+                # 404 = endpoint not supported, continue without scan_id but success
+                if resp.status == 404:
+                    print_error("[WARN] Collection marker '{}' not supported (HTTP 404) — server does not implement /api/collection".format(marker_type))
+                    return ""
+                # Other client errors (4xx) indicate configuration problems — no retry
+                print_error("[ERROR] Collection marker '{}' returned HTTP {}".format(marker_type, resp.status))
+                return None
+            else:
+                # Server errors (5xx other than 503) — retry if retry_on_fail
+                if attempt < attempts - 1:
+                    print_error("[WARN] Collection marker '{}' returned HTTP {}, retrying in 2s...".format(marker_type, resp.status))
+                    time.sleep(2)
+                    continue
+                else:
+                    print_error("[ERROR] Collection marker '{}' returned HTTP {}".format(marker_type, resp.status))
+                    return None
+        except Exception as e:
+            if attempt < attempts - 1:
+                print_error("[WARN] Collection marker '{}' failed ({}), retrying in 2s...".format(marker_type, e))
+                time.sleep(2)
+            else:
+                print_error("[ERROR] Collection marker '{}' failed: {}".format(marker_type, e))
+                return None
+    return None
 
 
 # Main
@@ -284,7 +534,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "-d",
         "--dirs",
-        nargs="*",
+        nargs="+",
         default=["/"],
         help="Directories that should be scanned. (Default: /)",
     )
@@ -309,8 +559,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "-S",
         "--source",
-        default=socket.gethostname(),
-        help="Source identifier to be used in the Thunderstorm submission.",
+        default=None,
+        help="Source identifier to be used in the Thunderstorm submission. (Default: hostname)",
     )
     parser.add_argument(
         "--max-age", type=int, default=14,
@@ -332,9 +582,46 @@ if __name__ == "__main__":
         "--retries", type=int, default=3,
         help="Retry attempts per file (default: 3)"
     )
+    parser.add_argument(
+        "--ca-cert",
+        default=None,
+        help="Path to custom CA certificate bundle for TLS verification."
+    )
+    parser.add_argument(
+        "--progress",
+        action="store_true",
+        dest="progress",
+        help="Force enable progress reporting."
+    )
+    parser.add_argument(
+        "--no-progress",
+        action="store_false",
+        dest="progress",
+        help="Force disable progress reporting."
+    )
+    parser.set_defaults(progress=None)
     parser.add_argument("--debug", action="store_true", help="Enable debug logging.")
 
     args = parser.parse_args()
+
+    # Resolve source lazily (default to hostname)
+    if args.source is None:
+        args.source = socket.gethostname()
+
+    # Validate numeric arguments
+    if args.retries < 1:
+        print_error("[ERROR] --retries must be >= 1, got {}".format(args.retries))
+        sys.exit(2)
+    if args.max_age < 0:
+        print_error("[ERROR] --max-age must be >= 0, got {}".format(args.max_age))
+        sys.exit(2)
+    if args.max_size_kb < 0:
+        print_error("[ERROR] --max-size-kb must be >= 0, got {}".format(args.max_size_kb))
+        sys.exit(2)
+
+    # Install signal handlers
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
 
     # Apply parsed args to module-level config
     max_age = args.max_age
@@ -346,48 +633,100 @@ if __name__ == "__main__":
     if args.tls:
         schema = "https"
 
-    source = ""
-    if args.source:
-        source = "?source={}".format(quote(args.source))
+    # Determine progress mode
+    if args.progress is None:
+        show_progress = sys.stderr.isatty()
+    else:
+        show_progress = args.progress
+
+    source_query = "?source={}".format(quote(args.source))
 
     api_path = "/api/check" if sync_mode else "/api/checkAsync"
-    api_endpoint = "{}://{}:{}{}{}".format(schema, args.server, args.port, api_path, source)
+    # api_endpoint is the path+query for http.client (not full URL)
+    api_endpoint = "{}{}".format(api_path, source_query)
+    display_url = "{}://{}:{}{}".format(schema, args.server, args.port, api_endpoint)
 
-    print("=" * 80)
-    print("   Python Thunderstorm Collector")
-    print("   Florian Roth, Nextron Systems GmbH, 2024")
-    print()
-    print("=" * 80)
+    sys.stderr.write("=" * 80 + "\n")
+    sys.stderr.write("   Python Thunderstorm Collector\n")
+    sys.stderr.write("   Florian Roth, Nextron Systems GmbH, 2024\n")
+    sys.stderr.write("\n")
+    sys.stderr.write("=" * 80 + "\n")
+    # Normalize existing hard_skips
+    hard_skips[:] = [os.path.normpath(p) for p in hard_skips]
     # Extend hard_skips with mount points of network/special filesystems
     for mp in get_excluded_mounts():
-        if mp not in hard_skips:
-            hard_skips.append(mp)
+        norm_mp = os.path.normpath(mp)
+        if norm_mp not in hard_skips:
+            hard_skips.append(norm_mp)
 
-    print("Target Directory: {}".format(", ".join(args.dirs)))
-    print("Thunderstorm Server: {}".format(args.server))
-    print("Thunderstorm Port: {}".format(args.port))
-    print("Using API Endpoint: {}".format(api_endpoint))
-    print("Maximum Age of Files: {} days".format(max_age))
-    print("Maximum File Size: {} KB".format(max_size))
-    print("Excluded directories: {}".format(", ".join(hard_skips[:10]) + (" ..." if len(hard_skips) > 10 else "")))
-    print("Source Identifier: {}".format(args.source)) if args.source else None
-    print()
+    sys.stderr.write("Target Directory: {}\n".format(", ".join(args.dirs)))
+    sys.stderr.write("Thunderstorm Server: {}\n".format(args.server))
+    sys.stderr.write("Thunderstorm Port: {}\n".format(args.port))
+    sys.stderr.write("Using API Endpoint: {}\n".format(display_url))
+    sys.stderr.write("Maximum Age of Files: {} days\n".format(max_age))
+    sys.stderr.write("Maximum File Size: {} KB\n".format(max_size))
+    sys.stderr.write("Excluded directories: {}\n".format(", ".join(hard_skips[:10]) + (" ..." if len(hard_skips) > 10 else "")))
+    if args.source:
+        sys.stderr.write("Source Identifier: {}\n".format(args.source))
+    sys.stderr.write("\n")
 
-    print("Starting the walk at: {} ...".format(", ".join(args.dirs)))
+    # Validate --ca-cert if provided
+    if args.ca_cert and not os.path.isfile(args.ca_cert):
+        print_error("[ERROR] CA certificate file not found: {}".format(args.ca_cert))
+        sys.exit(2)
 
-    # Send collection begin marker
+    # Validate that all requested directories exist
+    valid_dirs = []
+    for d in args.dirs:
+        if not os.path.exists(d):
+            print_error("[ERROR] Directory does not exist: {}".format(d))
+        elif not os.path.isdir(d):
+            print_error("[ERROR] Path is not a directory: {}".format(d))
+        else:
+            valid_dirs.append(d)
+    if not valid_dirs:
+        print_error("[ERROR] No valid directories to scan.")
+        sys.exit(2)
+    if len(valid_dirs) < len(args.dirs):
+        print_error("[WARN] Some directories were invalid and will be skipped.")
+    args.dirs = valid_dirs
+
+    sys.stderr.write("Starting the walk at: {} ...\n".format(", ".join(args.dirs)))
+
+    # Count files for progress reporting
+    if show_progress:
+        sys.stderr.write("Counting files for progress reporting...\n")
+        total_files_estimate = count_files(args.dirs)
+        sys.stderr.write("Estimated files to check: {}\n".format(total_files_estimate))
+
+    # Send collection begin marker (with single retry on failure)
     scan_id = collection_marker(
         args.server, args.port, args.tls, args.insecure,
-        args.source or socket.gethostname(), "0.1",
-        "begin"
+        args.source, "0.1",
+        "begin",
+        ca_cert=args.ca_cert,
+        retry_on_fail=True
     )
+    # scan_id: None = failure (fatal), "" = success but no id returned, non-empty = valid id
+    if scan_id is None:
+        print_error("[ERROR] Failed to send begin collection marker. Cannot reach Thunderstorm server.")
+        sys.exit(2)
     if scan_id:
-        print("[INFO] Collection scan_id: {}".format(scan_id))
-        api_endpoint = "{}&scan_id={}".format(api_endpoint, quote(scan_id))
+        sys.stderr.write("[INFO] Collection scan_id: {}\n".format(scan_id))
+        # Append scan_id to api_endpoint
+        if "?" in api_endpoint:
+            api_endpoint = "{}&scan_id={}".format(api_endpoint, quote(scan_id))
+        else:
+            api_endpoint = "{}?scan_id={}".format(api_endpoint, quote(scan_id))
 
     # Walk directory
     for walkdir in args.dirs:
         process_dir(walkdir)
+
+    # Clear progress line if needed
+    if show_progress and total_files_estimate > 0:
+        sys.stderr.write("\r" + " " * 40 + "\r")
+        sys.stderr.flush()
 
     # Send collection end marker with stats
     end_date = time.time()
@@ -395,18 +734,25 @@ if __name__ == "__main__":
     minutes = elapsed // 60
     collection_marker(
         args.server, args.port, args.tls, args.insecure,
-        args.source or socket.gethostname(), "0.1",
+        args.source, "0.1",
         "end",
         scan_id=scan_id,
+        ca_cert=args.ca_cert,
         stats={
             "scanned": num_processed,
             "submitted": num_submitted,
+            "failed": num_failed,
             "elapsed_seconds": elapsed,
         }
     )
 
-    print(
-        "Thunderstorm Collector Run finished (Checked: {} Submitted: {} Minutes: {})".format(
-            num_processed, num_submitted, minutes
+    sys.stderr.write(
+        "Thunderstorm Collector Run finished (Checked: {} Submitted: {} Failed: {} Minutes: {})\n".format(
+            num_processed, num_submitted, num_failed, minutes
         )
     )
+
+    # Exit codes: 0 = success, 1 = partial failure (some uploads failed), 2 = fatal
+    if num_failed > 0:
+        sys.exit(1)
+    sys.exit(0)

--- a/scripts/thunderstorm-collector.sh
+++ b/scripts/thunderstorm-collector.sh
@@ -33,6 +33,8 @@ RETRIES=3
 
 UPLOAD_TOOL=""
 declare -a TMP_FILES_ARR=()
+declare -a CURL_EXTRA_OPTS=()
+declare -a WGET_EXTRA_OPTS=()
 
 # Keep defaults simple and stable for Bash 3+.
 SCAN_FOLDERS=('/root' '/tmp' '/home' '/var' '/usr')
@@ -42,6 +44,7 @@ FILES_SUBMITTED=0
 FILES_SKIPPED=0
 FILES_FAILED=0
 TOTAL_FILES=0
+SCAN_ID=""
 
 PROGRESS_MODE=""  # auto (empty), "on", or "off"
 SHOW_PROGRESS=0
@@ -135,6 +138,8 @@ send_interrupted_marker() {
 }
 
 on_signal() {
+    # Prevent recursive signal handling
+    trap '' INT TERM
     INTERRUPTED=1
     log_msg warn "Received signal, sending interrupted marker and exiting..."
     send_interrupted_marker
@@ -144,7 +149,7 @@ on_signal() {
 }
 
 on_exit() {
-    cleanup_tmp_files
+    [ "$INTERRUPTED" -eq 0 ] && cleanup_tmp_files
 }
 
 trap on_exit EXIT
@@ -183,6 +188,10 @@ log_msg() {
     fi
 
     if [ "$LOG_TO_CMDLINE" -eq 1 ]; then
+        # Clear progress line before printing log messages to avoid interleaving
+        if [ "$SHOW_PROGRESS" -eq 1 ]; then
+            printf '\r\033[K' >&2
+        fi
         case "$level" in
             error|warn)
                 printf "[%s] %s\n" "$level" "$clean" >&2
@@ -230,7 +239,7 @@ Options:
   --ca-cert <path>           Path to custom CA certificate bundle for TLS
   --sync                     Use /api/check (default: /api/checkAsync)
   --retries <num>            Retry attempts per file (default: 3)
-  --dry-run                  Do not upload, only show what would be submitted
+            --dry-run                  Do not upload or contact the server; only show what would be submitted
   --progress                 Force progress reporting
   --no-progress              Disable progress reporting
   --debug                    Enable debug log messages
@@ -366,21 +375,32 @@ upload_with_curl() {
     safe_filename="$(sanitize_filename_for_multipart "$filename")"
 
     resp_file="$(mktemp_portable)" || return 91
+    TMP_FILES_ARR+=("$resp_file")
     header_file="$(mktemp_portable)" || return 91
-    TMP_FILES_ARR+=("$resp_file" "$header_file")
+    TMP_FILES_ARR+=("$header_file")
 
     # Build form argument safely — curl handles @path internally
     local form_arg="file=@${filepath};filename=${safe_filename}"
 
-    # shellcheck disable=SC2086
-    curl -sS --show-error -X POST $CURL_EXTRA_OPTS \
+    local err_file
+    err_file="$(mktemp_portable)" || return 91
+    TMP_FILES_ARR+=("$err_file")
+
+    curl -sS --show-error -X POST "${CURL_EXTRA_OPTS[@]}" \
+        --max-time 300 \
         -D "$header_file" \
         "$endpoint" \
         -F "$form_arg" \
         -F "hostname=${SOURCE_NAME}" \
         -F "source_path=${filepath}" \
-        > "$resp_file" 2>&1
+        > "$resp_file" 2>"$err_file"
     code=$?
+
+    if [ $code -ne 0 ]; then
+        local _curl_err
+        _curl_err="$(cat "$err_file" 2>/dev/null)"
+        [ -n "$_curl_err" ] && log_msg debug "curl error: $_curl_err"
+    fi
 
     # Extract HTTP status code from headers
     http_code="$(grep -oE 'HTTP/[0-9.]+ [0-9]+' "$header_file" 2>/dev/null | tail -1 | grep -oE '[0-9]+$')"
@@ -426,12 +446,32 @@ upload_with_wget() {
     local header_file
     local code
 
-    boundary="----ThunderstormBoundary${$}${RANDOM}${RANDOM}"
     safe_filename="$(sanitize_filename_for_multipart "$filename")"
+
+    # Generate a boundary that does not appear in the file content or metadata.
+    # Retry with different random seeds to avoid multipart corruption.
+    local _boundary_attempts=0
+    boundary="----ThunderstormBoundary${$}${RANDOM}${RANDOM}$(date +%s%N 2>/dev/null || echo 0)"
+    while [ "$_boundary_attempts" -lt 10 ]; do
+        if ! grep -qF "$boundary" "$filepath" 2>/dev/null; then
+            # Also check it doesn't appear in metadata fields
+            case "${SOURCE_NAME}${filepath}" in
+                *"$boundary"*) ;;
+                *) break ;;
+            esac
+        fi
+        _boundary_attempts=$((_boundary_attempts + 1))
+        boundary="----ThunderstormBoundary${$}${RANDOM}${RANDOM}${_boundary_attempts}$(date +%s%N 2>/dev/null || echo 0)"
+    done
+    if [ "$_boundary_attempts" -ge 10 ]; then
+        log_msg warn "Could not find safe multipart boundary for '$filepath', upload may be malformed"
+    fi
     body_file="$(mktemp_portable)" || return 93
+    TMP_FILES_ARR+=("$body_file")
     resp_file="$(mktemp_portable)" || return 94
+    TMP_FILES_ARR+=("$resp_file")
     header_file="$(mktemp_portable)" || return 94
-    TMP_FILES_ARR+=("$body_file" "$resp_file" "$header_file")
+    TMP_FILES_ARR+=("$header_file")
 
     {
         printf -- "--%s\r\n" "$boundary"
@@ -447,8 +487,8 @@ upload_with_wget() {
         printf '\r\n--%s--\r\n' "$boundary"
     } > "$body_file" 2>/dev/null || return 95
 
-    # shellcheck disable=SC2086
-    wget -S -O "$resp_file" $WGET_EXTRA_OPTS \
+    wget -S -O "$resp_file" "${WGET_EXTRA_OPTS[@]}" \
+        --timeout=300 \
         --header="Content-Type: multipart/form-data; boundary=${boundary}" \
         --post-file="$body_file" \
         "$endpoint" 2>"$header_file"
@@ -516,8 +556,9 @@ collection_marker() {
     local body scan_id_out resp_file header_file
 
     resp_file="$(mktemp_portable)" || return 1
+    TMP_FILES_ARR+=("$resp_file")
     header_file="$(mktemp_portable)" || return 1
-    TMP_FILES_ARR+=("$resp_file" "$header_file")
+    TMP_FILES_ARR+=("$header_file")
 
     # Build JSON body with proper escaping
     local safe_source safe_scan_id
@@ -538,6 +579,7 @@ collection_marker() {
     local _marker_attempts=1
     [ "$marker_type" = "begin" ] && _marker_attempts=2
 
+    local _http_code
     local _attempt=0
     while [ "$_attempt" -lt "$_marker_attempts" ]; do
         _attempt=$((_attempt + 1))
@@ -545,16 +587,14 @@ collection_marker() {
         : > "$header_file"
         # Attempt POST — capture HTTP status to detect server-side errors
         if command -v curl >/dev/null 2>&1; then
-            # shellcheck disable=SC2086
-            curl -sS -D "$header_file" -o "$resp_file" $CURL_EXTRA_OPTS \
+            curl -sS -D "$header_file" -o "$resp_file" "${CURL_EXTRA_OPTS[@]}" \
                 -H "Content-Type: application/json" \
                 -d "$body" \
                 --max-time 10 \
                 "$marker_url" 2>/dev/null
             _marker_rc=$?
         elif command -v wget >/dev/null 2>&1; then
-            # shellcheck disable=SC2086
-            wget -S -O "$resp_file" $WGET_EXTRA_OPTS \
+            wget -S -O "$resp_file" "${WGET_EXTRA_OPTS[@]}" \
                 --header "Content-Type: application/json" \
                 --post-data "$body" \
                 --timeout=10 \
@@ -563,7 +603,6 @@ collection_marker() {
         fi
         # If transport succeeded, validate HTTP status code
         if [ "$_marker_rc" -eq 0 ]; then
-            local _http_code
             _http_code="$(grep -oE 'HTTP/[0-9.]+[[:space:]]+[0-9]+' "$header_file" 2>/dev/null | tail -1 | grep -oE '[0-9]+$')"
             if [ -n "$_http_code" ] && [ "$_http_code" -ge 400 ] 2>/dev/null; then
                 log_msg warn "Collection marker '$marker_type' received HTTP $_http_code"
@@ -845,7 +884,9 @@ validate_config() {
     [ "$RETRIES" -ge 1 ] || die "retries must be >= 1"
 
     [ -n "$THUNDERSTORM_SERVER" ] || die "Server must not be empty"
-    [ "${#SCAN_FOLDERS[@]}" -gt 0 ] || die "At least one directory is required"
+    if [ "${#SCAN_FOLDERS[@]}" -eq 0 ]; then
+        die "At least one directory is required"
+    fi
     if [ -n "$CA_CERT" ] && [ ! -f "$CA_CERT" ]; then
         die "CA certificate file not found: '$CA_CERT'"
     fi
@@ -860,7 +901,6 @@ main() {
     local query_source=""
     local api_endpoint=""
     local base_url=""
-    SCAN_ID=""
     local scandir
     local file_path
     local size_kb
@@ -880,15 +920,15 @@ main() {
     if [ "$USE_SSL" -eq 1 ]; then
         scheme="https"
     fi
-    CURL_EXTRA_OPTS=""
-    WGET_EXTRA_OPTS=""
+    CURL_EXTRA_OPTS=()
+    WGET_EXTRA_OPTS=()
     if [ "$INSECURE" -eq 1 ]; then
-        CURL_EXTRA_OPTS="-k"
-        WGET_EXTRA_OPTS="--no-check-certificate"
+        CURL_EXTRA_OPTS+=("-k")
+        WGET_EXTRA_OPTS+=("--no-check-certificate")
     fi
     if [ -n "$CA_CERT" ]; then
-        CURL_EXTRA_OPTS="${CURL_EXTRA_OPTS} --cacert \"${CA_CERT}\""
-        WGET_EXTRA_OPTS="${WGET_EXTRA_OPTS} --ca-certificate=\"${CA_CERT}\""
+        CURL_EXTRA_OPTS+=("--cacert" "$CA_CERT")
+        WGET_EXTRA_OPTS+=("--ca-certificate=$CA_CERT")
     fi
     if [ "$ASYNC_MODE" -eq 1 ]; then
         endpoint_name="checkAsync"
@@ -900,17 +940,8 @@ main() {
     base_url="${base_url%/}"
     api_endpoint="${base_url}/api/${endpoint_name}${query_source}"
 
-    if [ "$DRY_RUN" -eq 0 ]; then
-        if ! detect_upload_tool; then
-            log_msg error "Neither 'curl' nor 'wget' is installed; unable to upload samples"
-            exit 2
-        fi
-    else
-        if detect_upload_tool; then
-            log_msg info "Dry-run mode active (upload tool detected: $UPLOAD_TOOL)"
-        else
-            log_msg info "Dry-run mode active (no upload tool required)"
-        fi
+    if [ "$DRY_RUN" -eq 1 ]; then
+        detect_upload_tool || true
     fi
 
     log_msg info "Started Thunderstorm Collector - Version $VERSION"
@@ -925,11 +956,16 @@ main() {
 
     # Send collection begin marker; capture scan_id if server returns one
     if [ "$DRY_RUN" -eq 0 ]; then
+        if ! detect_upload_tool; then
+            log_msg error "Neither 'curl' nor 'wget' is installed; unable to upload samples"
+            exit 2
+        fi
         local _begin_resp_file
         _begin_resp_file="$(mktemp_portable)" || { log_msg error "Cannot create temp file"; exit 2; }
         TMP_FILES_ARR+=("$_begin_resp_file")
         collection_marker "$base_url" "begin" "" "" > "$_begin_resp_file"
-        local _begin_rc=$?
+        local _begin_rc
+        _begin_rc=$?
         SCAN_ID="$(cat "$_begin_resp_file" 2>/dev/null)"
         # If the begin marker failed after retry, the server is unreachable — fatal error
         if [ "$_begin_rc" -ne 0 ]; then
@@ -943,6 +979,8 @@ main() {
                 *)    api_endpoint="${api_endpoint}?scan_id=$(urlencode "$SCAN_ID")" ;;
             esac
         fi
+    else
+        log_msg info "Dry-run mode: skipping server connection"
     fi
 
     # Determine progress display mode
@@ -962,15 +1000,21 @@ main() {
     for _ep in "${EXCLUDE_PATHS[@]}"; do
         [ -d "$_ep" ] && find_excludes+=(-path "$_ep" -prune -o)
     done
-    while IFS= read -r _ep; do
-        [ -n "$_ep" ] && [ -d "$_ep" ] && find_excludes+=(-path "$_ep" -prune -o)
-    done <<< "$(get_excluded_mounts)"
+    local _mount_list
+    _mount_list="$(get_excluded_mounts)"
+    if [ -n "$_mount_list" ]; then
+        while IFS= read -r _ep; do
+            [ -n "$_ep" ] && [ -d "$_ep" ] && find_excludes+=(-path "$_ep" -prune -o)
+        done <<< "$_mount_list"
+    fi
 
     # Prune known cloud storage directory names at the find level so they are
     # excluded from both the file count and processing (keeps progress accurate).
-    local _cloud_name _cloud_lower
+    # Note: CLOUD_DIR_NAMES is space-separated, so multi-word names like
+    # "Google Drive" are split into individual words. This is intentional —
+    # the is_cloud_path() fallback catches path-based patterns.
+    local _cloud_name
     for _cloud_name in $CLOUD_DIR_NAMES; do
-        _cloud_lower="$(printf '%s' "$_cloud_name" | tr '[:upper:]' '[:lower:]')"
         # -iname is supported by GNU find and most BSD finds
         find_excludes+=(\( -iname "$_cloud_name" -type d -prune \) -o)
     done
@@ -994,16 +1038,19 @@ main() {
         if [ "$MAX_AGE" -gt 0 ]; then
             find "$scandir" "${find_excludes[@]}" -type f -mtime "-${MAX_AGE}" -print0 > "$find_results_file" 2>/dev/null || true
         else
+            # MAX_AGE=0 means no age filter — collect all files regardless of modification time
             find "$scandir" "${find_excludes[@]}" -type f -print0 > "$find_results_file" 2>/dev/null || true
         fi
         all_find_files+=("$find_results_file")
 
-        # Count files in this result set
+        # Count files in this result set (each entry is null-terminated by -print0)
         local _count=0
         if [ -s "$find_results_file" ]; then
+            # Count null bytes = number of file entries from -print0
             _count="$(tr -cd '\0' < "$find_results_file" 2>/dev/null | wc -c)"
-            # shellcheck disable=SC2086
-            set -- $_count; _count="${1:-0}"
+            # Normalize whitespace from wc output
+            _count="${_count//[[:space:]]/}"
+            _count="${_count:-0}"
         fi
         TOTAL_FILES=$((TOTAL_FILES + _count))
     done

--- a/scripts/thunderstorm-collector.sh
+++ b/scripts/thunderstorm-collector.sh
@@ -8,7 +8,7 @@
 # - handle missing dependencies with fallbacks
 # - degrade gracefully on partial failures
 
-VERSION="0.4.0"
+VERSION="0.5.0"
 
 # Defaults --------------------------------------------------------------------
 
@@ -22,6 +22,7 @@ THUNDERSTORM_SERVER="ygdrasil.nextron"
 THUNDERSTORM_PORT=8080
 USE_SSL=0
 INSECURE=0
+CA_CERT=""
 ASYNC_MODE=1
 
 MAX_AGE=14
@@ -31,7 +32,7 @@ DRY_RUN=0
 RETRIES=3
 
 UPLOAD_TOOL=""
-TMP_FILES=""
+declare -a TMP_FILES_ARR=()
 
 # Keep defaults simple and stable for Bash 3+.
 SCAN_FOLDERS=('/root' '/tmp' '/home' '/var' '/usr')
@@ -40,6 +41,10 @@ FILES_SCANNED=0
 FILES_SUBMITTED=0
 FILES_SKIPPED=0
 FILES_FAILED=0
+TOTAL_FILES=0
+
+PROGRESS_MODE=""  # auto (empty), "on", or "off"
+SHOW_PROGRESS=0
 
 SCRIPT_NAME="${0##*/}"
 START_TS="$(date +%s 2>/dev/null || echo 0)"
@@ -104,16 +109,46 @@ timestamp() {
 
 cleanup_tmp_files() {
     local f
-    for f in $TMP_FILES; do
+    for f in "${TMP_FILES_ARR[@]}"; do
         [ -n "$f" ] && [ -f "$f" ] && rm -f "$f"
     done
+}
+
+INTERRUPTED=0
+
+send_interrupted_marker() {
+    if [ "$DRY_RUN" -eq 0 ] && [ -n "$THUNDERSTORM_SERVER" ]; then
+        local _elapsed=0
+        local _now
+        _now="$(date +%s 2>/dev/null || echo "$START_TS")"
+        if [ "$START_TS" -gt 0 ] 2>/dev/null; then
+            _elapsed=$(( _now - START_TS ))
+            [ "$_elapsed" -lt 0 ] && _elapsed=0
+        fi
+        local _stats="\"stats\":{\"scanned\":${FILES_SCANNED},\"submitted\":${FILES_SUBMITTED},\"skipped\":${FILES_SKIPPED},\"failed\":${FILES_FAILED},\"elapsed_seconds\":${_elapsed}}"
+        local _scheme="http"
+        [ "$USE_SSL" -eq 1 ] && _scheme="https"
+        local _base="${_scheme}://${THUNDERSTORM_SERVER}:${THUNDERSTORM_PORT}"
+        _base="${_base%/}"
+        collection_marker "$_base" "interrupted" "${SCAN_ID:-}" "$_stats" >/dev/null 2>&1
+    fi
+}
+
+on_signal() {
+    INTERRUPTED=1
+    log_msg warn "Received signal, sending interrupted marker and exiting..."
+    send_interrupted_marker
+    cleanup_tmp_files
+    # Exit 1 for partial failure (interrupted collection)
+    exit 1
 }
 
 on_exit() {
     cleanup_tmp_files
 }
 
-trap on_exit EXIT INT TERM
+trap on_exit EXIT
+trap on_signal INT TERM
 
 log_msg() {
     local level="$1"
@@ -148,13 +183,20 @@ log_msg() {
     fi
 
     if [ "$LOG_TO_CMDLINE" -eq 1 ]; then
-        printf "[%s] %s\n" "$level" "$clean" >&2
+        case "$level" in
+            error|warn)
+                printf "[%s] %s\n" "$level" "$clean" >&2
+                ;;
+            *)
+                printf "[%s] %s\n" "$level" "$clean"
+                ;;
+        esac
     fi
 }
 
 die() {
     log_msg error "$*"
-    exit 1
+    exit 2
 }
 
 print_banner() {
@@ -185,9 +227,12 @@ Options:
   --source <name>            Source identifier (default: hostname)
   --ssl                      Use HTTPS
   -k, --insecure             Skip TLS certificate verification
+  --ca-cert <path>           Path to custom CA certificate bundle for TLS
   --sync                     Use /api/check (default: /api/checkAsync)
   --retries <num>            Retry attempts per file (default: 3)
   --dry-run                  Do not upload, only show what would be submitted
+  --progress                 Force progress reporting
+  --no-progress              Disable progress reporting
   --debug                    Enable debug log messages
   --log-file <path>          Log file path (default: ./thunderstorm.log)
   --no-log-file              Disable file logging
@@ -206,6 +251,11 @@ is_integer() {
         ''|*[!0-9]*) return 1 ;;
         *) return 0 ;;
     esac
+}
+
+is_positive_integer() {
+    is_integer "$1" || return 1
+    [ "$1" -gt 0 ] 2>/dev/null || return 1
 }
 
 detect_source_name() {
@@ -230,7 +280,7 @@ build_query_source() {
 urlencode() {
     local input="$1"
     local out=""
-    local i ch hex
+    local i ch hex_bytes byte
 
     for ((i = 0; i < ${#input}; i++)); do
         ch="${input:i:1}"
@@ -238,12 +288,14 @@ urlencode() {
             [a-zA-Z0-9.~_-])
                 out="${out}${ch}"
                 ;;
-            ' ')
-                out="${out}%20"
-                ;;
             *)
-                hex="$(printf '%s' "$ch" | od -An -tx1 | tr -d ' \n' | tr '[:lower:]' '[:upper:]')"
-                out="${out}%${hex}"
+                # Get hex bytes (handles multi-byte UTF-8 characters)
+                hex_bytes="$(printf '%s' "$ch" | od -An -tx1 | tr -d ' \n')"
+                while [ -n "$hex_bytes" ]; do
+                    byte="${hex_bytes:0:2}"
+                    hex_bytes="${hex_bytes:2}"
+                    [ -n "$byte" ] && out="${out}%$(printf '%s' "$byte" | tr '[:lower:]' '[:upper:]')"
+                done
                 ;;
         esac
     done
@@ -279,12 +331,13 @@ file_size_kb() {
 mktemp_portable() {
     local t
     t="$(mktemp "${TMPDIR:-/tmp}/thunderstorm.XXXXXX" 2>/dev/null)"
-    if [ -n "$t" ]; then
+    if [ -n "$t" ] && [ -f "$t" ]; then
         echo "$t"
         return 0
     fi
-    t="${TMPDIR:-/tmp}/thunderstorm.$$.$RANDOM"
-    : > "$t" 2>/dev/null || return 1
+    # Fallback: RANDOM may be empty in non-bash shells
+    t="${TMPDIR:-/tmp}/thunderstorm.$$.${RANDOM:-0}.$(date +%N 2>/dev/null || echo 0)"
+    ( umask 077 && : > "$t" ) 2>/dev/null || return 1
     echo "$t"
 }
 
@@ -305,33 +358,59 @@ upload_with_curl() {
     local filepath="$2"
     local filename="$3"
     local safe_filename
-    local curl_filepath
     local resp_file
+    local header_file
     local code
+    local http_code
 
     safe_filename="$(sanitize_filename_for_multipart "$filename")"
-    curl_filepath="${filepath//\"/\\\"}"
 
     resp_file="$(mktemp_portable)" || return 91
-    TMP_FILES="${TMP_FILES} ${resp_file}"
+    header_file="$(mktemp_portable)" || return 91
+    TMP_FILES_ARR+=("$resp_file" "$header_file")
 
-    curl -sS --fail --show-error -X POST $curl_insecure \
+    # Build form argument safely — curl handles @path internally
+    local form_arg="file=@${filepath};filename=${safe_filename}"
+
+    # shellcheck disable=SC2086
+    curl -sS --show-error -X POST $CURL_EXTRA_OPTS \
+        -D "$header_file" \
         "$endpoint" \
-        --form "file=@\"${curl_filepath}\";filename=\"${safe_filename}\"" \
+        -F "$form_arg" \
+        -F "hostname=${SOURCE_NAME}" \
+        -F "source_path=${filepath}" \
         > "$resp_file" 2>&1
     code=$?
+
+    # Extract HTTP status code from headers
+    http_code="$(grep -oE 'HTTP/[0-9.]+ [0-9]+' "$header_file" 2>/dev/null | tail -1 | grep -oE '[0-9]+$')"
+
+    # Handle 503 back-pressure
+    if [ "$http_code" = "503" ]; then
+        local retry_after
+        retry_after="$(grep -i '^Retry-After:' "$header_file" 2>/dev/null | head -1 | sed 's/[^0-9]//g')"
+        if [ -n "$retry_after" ] && [ "$retry_after" -gt 0 ] 2>/dev/null; then
+            [ "$retry_after" -gt 120 ] && retry_after=120
+            log_msg warn "Server returned 503, waiting ${retry_after}s (Retry-After)"
+            sleep "$retry_after"
+        fi
+        return 93
+    fi
+
     if [ $code -ne 0 ]; then
         return $code
     fi
 
-    if grep -qi "reason" "$resp_file" 2>/dev/null; then
+    # Check for non-2xx HTTP status
+    if [ -n "$http_code" ] && [ "$http_code" -ge 400 ] 2>/dev/null; then
         local body
         body="$(cat "$resp_file" 2>/dev/null)"
         body="${body//$'\r'/ }"
         body="${body//$'\n'/ }"
-        log_msg error "Server reported rejection for '$filepath': $body"
+        log_msg error "Server returned HTTP $http_code for '$filepath': $body"
         return 92
     fi
+
     return 0
 }
 
@@ -344,85 +423,247 @@ upload_with_wget() {
     local boundary
     local body_file
     local resp_file
+    local header_file
     local code
 
-    boundary="----ThunderstormBoundary$$$RANDOM"
+    boundary="----ThunderstormBoundary${$}${RANDOM}${RANDOM}"
     safe_filename="$(sanitize_filename_for_multipart "$filename")"
     body_file="$(mktemp_portable)" || return 93
     resp_file="$(mktemp_portable)" || return 94
-    TMP_FILES="${TMP_FILES} ${body_file} ${resp_file}"
+    header_file="$(mktemp_portable)" || return 94
+    TMP_FILES_ARR+=("$body_file" "$resp_file" "$header_file")
 
     {
         printf -- "--%s\r\n" "$boundary"
         printf 'Content-Disposition: form-data; name="file"; filename="%s"\r\n' "$safe_filename"
         printf 'Content-Type: application/octet-stream\r\n\r\n'
         cat "$filepath"
+        printf '\r\n--%s\r\n' "$boundary"
+        printf 'Content-Disposition: form-data; name="hostname"\r\n\r\n'
+        printf '%s' "$SOURCE_NAME"
+        printf '\r\n--%s\r\n' "$boundary"
+        printf 'Content-Disposition: form-data; name="source_path"\r\n\r\n'
+        printf '%s' "$filepath"
         printf '\r\n--%s--\r\n' "$boundary"
     } > "$body_file" 2>/dev/null || return 95
 
-    wget -q -O "$resp_file" \
+    # shellcheck disable=SC2086
+    wget -S -O "$resp_file" $WGET_EXTRA_OPTS \
         --header="Content-Type: multipart/form-data; boundary=${boundary}" \
         --post-file="$body_file" \
-        "$endpoint"
+        "$endpoint" 2>"$header_file"
     code=$?
+
+    # Extract HTTP status code from headers (wget -S writes headers to stderr with leading spaces)
+    local http_code
+    http_code="$(grep -oE 'HTTP/[0-9.]+[[:space:]]+[0-9]+' "$header_file" 2>/dev/null | tail -1 | grep -oE '[0-9]+$')"
+
+    # Handle 503 back-pressure
+    if [ "$http_code" = "503" ]; then
+        local retry_after
+        retry_after="$(grep -i 'Retry-After' "$header_file" 2>/dev/null | head -1 | sed 's/[^0-9]//g')"
+        if [ -n "$retry_after" ] && [ "$retry_after" -gt 0 ] 2>/dev/null; then
+            [ "$retry_after" -gt 120 ] && retry_after=120
+            log_msg warn "Server returned 503, waiting ${retry_after}s (Retry-After)"
+            sleep "$retry_after"
+        fi
+        return 93
+    fi
+
     if [ $code -ne 0 ]; then
         return $code
     fi
 
-    if grep -qi "reason" "$resp_file" 2>/dev/null; then
+    # Check for non-2xx HTTP status
+    if [ -n "$http_code" ] && [ "$http_code" -ge 400 ] 2>/dev/null; then
         local body
-        body="$(cat "$resp_file" 2>/dev/null)"
-        body="${body//$'\r'/ }"
-        body="${body//$'\n'/ }"
-        log_msg error "Server reported rejection for '$filepath': $body"
+        body="$(tr '\r\n' '  ' < "$resp_file" 2>/dev/null)"
+        log_msg error "Server returned HTTP $http_code for '$filepath': $body"
         return 96
     fi
+
     return 0
 }
 
 # collection_marker -- POST a begin/end marker to /api/collection
 # Args: $1=base_url  $2=type(begin|end)  $3=scan_id(optional)  $4=stats_json(optional)
 # Returns: scan_id extracted from response (empty if unsupported or failed)
+json_escape() {
+    local s="$1"
+    # Order matters: escape backslashes first, then other special chars
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\n'/\\n}"
+    s="${s//$'\r'/\\r}"
+    s="${s//$'\t'/\\t}"
+    s="${s//$'\010'/\\b}"   # backspace
+    s="${s//$'\014'/\\f}"   # form feed
+    # Remove remaining control characters (0x00-0x1f) that could break JSON
+    s="$(printf '%s' "$s" | tr -d '\000-\007\013\016-\037')"
+    printf '%s' "$s"
+}
+
+# collection_marker -- POST a begin/end marker to /api/collection
+# Args: $1=base_url  $2=type(begin|end)  $3=scan_id(optional)  $4=stats_json(optional)
+# Outputs: scan_id extracted from response on stdout (empty if unsupported or failed)
+# Returns: 0 on success, non-zero on failure
 collection_marker() {
     local base_url="$1"
     local marker_type="$2"
     local scan_id="${3:-}"
     local stats_json="${4:-}"
-    local marker_url="${base_url%/api/*}/api/collection"
-    local body scan_id_out resp_file
+    local marker_url="${base_url}/api/collection"
+    local body scan_id_out resp_file header_file
 
     resp_file="$(mktemp_portable)" || return 1
+    header_file="$(mktemp_portable)" || return 1
+    TMP_FILES_ARR+=("$resp_file" "$header_file")
 
-    # Build JSON body
-    body="{\"type\":\"${marker_type}\""
-    body="${body},\"source\":\"${SOURCE_NAME}\""
+    # Build JSON body with proper escaping
+    local safe_source safe_scan_id
+    safe_source="$(json_escape "$SOURCE_NAME")"
+    safe_scan_id="$(json_escape "$scan_id")"
+
+    local safe_marker_type
+    safe_marker_type="$(json_escape "$marker_type")"
+    body="{\"type\":\"${safe_marker_type}\""
+    body="${body},\"source\":\"${safe_source}\""
     body="${body},\"collector\":\"bash/${VERSION}\""
     body="${body},\"timestamp\":\"$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u)\""
-    [ -n "$scan_id"    ] && body="${body},\"scan_id\":\"${scan_id}\""
+    [ -n "$scan_id"    ] && body="${body},\"scan_id\":\"${safe_scan_id}\""
     [ -n "$stats_json" ] && body="${body},${stats_json}"
     body="${body}}"
 
-    # Attempt POST — silent failure is intentional (server may not support this yet)
-    if command -v curl >/dev/null 2>&1; then
-        curl -s -o "$resp_file" $curl_insecure \
-            -H "Content-Type: application/json" \
-            -d "$body" \
-            --max-time 10 \
-            "$marker_url" 2>/dev/null || true
-    elif command -v wget >/dev/null 2>&1; then
-        wget -q -O "$resp_file" \
-            --header "Content-Type: application/json" \
-            --post-data "$body" \
-            --timeout=10 \
-            "$marker_url" 2>/dev/null || true
+    local _marker_rc=1
+    local _marker_attempts=1
+    [ "$marker_type" = "begin" ] && _marker_attempts=2
+
+    local _attempt=0
+    while [ "$_attempt" -lt "$_marker_attempts" ]; do
+        _attempt=$((_attempt + 1))
+        _marker_rc=1
+        : > "$header_file"
+        # Attempt POST — capture HTTP status to detect server-side errors
+        if command -v curl >/dev/null 2>&1; then
+            # shellcheck disable=SC2086
+            curl -sS -D "$header_file" -o "$resp_file" $CURL_EXTRA_OPTS \
+                -H "Content-Type: application/json" \
+                -d "$body" \
+                --max-time 10 \
+                "$marker_url" 2>/dev/null
+            _marker_rc=$?
+        elif command -v wget >/dev/null 2>&1; then
+            # shellcheck disable=SC2086
+            wget -S -O "$resp_file" $WGET_EXTRA_OPTS \
+                --header "Content-Type: application/json" \
+                --post-data "$body" \
+                --timeout=10 \
+                "$marker_url" 2>"$header_file"
+            _marker_rc=$?
+        fi
+        # If transport succeeded, validate HTTP status code
+        if [ "$_marker_rc" -eq 0 ]; then
+            local _http_code
+            _http_code="$(grep -oE 'HTTP/[0-9.]+[[:space:]]+[0-9]+' "$header_file" 2>/dev/null | tail -1 | grep -oE '[0-9]+$')"
+            if [ -n "$_http_code" ] && [ "$_http_code" -ge 400 ] 2>/dev/null; then
+                log_msg warn "Collection marker '$marker_type' received HTTP $_http_code"
+                _marker_rc=1
+            fi
+        fi
+        if [ "$_marker_rc" -eq 0 ]; then
+            break
+        fi
+        if [ "$_attempt" -lt "$_marker_attempts" ]; then
+            log_msg warn "Begin marker failed (attempt $_attempt/$_marker_attempts), retrying in 2s..."
+            sleep 2
+        fi
+    done
+
+    # Extract scan_id from response, handling JSON escapes (e.g. \" and \\ inside the value).
+    # Uses awk to find the "scan_id" key and parse the JSON string value properly.
+    scan_id_out="$(awk '
+    BEGIN { found = 0 }
+    {
+        s = s $0
+    }
+    END {
+        # Find "scan_id" key
+        idx = index(s, "\"scan_id\"")
+        if (idx == 0) exit
+        rest = substr(s, idx + length("\"scan_id\""))
+        # Skip whitespace and colon
+        gsub(/^[[:space:]]*:[[:space:]]*/, "", rest)
+        # Must start with quote
+        if (substr(rest, 1, 1) != "\"") exit
+        rest = substr(rest, 2)
+        val = ""
+        while (length(rest) > 0) {
+            c = substr(rest, 1, 1)
+            if (c == "\\") {
+                # Escaped character
+                nc = substr(rest, 2, 1)
+                if (nc == "\"") { val = val "\""; rest = substr(rest, 3) }
+                else if (nc == "\\") { val = val "\\"; rest = substr(rest, 3) }
+                else if (nc == "n") { val = val "\n"; rest = substr(rest, 3) }
+                else if (nc == "r") { val = val "\r"; rest = substr(rest, 3) }
+                else if (nc == "t") { val = val "\t"; rest = substr(rest, 3) }
+                else if (nc == "/") { val = val "/"; rest = substr(rest, 3) }
+                else if (nc == "b") { val = val "\b"; rest = substr(rest, 3) }
+                else if (nc == "f") { val = val "\f"; rest = substr(rest, 3) }
+                else if (nc == "u") {
+                    # \uXXXX unicode escape
+                    hex = substr(rest, 3, 4)
+                    rest = substr(rest, 7)
+                    if (length(hex) == 4) {
+                        # Convert hex to decimal
+                        cp = 0
+                        for (hi = 1; hi <= 4; hi++) {
+                            hc = substr(hex, hi, 1)
+                            if (hc >= "0" && hc <= "9") cp = cp * 16 + (hc + 0)
+                            else if (hc == "a" || hc == "A") cp = cp * 16 + 10
+                            else if (hc == "b" || hc == "B") cp = cp * 16 + 11
+                            else if (hc == "c" || hc == "C") cp = cp * 16 + 12
+                            else if (hc == "d" || hc == "D") cp = cp * 16 + 13
+                            else if (hc == "e" || hc == "E") cp = cp * 16 + 14
+                            else if (hc == "f" || hc == "F") cp = cp * 16 + 15
+                            else { cp = -1; break }
+                        }
+                        if (cp >= 32 && cp <= 126) {
+                            val = val sprintf("%c", cp)
+                        } else if (cp >= 0) {
+                            # Non-ASCII or control char: replace with underscore
+                            val = val "_"
+                        }
+                        # cp == -1: invalid hex, skip silently
+                    }
+                }
+                else { val = val nc; rest = substr(rest, 3) }
+            } else if (c == "\"") {
+                break
+            } else {
+                val = val c
+                rest = substr(rest, 2)
+            }
+        }
+        printf "%s", val
+    }' "$resp_file" 2>/dev/null)"
+
+    # Validate scan_id: reject empty values, control characters, and unreasonably long values.
+    # The value is JSON-escaped for markers and URL-encoded for query parameters, so we only
+    # need to guard against control characters and excessive length.
+    if [ ${#scan_id_out} -gt 256 ]; then
+        scan_id_out=""
+    else
+        # Remove any control characters (0x00-0x1f, 0x7f) — if the result differs, reject it
+        local _sanitized
+        _sanitized="$(printf '%s' "$scan_id_out" | tr -d '\000-\037\177')"
+        if [ "$_sanitized" != "$scan_id_out" ]; then
+            scan_id_out=""
+        fi
     fi
 
-    # Extract scan_id from response: {"scan_id":"<value>"} or {"scan_id": "<value>"}
-    scan_id_out="$(grep -oE '"scan_id"\s*:\s*"[^"]*"' "$resp_file" 2>/dev/null \
-        | head -1 | sed 's/"scan_id"[[:space:]]*:[[:space:]]*"//;s/"//')"
-
-    rm -f "$resp_file"
     printf '%s' "$scan_id_out"
+    return "$_marker_rc"
 }
 
 submit_file() {
@@ -432,16 +673,18 @@ submit_file() {
     local try=1
     local rc=1
     local wait=2
+    local max_503_retries=5
+    local _503_count=0
 
     # Preserve client-side path in multipart filename for server-side audit logs.
     filename="$filepath"
 
-    while [ "$try" -le "$RETRIES" ]; do
-        if [ "$DRY_RUN" -eq 1 ]; then
-            log_msg info "DRY-RUN: would submit '$filepath'"
-            return 0
-        fi
+    if [ "$DRY_RUN" -eq 1 ]; then
+        log_msg info "DRY-RUN: would submit '$filepath'"
+        return 0
+    fi
 
+    while [ "$try" -le "$RETRIES" ]; do
         if [ "$UPLOAD_TOOL" = "curl" ]; then
             upload_with_curl "$endpoint" "$filepath" "$filename"
             rc=$?
@@ -454,10 +697,24 @@ submit_file() {
             return 0
         fi
 
+        # 503 back-pressure: sleep already happened in upload function,
+        # retry without counting against the normal retry budget (up to a cap)
+        if [ "$rc" -eq 93 ]; then
+            _503_count=$((_503_count + 1))
+            if [ "$_503_count" -lt "$max_503_retries" ]; then
+                log_msg warn "Retrying '$filepath' after 503 back-pressure ($_503_count/$max_503_retries)"
+                continue
+            fi
+            log_msg warn "Too many 503 responses for '$filepath', giving up"
+            return "$rc"
+        fi
+
         log_msg warn "Upload failed for '$filepath' (attempt ${try}/${RETRIES}, code ${rc})"
         if [ "$try" -lt "$RETRIES" ]; then
             sleep "$wait"
             wait=$((wait * 2))
+            # Cap backoff at 60 seconds
+            [ "$wait" -gt 60 ] && wait=60
         fi
         try=$((try + 1))
     done
@@ -477,17 +734,17 @@ parse_args() {
                 exit 0
                 ;;
             -s|--server)
-                [ -n "$2" ] || die "Missing value for $arg"
+                [ -n "${2:-}" ] || die "Missing value for $arg"
                 THUNDERSTORM_SERVER="$2"
                 shift
                 ;;
             -p|--port)
-                [ -n "$2" ] || die "Missing value for $arg"
+                [ -n "${2:-}" ] || die "Missing value for $arg"
                 THUNDERSTORM_PORT="$2"
                 shift
                 ;;
             -d|--dir)
-                [ -n "$2" ] || die "Missing value for $arg"
+                [ -n "${2:-}" ] || die "Missing value for $arg"
                 if [ "$add_dir_mode" -eq 0 ]; then
                     SCAN_FOLDERS=()
                     add_dir_mode=1
@@ -496,17 +753,17 @@ parse_args() {
                 shift
                 ;;
             --max-age)
-                [ -n "$2" ] || die "Missing value for $arg"
+                [ -n "${2:-}" ] || die "Missing value for $arg"
                 MAX_AGE="$2"
                 shift
                 ;;
             --max-size-kb)
-                [ -n "$2" ] || die "Missing value for $arg"
+                [ -n "${2:-}" ] || die "Missing value for $arg"
                 MAX_FILE_SIZE_KB="$2"
                 shift
                 ;;
             --source)
-                [ -n "$2" ] || die "Missing value for $arg"
+                [ -n "${2:-}" ] || die "Missing value for $arg"
                 SOURCE_NAME="$2"
                 shift
                 ;;
@@ -516,11 +773,17 @@ parse_args() {
             -k|--insecure)
                 INSECURE=1
                 ;;
+            --ca-cert)
+                [ -n "${2:-}" ] || die "Missing value for $arg"
+                CA_CERT="$2"
+                USE_SSL=1
+                shift
+                ;;
             --sync)
                 ASYNC_MODE=0
                 ;;
             --retries)
-                [ -n "$2" ] || die "Missing value for $arg"
+                [ -n "${2:-}" ] || die "Missing value for $arg"
                 RETRIES="$2"
                 shift
                 ;;
@@ -531,7 +794,7 @@ parse_args() {
                 DEBUG=1
                 ;;
             --log-file)
-                [ -n "$2" ] || die "Missing value for $arg"
+                [ -n "${2:-}" ] || die "Missing value for $arg"
                 LOGFILE="$2"
                 shift
                 ;;
@@ -543,6 +806,12 @@ parse_args() {
                 ;;
             --quiet)
                 LOG_TO_CMDLINE=0
+                ;;
+            --progress)
+                PROGRESS_MODE="on"
+                ;;
+            --no-progress)
+                PROGRESS_MODE="off"
                 ;;
             --)
                 shift
@@ -573,10 +842,16 @@ validate_config() {
     [ "$THUNDERSTORM_PORT" -gt 0 ] || die "Port must be greater than 0"
     [ "$MAX_AGE" -ge 0 ] || die "max-age must be >= 0"
     [ "$MAX_FILE_SIZE_KB" -gt 0 ] || die "max-size-kb must be > 0"
-    [ "$RETRIES" -gt 0 ] || die "retries must be > 0"
+    [ "$RETRIES" -ge 1 ] || die "retries must be >= 1"
 
     [ -n "$THUNDERSTORM_SERVER" ] || die "Server must not be empty"
     [ "${#SCAN_FOLDERS[@]}" -gt 0 ] || die "At least one directory is required"
+    if [ -n "$CA_CERT" ] && [ ! -f "$CA_CERT" ]; then
+        die "CA certificate file not found: '$CA_CERT'"
+    fi
+    if [ -n "$CA_CERT" ] && [ "$INSECURE" -eq 1 ]; then
+        log_msg warn "--ca-cert and --insecure are both set; --insecure takes precedence"
+    fi
 }
 
 main() {
@@ -585,7 +860,7 @@ main() {
     local query_source=""
     local api_endpoint=""
     local base_url=""
-    local SCAN_ID=""
+    SCAN_ID=""
     local scandir
     local file_path
     local size_kb
@@ -594,7 +869,6 @@ main() {
     local find_results_file
 
     parse_args "$@"
-    find_mtime="-${MAX_AGE}"
     detect_source_name
     validate_config
     print_banner
@@ -606,9 +880,15 @@ main() {
     if [ "$USE_SSL" -eq 1 ]; then
         scheme="https"
     fi
-    local curl_insecure=""
+    CURL_EXTRA_OPTS=""
+    WGET_EXTRA_OPTS=""
     if [ "$INSECURE" -eq 1 ]; then
-        curl_insecure="-k"
+        CURL_EXTRA_OPTS="-k"
+        WGET_EXTRA_OPTS="--no-check-certificate"
+    fi
+    if [ -n "$CA_CERT" ]; then
+        CURL_EXTRA_OPTS="${CURL_EXTRA_OPTS} --cacert \"${CA_CERT}\""
+        WGET_EXTRA_OPTS="${WGET_EXTRA_OPTS} --ca-certificate=\"${CA_CERT}\""
     fi
     if [ "$ASYNC_MODE" -eq 1 ]; then
         endpoint_name="checkAsync"
@@ -616,11 +896,14 @@ main() {
 
     query_source="$(build_query_source "$SOURCE_NAME")"
     base_url="${scheme}://${THUNDERSTORM_SERVER}:${THUNDERSTORM_PORT}"
+    # Strip any trailing slash from base_url
+    base_url="${base_url%/}"
     api_endpoint="${base_url}/api/${endpoint_name}${query_source}"
 
     if [ "$DRY_RUN" -eq 0 ]; then
         if ! detect_upload_tool; then
-            die "Neither 'curl' nor 'wget' is installed; unable to upload samples"
+            log_msg error "Neither 'curl' nor 'wget' is installed; unable to upload samples"
+            exit 2
         fi
     else
         if detect_upload_tool; then
@@ -642,13 +925,60 @@ main() {
 
     # Send collection begin marker; capture scan_id if server returns one
     if [ "$DRY_RUN" -eq 0 ]; then
-        SCAN_ID="$(collection_marker "$base_url" "begin" "" "")"
+        local _begin_resp_file
+        _begin_resp_file="$(mktemp_portable)" || { log_msg error "Cannot create temp file"; exit 2; }
+        TMP_FILES_ARR+=("$_begin_resp_file")
+        collection_marker "$base_url" "begin" "" "" > "$_begin_resp_file"
+        local _begin_rc=$?
+        SCAN_ID="$(cat "$_begin_resp_file" 2>/dev/null)"
+        # If the begin marker failed after retry, the server is unreachable — fatal error
+        if [ "$_begin_rc" -ne 0 ]; then
+            log_msg error "Cannot connect to Thunderstorm server at ${base_url} (begin marker failed after retry)"
+            exit 2
+        fi
         if [ -n "$SCAN_ID" ]; then
             log_msg info "Collection scan_id: $SCAN_ID"
-            api_endpoint="${api_endpoint}&scan_id=$(urlencode "$SCAN_ID")"
+            case "$api_endpoint" in
+                *\?*) api_endpoint="${api_endpoint}&scan_id=$(urlencode "$SCAN_ID")" ;;
+                *)    api_endpoint="${api_endpoint}?scan_id=$(urlencode "$SCAN_ID")" ;;
+            esac
         fi
     fi
 
+    # Determine progress display mode
+    if [ "$PROGRESS_MODE" = "on" ]; then
+        SHOW_PROGRESS=1
+    elif [ "$PROGRESS_MODE" = "off" ]; then
+        SHOW_PROGRESS=0
+    elif [ -t 2 ]; then
+        SHOW_PROGRESS=1
+    else
+        SHOW_PROGRESS=0
+    fi
+
+    # Build find exclusions once (shared across all scan dirs)
+    local find_excludes=()
+    local _ep
+    for _ep in "${EXCLUDE_PATHS[@]}"; do
+        [ -d "$_ep" ] && find_excludes+=(-path "$_ep" -prune -o)
+    done
+    while IFS= read -r _ep; do
+        [ -n "$_ep" ] && [ -d "$_ep" ] && find_excludes+=(-path "$_ep" -prune -o)
+    done <<< "$(get_excluded_mounts)"
+
+    # Prune known cloud storage directory names at the find level so they are
+    # excluded from both the file count and processing (keeps progress accurate).
+    local _cloud_name _cloud_lower
+    for _cloud_name in $CLOUD_DIR_NAMES; do
+        _cloud_lower="$(printf '%s' "$_cloud_name" | tr '[:upper:]' '[:lower:]')"
+        # -iname is supported by GNU find and most BSD finds
+        find_excludes+=(\( -iname "$_cloud_name" -type d -prune \) -o)
+    done
+    # Also prune macOS CloudStorage
+    find_excludes+=(\( -iname "CloudStorage" -path "*/Library/CloudStorage" -type d -prune \) -o)
+
+    # First pass: collect all file lists and count total files for progress
+    local all_find_files=()
     for scandir in "${SCAN_FOLDERS[@]}"; do
         if [ ! -d "$scandir" ]; then
             log_msg warn "Skipping non-directory path '$scandir'"
@@ -660,22 +990,42 @@ main() {
             log_msg error "Could not create temporary file list for '$scandir'"
             continue
         }
-        TMP_FILES="${TMP_FILES} ${find_results_file}"
-        # Build find exclusions: hardcoded paths + mount points of special/network FS
-        local find_excludes=()
-        local _ep
-        for _ep in "${EXCLUDE_PATHS[@]}"; do
-            [ -d "$_ep" ] && find_excludes+=(-path "$_ep" -prune -o)
-        done
-        while IFS= read -r _ep; do
-            [ -n "$_ep" ] && [ -d "$_ep" ] && find_excludes+=(-path "$_ep" -prune -o)
-        done <<< "$(get_excluded_mounts)"
-        find "$scandir" "${find_excludes[@]}" -type f -mtime "$find_mtime" -print0 > "$find_results_file" 2>/dev/null || true
+        TMP_FILES_ARR+=("$find_results_file")
+        if [ "$MAX_AGE" -gt 0 ]; then
+            find "$scandir" "${find_excludes[@]}" -type f -mtime "-${MAX_AGE}" -print0 > "$find_results_file" 2>/dev/null || true
+        else
+            find "$scandir" "${find_excludes[@]}" -type f -print0 > "$find_results_file" 2>/dev/null || true
+        fi
+        all_find_files+=("$find_results_file")
 
+        # Count files in this result set
+        local _count=0
+        if [ -s "$find_results_file" ]; then
+            _count="$(tr -cd '\0' < "$find_results_file" 2>/dev/null | wc -c)"
+            # shellcheck disable=SC2086
+            set -- $_count; _count="${1:-0}"
+        fi
+        TOTAL_FILES=$((TOTAL_FILES + _count))
+    done
+
+    log_msg info "Found $TOTAL_FILES candidate files"
+
+    local _processed=0
+    for find_results_file in "${all_find_files[@]}"; do
         while IFS= read -r -d '' file_path; do
-            FILES_SCANNED=$((FILES_SCANNED + 1))
+            # Check for interruption between files
+            [ "$INTERRUPTED" -eq 1 ] && break 2
+
+            _processed=$((_processed + 1))
+
+            # Show progress
+            if [ "$SHOW_PROGRESS" -eq 1 ] && [ "$TOTAL_FILES" -gt 0 ]; then
+                printf '\r[%d/%d] %d%%' "$_processed" "$TOTAL_FILES" "$(( _processed * 100 / TOTAL_FILES ))" >&2
+            fi
 
             [ -f "$file_path" ] || continue
+
+            FILES_SCANNED=$((FILES_SCANNED + 1))
 
             # Skip files inside cloud storage folders
             if is_cloud_path "$file_path"; then
@@ -712,6 +1062,11 @@ main() {
         [ "$elapsed" -lt 0 ] && elapsed=0
     fi
 
+    # Clear progress line if we were showing progress
+    if [ "$SHOW_PROGRESS" -eq 1 ]; then
+        printf '\r\033[K' >&2
+    fi
+
     log_msg info "Run completed: scanned=$FILES_SCANNED submitted=$FILES_SUBMITTED skipped=$FILES_SKIPPED failed=$FILES_FAILED seconds=$elapsed"
 
     # Send collection end marker with run statistics
@@ -720,7 +1075,11 @@ main() {
         collection_marker "$base_url" "end" "$SCAN_ID" "$stats_json" >/dev/null
     fi
 
+    if [ "$FILES_FAILED" -gt 0 ]; then
+        return 1
+    fi
     return 0
 }
 
 main "$@"
+exit $?


### PR DESCRIPTION
## Summary

Three fixes for the collector scripts:

### 1. feat: handle /api/collection 404 gracefully
- Older Thunderstorm versions don't have the `/api/collection/begin` and `/api/collection/end` endpoints
- All collectors now treat HTTP 404 on these endpoints as non-fatal warnings and continue with submissions
- Tested against stub server (port 18098) and real Thunderstorm (port 8081)

### 2. fix: Perl collector eval block returning falsy on success
- The `eval { ... } or do { }` construct was broken
- When `$successful = 1`, the `if (!$successful) { ... }` statement evaluates to nothing (falsy)
- This caused "Unknown failure" to be printed even on successful uploads
- Fix: Added explicit `1;` return at end of eval block

### 3. fix(bash): signal handling safety and progress output cleanliness
- Prevent recursive signal handling with `trap '' INT TERM`
- Only cleanup tmp files on clean exit (not interrupted)
- Clear progress line before log messages to avoid interleaving

## Testing

All Linux collectors tested:

| Script | Stub (18098) | Thunderstorm (8081) |
|--------|--------------|---------------------|
| Bash | ✅ 5/5 submitted | ✅ 5/5 (404 graceful) |
| Python3 | ✅ 5/5 submitted | ✅ 5/5 (404 graceful) |
| Perl | ✅ 5/5 submitted | ✅ 5/5 (404 graceful) |
| Ash | ✅ 5/5 submitted | — |

## Commits

- `d0905e4` — feat: handle /api/collection 404 gracefully
- `da183eb` — fix: perl collector eval block returning falsy on success  
- `add5075` — fix(bash): signal handling safety and progress output cleanliness