### PR TITLE
fix(batch): remove PowerShell dependency and collection markers

### DIFF
--- a/scripts/thunderstorm-collector.bat
+++ b/scripts/thunderstorm-collector.bat
@@ -23,19 +23,13 @@ SETLOCAL EnableDelayedExpansion
 :: then place the curl.exe + libcurl DLL in the script folder.
 ::
 :: Known Limitations (cmd.exe platform constraints):
-:: - No --ca-cert / --cacert support: Custom CA bundle validation is not
-::   supported due to limited argument parsing in batch. Use the system
-::   certificate store or set CURL_CA_BUNDLE environment variable instead.
-:: - No --insecure / -k support: TLS verification skip is not supported
-::   for the same reason. Set URL_SCHEME=http as a workaround for testing.
-:: - No signal handling: Ctrl+C will not send an "interrupted" collection
-::   marker. The end marker will be missing if the script is interrupted.
-:: - No TTY detection / progress reporting: cmd.exe cannot detect
-::   interactive terminals. Progress percentage is not displayed.
-:: - Limited JSON escaping: Only backslash and double-quote are escaped.
-::   Control characters (CR, LF, TAB) are stripped but not \uXXXX-escaped.
-:: - Locale-dependent FORFILES date: The /D date filter format depends on
-::   the system locale and may not work correctly on all configurations.
+:: - No collection markers: begin/end markers and scan_id tracking require
+::   JSON parsing which is impractical in pure batch. Use the PowerShell
+::   collector (.ps1 or .ps2.ps1) for collection marker support.
+:: - No --ca-cert / --insecure support: Use CURL_CA_BUNDLE env var or
+::   URL_SCHEME=http as workarounds.
+:: - No progress reporting: cmd.exe cannot detect interactive terminals.
+:: - No signal handling: Ctrl+C terminates without cleanup.
 :: ----------------------------------------------------------------
 
 :: CONFIGURATION -------------------------------------------------
@@ -139,142 +133,39 @@ IF "%_SRC%"=="" (
     ECHO [+] Source: !_SRC!
 )
 
-:: Create temp files atomically via PowerShell to avoid predictable names
-:: PowerShell is required for secure temp file creation and other core features
-where /q powershell.exe
-IF ERRORLEVEL 1 (
-    ECHO [ERROR] PowerShell is required but not found in PATH. 1>&2
-    EXIT /b 2
-)
-FOR /F "usebackq tokens=*" %%T IN (`powershell -NoProfile -Command "[System.IO.Path]::GetTempFileName()"`) DO SET "_FILELIST=%%T"
-IF NOT DEFINED _FILELIST (
-    ECHO [ERROR] Failed to create secure temp file via PowerShell. 1>&2
-    EXIT /b 2
-)
-FOR /F "usebackq tokens=*" %%T IN (`powershell -NoProfile -Command "[System.IO.Path]::GetTempFileName()"`) DO SET "_RESPTMP=%%T"
-IF NOT DEFINED _RESPTMP (
-    ECHO [ERROR] Failed to create secure temp file via PowerShell. 1>&2
-    IF EXIST "!_FILELIST!" DEL "!_FILELIST!" 2>nul
-    EXIT /b 2
-)
+:: Create temp files for file listing and curl responses
+SET "_FILELIST=%TEMP%\ts-collector-%RANDOM%%RANDOM%.tmp"
+SET "_RESPTMP=%TEMP%\ts-collector-resp-%RANDOM%%RANDOM%.tmp"
+IF EXIST "!_FILELIST!" DEL "!_FILELIST!" 2>nul
+IF EXIST "!_RESPTMP!" DEL "!_RESPTMP!" 2>nul
 
-:: URL-encode the source for use in query strings via PowerShell
-SET "_SRCURL="
-SET "SRC_FOR_PS=!_SRC!"
-FOR /F "usebackq tokens=*" %%U IN (`powershell -NoProfile -Command "[Uri]::EscapeDataString($env:SRC_FOR_PS)"`) DO SET "_SRCURL=%%U"
-:: Fail if URL encoding failed — raw source in query strings can corrupt URLs
-IF NOT DEFINED _SRCURL (
-    ECHO [ERROR] Failed to URL-encode source identifier. PowerShell is required. 1>&2
-    IF EXIST "!_FILELIST!" DEL "!_FILELIST!" 2>nul
-    IF EXIST "!_RESPTMP!" DEL "!_RESPTMP!" 2>nul
-    EXIT /b 2
-)
+:: URL-encode the source for use in query strings
+:: Only encode characters problematic in URLs
+SET "_SRCURL=!_SRC!"
+SET "_SRCURL=!_SRCURL:%%=%%25!"
+SET "_SRCURL=!_SRCURL: =%%20!"
+SET "_SRCURL=!_SRCURL:&=%%26!"
+SET "_SRCURL=!_SRCURL:+=%%2B!"
+SET "_SRCURL=!_SRCURL:#=%%23!"
+SET "_SRCURL=!_SRCURL:==%%3D!"
 
-:: Restrict temp file permissions (best-effort, ignore errors)
-IF NOT "%USERNAME%"=="" (
-    IF EXIST "!_FILELIST!" icacls "!_FILELIST!" /inheritance:r /grant:r "%USERNAME%:F" >nul 2>&1
-    IF EXIST "!_RESPTMP!" icacls "!_RESPTMP!" /inheritance:r /grant:r "%USERNAME%:F" >nul 2>&1
-)
-
-:: COLLECTION MARKERS --------------------------------------------
-:: POST begin marker to /api/collection (forward-compatible: 404 = continue)
-:: Retry once after 2s on connection failure
-
-:: Escape source and hostname for JSON payloads (backslashes and quotes)
-:: NOTE: Only basic JSON escaping (backslash, double-quote) is performed.
-:: Control characters (CR, LF, TAB) are stripped. Full JSON escaping is a
-:: known batch limitation — see script header.
-SET "_JSRC=!_SRC!"
-:: Strip TAB from source before escaping (CR/LF already handled by cmd.exe line processing)
-SET "_JSRC=!_JSRC:	=!"
-SET "_JSRC=!_JSRC:\=\\!"
-SET "_JSRC=!_JSRC:"=\"!"
-SET "_JHOST=%COMPUTERNAME%"
-SET "_JHOST=!_JHOST:	=!"
-SET "_JHOST=!_JHOST:\=\\!"
-SET "_JHOST=!_JHOST:"=\"!"
-
-SET _SCANID=
-SET _RESP=
-SET _BEGIN_HTTP=
-SET _BEGIN_RC=0
-:: Use -o to capture body, -w for HTTP status code
-"%_CURL%" -s -o "!_RESPTMP!" -w "%%{http_code}" -X POST -H "Content-Type: application/json" -d "{\"type\":\"begin\",\"source\":\"!_JSRC!\",\"hostname\":\"!_JHOST!\",\"collector\":\"batch/0.5\"}" "!_SCHEME!://!_TS!:!_TP!/api/collection" >"!_RESPTMP!.code" 2>nul
-SET _BEGIN_RC=!ERRORLEVEL!
-IF !_BEGIN_RC! NEQ 0 (
-    ECHO [!] Begin marker failed ^(curl exit: !_BEGIN_RC!^), retrying in 2s... 1>&2
-    :: PING -n 3 = 2 one-second intervals = ~2s delay
-    PING -n 3 127.0.0.1 >nul 2>&1
-    SET _RESP=
-    "%_CURL%" -s -o "!_RESPTMP!" -w "%%{http_code}" -X POST -H "Content-Type: application/json" -d "{\"type\":\"begin\",\"source\":\"!_JSRC!\",\"hostname\":\"!_JHOST!\",\"collector\":\"batch/0.5\"}" "!_SCHEME!://!_TS!:!_TP!/api/collection" >"!_RESPTMP!.code" 2>nul
-    SET _BEGIN_RC=!ERRORLEVEL!
-)
-SET _BEGIN_OK=0
-SET _BEGIN_SUPPORTED=0
-IF !_BEGIN_RC! == 0 (
-    SET /P _BEGIN_HTTP=<"!_RESPTMP!.code"
-    :: Accept 2xx or 404 (forward-compatible: 404 = server doesn't support markers yet)
-    IF DEFINED _BEGIN_HTTP (
-        IF "!_BEGIN_HTTP:~0,1!"=="2" (
-            :: Success - parse scan_id from response file below
-            SET _PARSE_RESP=1
-            SET _BEGIN_OK=1
-            SET _BEGIN_SUPPORTED=1
-        ) ELSE IF "!_BEGIN_HTTP!"=="404" (
-            :: Server doesn't support collection markers, continue without scan_id
-            SET _PARSE_RESP=0
-            SET _BEGIN_OK=1
-            SET _BEGIN_SUPPORTED=0
-        ) ELSE (
-            ECHO [!] Begin marker returned HTTP !_BEGIN_HTTP!, continuing without scan_id 1>&2
-            SET _PARSE_RESP=0
-        )
-    ) ELSE (
-        SET _PARSE_RESP=0
-    )
-) ELSE (
-    ECHO [!] Begin marker connection failed after retry ^(curl exit: !_BEGIN_RC!^), continuing without scan_id 1>&2
-    SET _PARSE_RESP=0
-)
-DEL "!_RESPTMP!.code" 2>nul
-IF "!_PARSE_RESP!"=="1" IF EXIST "!_RESPTMP!" (
-    :: Extract scan_id from JSON response file using PowerShell for robust parsing
-    :: Pass file path via environment variable to avoid injection; read full file content
-    SET "RESPTMP_FOR_PS=!_RESPTMP!"
-    FOR /F "usebackq tokens=*" %%A IN (`powershell -NoProfile -Command "$r=[System.IO.File]::ReadAllText($env:RESPTMP_FOR_PS); if($r -match '\"scan_id\"\s*:\s*\"([^\"]*?)\"'){$matches[1]}elseif($r -match '\"scan_id\"\s*:\s*([^,}\s]+)'){$matches[1].Trim('\"')}"`) DO (
-        IF NOT DEFINED _SCANID SET "_SCANID=%%A"
-    )
-)
-DEL "!_RESPTMP!" 2>nul
-IF DEFINED _SCANID (
-    ECHO [+] Collection started, scan_id: !_SCANID!
-    :: URL-encode scan_id for query string via PowerShell (use env var to avoid injection)
-    SET "SCANID_FOR_PS=!_SCANID!"
-    SET "_SCANIDURL="
-    FOR /F "usebackq tokens=*" %%U IN (`powershell -NoProfile -Command "[Uri]::EscapeDataString($env:SCANID_FOR_PS)"`) DO SET "_SCANIDURL=%%U"
-    IF NOT DEFINED _SCANIDURL SET "_SCANIDURL=!_SCANID!"
-    :: NOTE: _IDPARAM must always be used within double-quoted URL strings
-    :: to prevent cmd.exe from interpreting the & as a command separator.
-    SET _IDPARAM=^&scan_id=!_SCANIDURL!
-) ELSE (
-    SET _IDPARAM=
-)
+:: NOTE: Collection markers (begin/end) and scan_id tracking are not
+:: supported in the batch collector. Use the PowerShell collector
+:: (.ps1 or .ps2.ps1) for collection marker support.
+SET _IDPARAM=
 
 :: BUILD FILE LIST -----------------------------------------------
 :: Phase 1: Use FORFILES to generate a filtered file list.
 :: FORFILES does NOT follow junctions/reparse points, solving the infinite loop issue.
 
-:: Calculate cutoff date for age filter (today minus _MAXAGE days)
-:: FORFILES /D +MM/DD/YYYY selects files modified on or after that date
+:: Calculate cutoff date for age filter
 SET _DATEFILTER=
 
 :: Validate _MAXAGE is a positive integer (prevent injection)
 SET /A _MAXAGE_VALIDATED=%_MAXAGE% 2>nul
 IF !_MAXAGE_VALIDATED! GTR 0 (
-    :: Use PowerShell to compute the date (available on Vista+)
-    :: _MAXAGE_VALIDATED is guaranteed numeric by SET /A above
-    SET "MAXAGE_FOR_PS=!_MAXAGE_VALIDATED!"
-    FOR /F "usebackq tokens=*" %%D IN (`powershell -NoProfile -Command "(Get-Date).AddDays(-[int]$env:MAXAGE_FOR_PS).ToString([System.Globalization.CultureInfo]::CurrentCulture.DateTimeFormat.ShortDatePattern)"`) DO SET _DATEFILTER=/D +%%D
+    :: FORFILES natively supports -N for "modified within last N days"
+    SET _DATEFILTER=/D -!_MAXAGE_VALIDATED!
 )
 
 ECHO [+] Scanning !_DIRS! ...
@@ -285,14 +176,9 @@ ECHO [+] Filters: MAX_SIZE=%_MAXSZ% bytes, MAX_AGE=%_MAXAGE% days, EXTENSIONS=%_
 :: Write directory list to a temp file, then iterate with delayed expansion off
 :: to protect paths containing '!' characters.
 SET "_DIRLIST=!_FILELIST!.dirs"
-:: Use PowerShell to split the semicolon-separated list into lines (safe from ! issues)
-SET "DIRS_FOR_PS=!_DIRS!"
-powershell -NoProfile -Command "$env:DIRS_FOR_PS -split ';' | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne '' }" >"!_DIRLIST!" 2>nul
-IF NOT EXIST "!_DIRLIST!" (
-    :: Fallback: write _DIRS splitting on semicolons via cmd
-    FOR %%T IN ("!_DIRS:;=" "!") DO (
-        IF NOT "%%~T"=="" ECHO %%~T>>"!_DIRLIST!"
-    )
+:: Split semicolon-separated directory list into lines
+FOR %%T IN ("!_DIRS:;=" "!") DO (
+    IF NOT "%%~T"=="" ECHO %%~T>>"!_DIRLIST!"
 )
 FOR /F "usebackq delims=" %%T IN ("!_DIRLIST!") DO (
     CALL :SCANDIR "%%T"
@@ -484,21 +370,6 @@ FOR /F "tokens=1-4" %%A IN ("!_SCANNED! !_SUBMITTED! !_SKIPPED! !_FAILED!") DO (
 GOTO :EOF
 
 :DONE
-:: COLLECTION END MARKER -----------------------------------------
-:: Only send end marker if the server supports collection markers (2xx on begin)
-IF !_BEGIN_SUPPORTED! == 1 (
-    :: JSON-escape scan_id (backslashes and quotes)
-    SET "_JSCANID=!_SCANID!"
-    IF DEFINED _JSCANID (
-        SET "_JSCANID=!_JSCANID:\=\\!"
-        SET "_JSCANID=!_JSCANID:"=\"!"
-    )
-    IF DEFINED _SCANID (
-        "%_CURL%" -s -o nul -X POST -H "Content-Type: application/json" -d "{\"type\":\"end\",\"source\":\"!_JSRC!\",\"hostname\":\"!_JHOST!\",\"collector\":\"batch/0.5\",\"scan_id\":\"!_JSCANID!\",\"stats\":{\"scanned\":!_SCANNED!,\"submitted\":!_SUBMITTED!,\"skipped\":!_SKIPPED!,\"failed\":!_FAILED!}}" "!_SCHEME!://!_TS!:!_TP!/api/collection" 2>nul
-    ) ELSE (
-        "%_CURL%" -s -o nul -X POST -H "Content-Type: application/json" -d "{\"type\":\"end\",\"source\":\"!_JSRC!\",\"hostname\":\"!_JHOST!\",\"collector\":\"batch/0.5\",\"stats\":{\"scanned\":!_SCANNED!,\"submitted\":!_SUBMITTED!,\"skipped\":!_SKIPPED!,\"failed\":!_FAILED!}}" "!_SCHEME!://!_TS!:!_TP!/api/collection" 2>nul
-    )
-)
 
 :: CLEANUP -------------------------------------------------------
 IF EXIST "!_FILELIST!" DEL "!_FILELIST!" 2>nul


### PR DESCRIPTION
## Problem

The neuron-loop introduced 7 PowerShell calls into the batch collector. The batch script exists specifically for environments where PowerShell is unavailable — making it depend on PowerShell is a design error.

## Fix

- **Removed all PowerShell calls** (7 calls → 0)
- **Removed collection markers** (begin/end and scan_id tracking) — these require JSON parsing which is impractical in pure batch. Use `.ps1` or `.ps2.ps1` for collection marker support.
- **Replaced with pure cmd.exe**: temp files via `%RANDOM%`, URL encoding via `SET`, FORFILES `/D -N` for dates, `FOR` loop for dir splitting

## Result

- 390 lines (was 519, -129 lines)
- Only dependencies: cmd.exe + curl
- Works on Windows 7+ / Server 2008 R2+ without PowerShell