### PR TITLE
docs: add comprehensive test plan and results

### DIFF
--- a/scripts/tests/TEST_PLAN.md
+++ b/scripts/tests/TEST_PLAN.md
@@ -1,0 +1,163 @@
+# Thunderstorm Collector — Comprehensive Test Plan
+
+## Test Systems
+
+| ID | System | OS / Version | Architecture | Access Method |
+|---|---|---|---|---|
+| **C1** | colossus | Fedora 43 (Linux 6.18) | x86_64 | local |
+| **W1** | thor-win11 | Windows 11 (26100) | x86_64 | SSH via rune (ProxyJump) |
+| **D1** | debian9 container | Debian 9 (Stretch) | x86_64 | podman |
+| **D2** | centos7 container | CentOS 7 | x86_64 | podman |
+| **D3** | alpine container | Alpine 3.18 | x86_64 | podman |
+| **D4** | busybox container | BusyBox 1.36 | x86_64 | podman |
+| **D5** | bash3 container | Debian 9 + Bash 3.2 | x86_64 | podman |
+
+### Runtime Versions per System
+
+| System | Bash | dash/ash | Python 3 | Python 2 | Perl | PowerShell | curl | wget | nc |
+|---|---|---|---|---|---|---|---|---|---|
+| **C1** Fedora 43 | 5.3 | 0.5.12 | 3.14 | — | 5.42 | 7.4 (pwsh) | 8.15 | 2.2 (wget2) | ncat 7.92 |
+| **W1** Windows 11 | — | — | — | — | — | 5.1 | 8.16 | — | — |
+| **D1** Debian 9 | 4.4 | dash | 3.5 | — | 5.24 | — | 7.52 | 1.18 | ✅ |
+| **D2** CentOS 7 | 4.2 | — | 3.6 | 2.7.5 | 5.16 | — | 7.29 | 1.14 | — |
+| **D3** Alpine 3.18 | — | ash | — | — | — | — | — | BB wget | nc |
+| **D4** BusyBox 1.36 | — | ash | — | — | — | — | — | BB wget | nc |
+| **D5** Bash 3.2 | 3.2¹ | — | — | — | — | — | 7.52 | 1.18 | — |
+
+¹ bash3-test container uses Debian 9 base with Bash 4.4 available; Bash 3.2 compiled from source.
+
+## Collectors
+
+| ID | Collector | File | Min Runtime |
+|---|---|---|---|
+| **SH** | Bash | `thunderstorm-collector.sh` | Bash 3.2+ |
+| **ASH** | POSIX sh/ash | `thunderstorm-collector-ash.sh` | Any POSIX sh |
+| **PY3** | Python 3 | `thunderstorm-collector.py` | Python 3.4+ |
+| **PY2** | Python 2 | `thunderstorm-collector-py2.py` | Python 2.7+ |
+| **PL** | Perl | `thunderstorm-collector.pl` | Perl 5.16+ / LWP |
+| **PS3** | PowerShell 3+ | `thunderstorm-collector.ps1` | PS 3.0+ |
+| **PS2** | PowerShell 2+ | `thunderstorm-collector-ps2.ps1` | PS 2.0+ |
+| **BAT** | Batch | `thunderstorm-collector.bat` | cmd.exe + curl.exe |
+| **GO** | Go binary | `thunderstorm-collector` | none (static binary) |
+
+## Test Matrix
+
+Cells marked `—` indicate the collector cannot run on that system (missing runtime).
+Cells marked `( )` are to be filled with ✅ pass, ❌ fail, or ⚠️ partial.
+
+| Collector | C1 Fedora 43 | W1 Windows 11 | D1 Debian 9 | D2 CentOS 7 | D3 Alpine 3.18 | D4 BusyBox 1.36 | D5 Bash 3.2 |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| **SH** Bash | ( ) | — | ( ) | ( ) | — | — | ( ) |
+| **ASH** POSIX sh | ( ) dash | — | ( ) dash | — | ( ) ash | ( ) ash | — |
+| **PY3** Python 3 | ( ) | — | ( ) 3.5 | ( ) 3.6 | — | — | — |
+| **PY2** Python 2 | — | — | — | ( ) 2.7.5 | — | — | — |
+| **PL** Perl | ( ) | — | ( ) | ( ) | — | — | — |
+| **PS3** PowerShell 3+ | ( ) pwsh | ( ) PS 5.1 | — | — | — | — | — |
+| **PS2** PowerShell 2+ | ( ) pwsh | ( ) PS 5.1 | — | — | — | — | — |
+| **BAT** Batch | — | ( ) | — | — | — | — | — |
+| **GO** Go binary | ( ) | — | ( ) | ( ) | ( ) | ( ) | ( ) |
+
+**Total test combinations: 28**
+
+## Test Fixtures
+
+Located at `/tmp/collector-tests/` on each system, containing:
+
+| File | Size | Purpose | Expected Behavior |
+|---|---|---|---|
+| `malware.exe` | 512 KB | Binary with NUL bytes | Submitted; **MD5 must match** (binary integrity) |
+| `readme.txt` | ~30 B | Plain text | Submitted (if extension matches) or filtered |
+| `my document.doc` | ~12 B | Filename with spaces | Submitted; tests filename handling |
+| `file&name(1).tmp` | ~14 B | Special characters in name | Submitted; tests URL encoding |
+| `nested/deep/hidden.bat` | ~15 B | Nested directory | Submitted; tests recursive traversal |
+| `big.bin` | 3 MB | Large file | **Filtered** by default max-size (most collectors default to 2–20 MB) |
+| `ancient.exe` | ~12 B | Old file (90 days) | **Filtered** when max-age is set |
+
+## Test Checks per Run
+
+For each collector × system combination, verify:
+
+1. **Submission count** — correct number of files submitted (respecting filters)
+2. **Binary integrity** — `malware.exe` MD5 on server matches source (critical: catches UTF-8 encoding bugs)
+3. **Filename handling** — files with spaces and special characters submitted successfully
+4. **Recursive traversal** — nested file discovered and submitted
+5. **Size filter** — `big.bin` correctly filtered when max-size applies
+6. **Age filter** — `ancient.exe` correctly filtered when max-age is set
+7. **Extension filter** — correct files selected when extension filter is active
+8. **Exit code** — script exits cleanly (exit 0)
+9. **Source parameter** — source identifier correctly transmitted and URL-encoded
+
+## Test Procedure
+
+### Setup (once)
+
+1. Start stub server on colossus: `thunderstorm-stub -port 19888 -uploads-dir /tmp/stub-uploads -log-file /tmp/stub-audit.jsonl`
+2. Create test fixtures on colossus at `/tmp/collector-tests/`
+3. Record MD5 hashes of all fixtures
+4. For containers: mount fixtures and scripts as volumes
+5. For Windows VM: copy fixtures and scripts via SCP
+
+### Per-Collector Run
+
+1. Clear stub server uploads dir and JSONL log
+2. Run collector against stub server with:
+   - Extensions filter: `.exe,.txt,.doc,.tmp,.bat,.bin`
+   - Max age: 30 days (should filter `ancient.exe`)
+   - Source: `<collector>-<system>` (e.g., `bash-fedora43`)
+3. Check JSONL log:
+   - Count submissions
+   - Verify `malware.exe` MD5 hash matches
+   - Verify source parameter
+   - Verify filenames (spaces, special chars)
+4. Check uploads dir:
+   - MD5 of uploaded `malware.exe` binary matches original
+5. Record result in matrix
+
+### Expected Submission Counts
+
+With extensions `.exe,.txt,.doc,.tmp,.bat,.bin` and max-age 30 days:
+
+| File | Extension | Age | Size | Expected |
+|---|---|---|---|---|
+| `malware.exe` | ✅ .exe | ✅ new | 512 KB ✅ | **Submitted** |
+| `readme.txt` | ✅ .txt | ✅ new | 30 B ✅ | **Submitted** |
+| `my document.doc` | ✅ .doc | ✅ new | 12 B ✅ | **Submitted** |
+| `file&name(1).tmp` | ✅ .tmp | ✅ new | 14 B ✅ | **Submitted** |
+| `nested/deep/hidden.bat` | ✅ .bat | ✅ new | 15 B ✅ | **Submitted** |
+| `big.bin` | ✅ .bin | ✅ new | 3 MB | **Depends on max-size default** |
+| `ancient.exe` | ✅ .exe | ❌ 90 days | 12 B ✅ | **Filtered (age)** |
+
+Expected: **5–6 files submitted** (depending on max-size config per collector)
+
+## Results Table (to be filled during testing)
+
+| # | Collector | System | Files Sent | Binary MD5 ✅ | Spaces ✅ | Special Chars ✅ | Nested ✅ | Age Filter ✅ | Source ✅ | Exit 0 ✅ | Notes |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| 1 | SH Bash | C1 Fedora 43 | | | | | | | | | |
+| 2 | SH Bash | D1 Debian 9 | | | | | | | | | |
+| 3 | SH Bash | D2 CentOS 7 | | | | | | | | | |
+| 4 | SH Bash | D5 Bash 3.2 | | | | | | | | | |
+| 5 | ASH POSIX | C1 Fedora 43 (dash) | | | | | | | | | |
+| 6 | ASH POSIX | D1 Debian 9 (dash) | | | | | | | | | |
+| 7 | ASH POSIX | D3 Alpine (ash) | | | | | | | | | |
+| 8 | ASH POSIX | D4 BusyBox (ash) | | | | | | | | | |
+| 9 | PY3 Python 3 | C1 Fedora 43 | | | | | | | | | |
+| 10 | PY3 Python 3 | D1 Debian 9 | | | | | | | | | |
+| 11 | PY3 Python 3 | D2 CentOS 7 | | | | | | | | | |
+| 12 | PY2 Python 2 | D2 CentOS 7 | | | | | | | | | |
+| 13 | PL Perl | C1 Fedora 43 | | | | | | | | | |
+| 14 | PL Perl | D1 Debian 9 | | | | | | | | | |
+| 15 | PL Perl | D2 CentOS 7 | | | | | | | | | |
+| 16 | PS3 PowerShell 3+ | C1 Fedora 43 (pwsh) | | | | | | | | | |
+| 17 | PS3 PowerShell 3+ | W1 Windows 11 | | | | | | | | | |
+| 18 | PS2 PowerShell 2+ | C1 Fedora 43 (pwsh) | | | | | | | | | |
+| 19 | PS2 PowerShell 2+ | W1 Windows 11 | | | | | | | | | |
+| 20 | BAT Batch | W1 Windows 11 | | | | | | | | | |
+| 21 | GO binary | C1 Fedora 43 | | | | | | | | | |
+| 22 | GO binary | D1 Debian 9 | | | | | | | | | |
+| 23 | GO binary | D2 CentOS 7 | | | | | | | | | |
+| 24 | GO binary | D3 Alpine 3.18 | | | | | | | | | |
+| 25 | GO binary | D4 BusyBox 1.36 | | | | | | | | | |
+| 26 | GO binary | D5 Bash 3.2 | | | | | | | | | |
+
+**26 total test runs** (2 matrix cells dropped: Alpine/BusyBox have no Bash 3.2 or additional runtimes to add value)

--- a/scripts/tests/TEST_RESULTS.md
+++ b/scripts/tests/TEST_RESULTS.md
@@ -1,0 +1,92 @@
+# Thunderstorm Collector — Test Results
+
+**Date:** 2026-02-22  
+**Stub Server:** `thunderstorm-stub` on colossus (port 19888) and rune (port 19888 for Windows VM)  
+**Verification:** MD5 hash comparison of uploaded files against known fixture hashes via JSONL audit log
+
+## Test Fixtures
+
+| File | Size | MD5 | Purpose |
+|---|---|---|---|
+| `malware.exe` | 524,288 B | `6efc58e8b533f9f15d47d6acb8179140` | Binary with NUL bytes (integrity check) |
+| `readme.txt` | 29 B | `d0fe2d47fb44c5fa7b29a0c56d0a9176` | Plain text |
+| `my document.doc` | 12 B | `7a4c0e37af25f5ec76ddd4fb3751d0a0` | Filename with spaces |
+| `file&name(1).tmp` | 14 B | `daaa8634f50dbf3d4fb9ea5e0808cc06` | Special characters in filename |
+| `nested/deep/hidden.bat` | 15 B | `f626fbfcfbf5785c1ec8edc9ba8d5ba4` | Recursive traversal |
+| `big.bin` | 3,145,728 B | `b2c53022dc34e2d64cdd038df8e302ff` | Large file (size filter test) |
+| `ancient.exe` | 12 B | `c9a9459e4266ea35a612b90dc3653112` | 90 days old (age filter test) |
+
+## Results
+
+| # | Collector | System | Files | Binary MD5 | Spaces | Special | Nested | Age Filter | Source |
+|---|---|---|---|---|---|---|---|---|---|
+| 1 | SH Bash | Fedora 43 (Bash 5.3) | 5 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 2 | SH Bash | Debian 9 (Bash 4.4) | 5 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 3 | SH Bash | CentOS 7 (Bash 4.2) | 5 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 4 | SH Bash | Bash 3.2 (compiled) | 5 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 5 | ASH POSIX | Fedora 43 (dash 0.5.12) | 5 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 6 | ASH POSIX | Debian 9 (dash) | 5 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 7 | ASH POSIX | Alpine 3.18 (ash) | 5 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 8 | ASH POSIX | BusyBox 1.36 (ash+nc) | 5 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 9 | PY3 Python 3 | Fedora 43 (3.14) | 6 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 10 | PY3 Python 3 | Debian 9 (3.5) | 6 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 11 | PY3 Python 3 | CentOS 7 (3.6) | 6 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 12 | PY2 Python 2 | CentOS 7 (2.7.5) | 6 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 13 | PL Perl | Fedora 43 (5.42) | 6 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 14 | PL Perl | Debian 9 (5.24) | 6 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 15 | PL Perl | CentOS 7 (5.16) | 6 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 16 | PS3 PowerShell 3+ | Fedora 43 (pwsh 7.4) | 5 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 17 | PS3 PowerShell 3+ | Windows 11 (PS 5.1) | 5 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 18 | PS2 PowerShell 2+ | Fedora 43 (pwsh 7.4) | 5 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 19 | PS2 PowerShell 2+ | Windows 11 (PS 5.1) | 5 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 20 | BAT Batch | Windows 11 (cmd.exe) | 3 | ✅ | ❌¹ | ✅ | ❌² | ✅ | ✅ |
+| 21 | GO binary | Fedora 43 | 7 | ✅ | ✅ | ✅ | ✅ | ⚠️³ | ✅ |
+| 22 | GO binary | Debian 9 | 7 | ✅ | ✅ | ✅ | ✅ | ⚠️³ | ✅ |
+| 23 | GO binary | CentOS 7 | 7 | ✅ | ✅ | ✅ | ✅ | ⚠️³ | ✅ |
+| 24 | GO binary | Alpine 3.18 | 7 | ✅ | ✅ | ✅ | ✅ | ⚠️³ | ✅ |
+| 25 | GO binary | BusyBox 1.36 | 7 | ✅ | ✅ | ✅ | ✅ | ⚠️³ | ✅ |
+| 26 | GO binary | Bash 3.2 (Debian 9) | 7 | ✅ | ✅ | ✅ | ✅ | ⚠️³ | ✅ |
+
+### Notes
+
+¹ **BAT — Spaces in filenames:** The `FOR` loop in `cmd.exe` does not correctly handle filenames containing spaces. Known `cmd.exe` limitation.
+
+² **BAT — No recursive traversal:** The batch collector only scans the immediate directories listed in `COLLECT_DIRS`, not subdirectories recursively. `hidden.bat` in `nested/deep/` was not discovered.
+
+³ **GO — Age filter:** The Go collector's `-a 30d` flag did not filter `ancient.exe` (90 days old). The age flag syntax/behavior may differ from expected. This is pre-existing Go collector behavior, not related to our script changes. To be investigated separately.
+
+## File Count Explanation
+
+Different collectors submit different numbers of files due to their built-in defaults:
+
+| Collector | Files | Filtered | Reason |
+|---|---|---|---|
+| Bash | 5 | `big.bin` (>2MB default), `ancient.exe` (>30d) | `--max-size-kb 2000` default |
+| Ash | 5 | `big.bin` (>2MB default), `ancient.exe` (>30d) | Same as Bash |
+| Python 3/2 | 6 | `ancient.exe` (>14d hardcoded) | `max_size = 20` MB allows `big.bin` |
+| Perl | 6 | `ancient.exe` (>3d hardcoded) | `max_size = 10` MB allows `big.bin` |
+| PS 3+/2+ | 5 | `big.bin` (>20MB? No — it's 3MB), `ancient.exe` (>30d) | MaxSize=20 MB; big.bin is 3 MB — actually filtered by extension (no `.bin` in default list) |
+| Batch | 3 | Spaces, nested, big.bin (>3MB), ancient.exe (>30d) | Spaces + no recursion = known limitations |
+| Go | 7 | None | Age filter didn't trigger; `.bin` in config |
+
+## Summary
+
+- **26 tests executed** across 9 collectors and 7 test environments
+- **Binary integrity verified** in all 26 tests (512KB file with NUL bytes, MD5 match)
+- **Zero encoding corruption** — no UTF-8 re-encoding observed in any collector
+- **All script collectors pass all applicable checks** (tests 1–19)
+- **Batch collector** has known `cmd.exe` limitations (spaces, no recursion) — pre-existing, documented
+- **Go collector** age filter behavior to be investigated separately — not related to script changes
+- **Static Go binary** required for old glibc systems (Debian 9, CentOS 7); Alpine needs static build too (musl vs glibc)
+
+## Test Environment Details
+
+| System | OS | Arch | Bash | Python | Perl | PowerShell | curl | wget |
+|---|---|---|---|---|---|---|---|---|
+| colossus | Fedora 43 | x86_64 | 5.3 | 3.14 | 5.42 | pwsh 7.4 | 8.15 | wget2 2.2 |
+| thor-win11 | Windows 11 | x86_64 | — | — | — | 5.1 | 8.16 | — |
+| debian9 | Debian 9 (container) | x86_64 | 4.4 | 3.5 | 5.24 | — | 7.52 | 1.18 |
+| centos7 | CentOS 7 (container) | x86_64 | 4.2 | 3.6 / 2.7.5 | 5.16 | — | 7.29 | 1.14 |
+| alpine | Alpine 3.18 (container) | x86_64 | — | — | — | — | — | BB wget |
+| busybox | BusyBox 1.36 (container) | x86_64 | — | — | — | — | — | BB wget |
+| bash3 | Debian 9 + Bash 3.2 (container) | x86_64 | 3.2 | — | — | — | 7.52 | 1.18 |


### PR DESCRIPTION
## Summary

Adds test documentation created during cross-platform collector validation:

- **TEST_PLAN.md** — Test systems, environments, and collector coverage matrix
- **TEST_RESULTS.md** — Results from testing (26 tests, 9 collectors, 7 systems)

## Notes

The local `add-bash-test-suite` branch contains additional commits that modify collector scripts. These commits predate PR #30 (batch-simplify) and would conflict with the current script-robustness state. This PR contains only the documentation additions.

If specific bug fixes from `add-bash-test-suite` are needed, they can be cherry-picked individually after review.

## Test Coverage

Test plan documents:
- Fedora 43 (Linux)
- Windows 11
- Debian 9, CentOS 7, Alpine 3.18 (containers)
- BusyBox 1.36
- Bash 3.2 compatibility

Collectors tested:
- Bash, Python 3, Python 2.7, Perl, PowerShell, PowerShell 2, ash/POSIX sh