### PR TITLE
test: add shared script collector harness

### DIFF
--- a/.github/workflows/script-collectors.yml
+++ b/.github/workflows/script-collectors.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
     inputs:
       collectors:
-        description: "Comma-separated collectors to test: bash, ash, python3, python2, perl, ps3, ps2, windows"
+        description: "Optional collector selectors for stacked collector branches, for example: bash, python3, windows"
         required: false
         default: ""
 
@@ -78,11 +78,28 @@ jobs:
             esac
           fi
 
+          collector_exists() {
+            case "$1" in
+              bash) [ -f scripts/thunderstorm-collector.sh ] ;;
+              ash) [ -f scripts/thunderstorm-collector-ash.sh ] ;;
+              python3) [ -f scripts/thunderstorm-collector.py ] ;;
+              python2) [ -f scripts/thunderstorm-collector-py2.py ] ;;
+              perl) [ -f scripts/thunderstorm-collector.pl ] ;;
+              *) return 1 ;;
+            esac
+          }
+
           collectors=()
           IFS=',' read -r -a requested_collectors <<< "$requested"
           for collector in "${requested_collectors[@]}"; do
             case "$collector" in
-              bash|ash|python3|python2|perl) collectors+=("$collector") ;;
+              bash|ash|python3|python2|perl)
+                if collector_exists "$collector"; then
+                  collectors+=("$collector")
+                else
+                  echo "Skipping missing Linux collector: $collector"
+                fi
+                ;;
             esac
           done
 
@@ -150,10 +167,14 @@ jobs:
           $collectors = @()
           foreach ($collector in $requested.Split(",", [System.StringSplitOptions]::RemoveEmptyEntries)) {
             switch ($collector.Trim()) {
-              "ps3" { $collectors += "ps3" }
-              "ps2" { $collectors += "ps2" }
-              "batch" { $collectors += "batch" }
-              "windows" { $collectors += @("ps3", "ps2", "batch") }
+              "ps3" { if (Test-Path "scripts\thunderstorm-collector.ps1") { $collectors += "ps3" } }
+              "ps2" { if (Test-Path "scripts\thunderstorm-collector-ps2.ps1") { $collectors += "ps2" } }
+              "batch" { if (Test-Path "scripts\thunderstorm-collector.bat") { $collectors += "batch" } }
+              "windows" {
+                if (Test-Path "scripts\thunderstorm-collector.ps1") { $collectors += "ps3" }
+                if (Test-Path "scripts\thunderstorm-collector-ps2.ps1") { $collectors += "ps2" }
+                if (Test-Path "scripts\thunderstorm-collector.bat") { $collectors += "batch" }
+              }
             }
           }
 

--- a/.github/workflows/script-collectors.yml
+++ b/.github/workflows/script-collectors.yml
@@ -1,0 +1,277 @@
+name: Script Collectors
+
+on:
+  push:
+    paths:
+      - "scripts/**"
+      - ".github/workflows/script-collectors.yml"
+  pull_request:
+    paths:
+      - "scripts/**"
+      - ".github/workflows/script-collectors.yml"
+  workflow_dispatch:
+    inputs:
+      collectors:
+        description: "Comma-separated collectors to test: bash, ash, python3, python2, perl, ps3, ps2, windows"
+        required: false
+        default: ""
+
+env:
+  STUB_SERVER_REF: 6b57bca2f2ae33c499ff717847bec3154a3841ad
+
+jobs:
+  linux:
+    name: Linux script collectors
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install script dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y dash libwww-perl
+
+      - name: Checkout thunderstorm-stub-server
+        uses: actions/checkout@v4
+        with:
+          repository: Nextron-Labs/thunderstorm-stub-server
+          ref: ${{ env.STUB_SERVER_REF }}
+          path: thunderstorm-stub-server
+
+      - name: Build thunderstorm-stub-server
+        working-directory: thunderstorm-stub-server
+        run: go build -o "$RUNNER_TEMP/thunderstorm-stub-server" .
+
+      - name: Syntax check shared harness
+        run: |
+          bash -n scripts/tests/run_detection_tests.sh
+          bash -n scripts/tests/run_e2e_compliance.sh
+          bash -n scripts/tests/run_filter_tests.sh
+          bash -n scripts/tests/run_operational_tests.sh
+
+      - name: Detect Linux collectors
+        id: collectors
+        run: |
+          set -euo pipefail
+          requested="${{ github.event.inputs.collectors || '' }}"
+          branch="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-}}"
+
+          if [ -z "$requested" ]; then
+            case "$branch" in
+              *script-bash*) requested="bash" ;;
+              *script-ash*) requested="ash" ;;
+              *script-python*) requested="python3,python2" ;;
+              *script-perl*) requested="perl" ;;
+              *script-windows*) requested="" ;;
+              *) requested="" ;;
+            esac
+          fi
+
+          collectors=()
+          IFS=',' read -r -a requested_collectors <<< "$requested"
+          for collector in "${requested_collectors[@]}"; do
+            case "$collector" in
+              bash|ash|python3|python2|perl) collectors+=("$collector") ;;
+            esac
+          done
+
+          if [ "${#collectors[@]}" -eq 0 ]; then
+            echo "collectors=" >> "$GITHUB_OUTPUT"
+            echo "No Linux script collectors selected for branch '$branch'."
+          else
+            IFS=,
+            echo "collectors=${collectors[*]}" >> "$GITHUB_OUTPUT"
+            echo "Linux collectors: ${collectors[*]}"
+          fi
+
+      - name: Shared e2e compliance
+        if: steps.collectors.outputs.collectors != ''
+        env:
+          THUNDERSTORM_TEST_COLLECTORS: ${{ steps.collectors.outputs.collectors }}
+          THUNDERSTORM_TEST_REQUIRE_MATCH: "1"
+        run: scripts/tests/run_e2e_compliance.sh "$RUNNER_TEMP/thunderstorm-stub-server"
+
+      - name: Bash collector suite
+        if: hashFiles('scripts/tests/run_tests.sh') != ''
+        run: bash scripts/tests/run_tests.sh "$RUNNER_TEMP/thunderstorm-stub-server"
+
+      - name: Ash regression suite
+        if: hashFiles('scripts/tests/run_ash_regression_tests.sh') != ''
+        run: sh scripts/tests/run_ash_regression_tests.sh
+
+      - name: Python regression suite
+        if: hashFiles('scripts/tests/run_python_regression_tests.sh') != ''
+        env:
+          PYTHONPYCACHEPREFIX: ${{ runner.temp }}/pycache
+        run: bash scripts/tests/run_python_regression_tests.sh
+
+  windows:
+    name: Windows script collectors
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Detect Windows collectors
+        id: collectors
+        shell: pwsh
+        run: |
+          $requested = "${{ github.event.inputs.collectors || '' }}"
+          $branch = if ($env:GITHUB_HEAD_REF) { $env:GITHUB_HEAD_REF } else { $env:GITHUB_REF_NAME }
+          if (-not $requested) {
+            if ($branch -like "*script-windows*") {
+              $requested = "ps3,ps2,batch"
+            } else {
+              $requested = ""
+            }
+          }
+
+          $collectors = @()
+          foreach ($collector in $requested.Split(",", [System.StringSplitOptions]::RemoveEmptyEntries)) {
+            switch ($collector.Trim()) {
+              "ps3" { $collectors += "ps3" }
+              "ps2" { $collectors += "ps2" }
+              "batch" { $collectors += "batch" }
+              "windows" { $collectors += @("ps3", "ps2", "batch") }
+            }
+          }
+
+          "count=$($collectors.Count)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "collectors=$($collectors -join ',')" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      - name: Checkout thunderstorm-stub-server
+        if: steps.collectors.outputs.count != '0'
+        uses: actions/checkout@v4
+        with:
+          repository: Nextron-Labs/thunderstorm-stub-server
+          ref: ${{ env.STUB_SERVER_REF }}
+          path: thunderstorm-stub-server
+
+      - name: Build thunderstorm-stub-server
+        if: steps.collectors.outputs.count != '0'
+        shell: pwsh
+        working-directory: thunderstorm-stub-server
+        run: go build -o "$env:RUNNER_TEMP\thunderstorm-stub-server.exe" .
+
+      - name: Run Windows collectors
+        if: steps.collectors.outputs.count != '0'
+        shell: pwsh
+        env:
+          SELECTED_COLLECTORS: ${{ steps.collectors.outputs.collectors }}
+        run: |
+          $sampleDir = Join-Path $env:RUNNER_TEMP "script-collector-sample"
+          $uploadsDir = Join-Path $env:RUNNER_TEMP "script-collector-uploads"
+          $auditFile = Join-Path $env:RUNNER_TEMP "stub-audit.jsonl"
+          $stdoutLog = Join-Path $env:RUNNER_TEMP "stub-stdout.log"
+          $stderrLog = Join-Path $env:RUNNER_TEMP "stub-stderr.log"
+          New-Item -ItemType Directory -Path $sampleDir, $uploadsDir -Force | Out-Null
+
+          $samplePath = Join-Path $sampleDir "sample.exe"
+          [IO.File]::WriteAllBytes($samplePath, [byte[]](0, 1, 2, 3, 84, 72, 85, 78, 68, 69, 82))
+          $expectedSha256 = (Get-FileHash -Path $samplePath -Algorithm SHA256).Hash.ToLower()
+
+          $port = "18080"
+          $proc = $null
+          $expectedCount = 0
+          try {
+            $proc = Start-Process `
+              -FilePath "$env:RUNNER_TEMP\thunderstorm-stub-server.exe" `
+              -ArgumentList @("--port", $port, "--uploads-dir", $uploadsDir, "--log-file", $auditFile) `
+              -RedirectStandardOutput $stdoutLog `
+              -RedirectStandardError $stderrLog `
+              -PassThru
+
+            $ready = $false
+            for ($i = 0; $i -lt 60; $i++) {
+              try {
+                Invoke-RestMethod -Uri "http://127.0.0.1:$port/api/status" | Out-Null
+                $ready = $true
+                break
+              } catch {
+                Start-Sleep -Seconds 1
+              }
+            }
+            if (-not $ready) { throw "Stub server did not become ready" }
+
+            $selected = ",$($env:SELECTED_COLLECTORS),"
+
+            if ($selected.Contains(",ps3,")) {
+              if (-not (Test-Path "scripts\thunderstorm-collector.ps1")) {
+                throw "Requested ps3 collector, but scripts\thunderstorm-collector.ps1 is missing"
+              }
+              powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\thunderstorm-collector.ps1 `
+                -ThunderstormServer 127.0.0.1 `
+                -ThunderstormPort $port `
+                -Folder $sampleDir `
+                -Source windows-ps-e2e `
+                -MaxAge 30 `
+                -MaxSize 100
+              if ($LASTEXITCODE -ne 0) { throw "PowerShell collector failed with exit code $LASTEXITCODE" }
+              $expectedCount++
+            }
+
+            if ($selected.Contains(",ps2,")) {
+              if (-not (Test-Path "scripts\thunderstorm-collector-ps2.ps1")) {
+                throw "Requested ps2 collector, but scripts\thunderstorm-collector-ps2.ps1 is missing"
+              }
+              powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\thunderstorm-collector-ps2.ps1 `
+                -ThunderstormServer 127.0.0.1 `
+                -ThunderstormPort $port `
+                -Folder $sampleDir `
+                -Source windows-ps2-e2e `
+                -MaxAge 30 `
+                -MaxSize 100
+              if ($LASTEXITCODE -ne 0) { throw "PowerShell 2 collector failed with exit code $LASTEXITCODE" }
+              $expectedCount++
+            }
+
+            if ($selected.Contains(",batch,")) {
+              if (-not (Test-Path "scripts\thunderstorm-collector.bat")) {
+                throw "Requested batch collector, but scripts\thunderstorm-collector.bat is missing"
+              }
+              $env:THUNDERSTORM_SERVER = "127.0.0.1"
+              $env:THUNDERSTORM_PORT = $port
+              $env:URL_SCHEME = "http"
+              $env:COLLECT_DIRS = $sampleDir
+              $env:RELEVANT_EXTENSIONS = ".exe"
+              $env:COLLECT_MAX_SIZE = "50000000"
+              $env:MAX_AGE = "30"
+              $env:SOURCE = "windows-bat-e2e"
+              cmd /c scripts\thunderstorm-collector.bat
+              if ($LASTEXITCODE -ne 0) { throw "Batch collector failed with exit code $LASTEXITCODE" }
+              $expectedCount++
+            }
+
+            python .\scripts\tests\verify_uploads.py `
+              --uploads-dir "$uploadsDir" `
+              --expected-sha256 "$expectedSha256" `
+              --min-count "$expectedCount" `
+              --timeout-seconds 180
+            if ($LASTEXITCODE -ne 0) { throw "Upload verification failed with exit code $LASTEXITCODE" }
+          } finally {
+            if ($proc) {
+              Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+            }
+            if (Test-Path $stdoutLog) { Get-Content -Path $stdoutLog }
+            if (Test-Path $stderrLog) { Get-Content -Path $stderrLog }
+            if (Test-Path $auditFile) { Get-Content -Path $auditFile }
+          }

--- a/.github/workflows/script-collectors.yml
+++ b/.github/workflows/script-collectors.yml
@@ -23,6 +23,7 @@ jobs:
   linux:
     name: Linux script collectors
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -118,6 +119,7 @@ jobs:
   windows:
     name: Windows script collectors
     runs-on: windows-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 

--- a/scripts/tests/run_detection_tests.sh
+++ b/scripts/tests/run_detection_tests.sh
@@ -119,11 +119,42 @@ collector_script_path() {
     esac
 }
 
+collector_has_flags() {
+    local script_path="$1" flag
+    shift
+    for flag in "$@"; do
+        grep -q -- "$flag" "$script_path" || return 1
+    done
+}
+
+collector_supports_shared_harness() {
+    local current script_path
+    current="$(normalize_collector "$1")"
+    script_path="$(collector_script_path "$current")" || return 1
+
+    case "$current" in
+        bash|ash)
+            collector_has_flags "$script_path" --server --port --dir --max-age --source --dry-run
+            ;;
+        python)
+            collector_has_flags "$script_path" --server --port --dirs --max-age --source --dry-run
+            ;;
+        perl)
+            collector_has_flags "$script_path" --server --port --dir --max-age --source --dry-run
+            ;;
+        ps3|ps2)
+            collector_has_flags "$script_path" ThunderstormServer ThunderstormPort Folder Source MaxAge MaxSize AllExtensions
+            ;;
+        *) return 1 ;;
+    esac
+}
+
 collector_runnable() {
     local current script_path
     current="$(normalize_collector "$1")"
     script_path="$(collector_script_path "$current")" || return 1
     [ -f "$script_path" ] || return 1
+    collector_supports_shared_harness "$current" || return 1
 
     case "$current" in
         bash) command -v bash >/dev/null 2>&1 ;;
@@ -188,6 +219,20 @@ find_stub() {
 
 STUB_BIN="$(find_stub)"
 
+find_stub_rules() {
+    local candidates=(
+        "${STUB_RULES_DIR:-}"
+        "$SCRIPT_DIR/../../../thunderstorm-stub-server/rules"
+        "$SCRIPT_DIR/../../thunderstorm-stub-server/rules"
+    )
+    for c in "${candidates[@]}"; do
+        [ -n "$c" ] && [ -d "$c" ] && (cd "$c" 2>/dev/null && pwd) && return
+    done
+    echo ""
+}
+
+STUB_RULES="$(find_stub_rules)"
+
 # Start the stub server (once for the entire test run)
 start_stub() {
     local tmpdir; tmpdir="$(mktemp -d /tmp/detection-test-XXXXXX)"
@@ -195,7 +240,7 @@ start_stub() {
     STUB_UPLOADS="$tmpdir/uploads"
     mkdir -p "$STUB_UPLOADS"
 
-    local rules_dir="${STUB_RULES_DIR:-$(cd "$SCRIPT_DIR/../../../thunderstorm-stub-server/rules" 2>/dev/null && pwd)}"
+    local rules_dir="$STUB_RULES"
 
     "$STUB_BIN" \
         -port "$STUB_PORT" \
@@ -353,7 +398,7 @@ run_ash() {
 run_python() {
     local dir="$1"; shift
     python3 "${COLLECTOR_DIR}/thunderstorm-collector.py" \
-        --server localhost --port "$STUB_PORT" --dir "$dir" \
+        --server localhost --port "$STUB_PORT" -d "$dir" \
         "$@" 2>&1
 }
 
@@ -1003,8 +1048,8 @@ test_retry_on_late_server() {
 
     # Start the stub server FIRST on the retry port, but with a delayed start.
     # We use a wrapper that waits 2 seconds before launching the stub.
-    local stub_bin="${STUB_BIN:-/home/neo/.openclaw/workspace/projects/thunderstorm-stub-server/thunderstorm-stub}"
-    local stub_rules="${STUB_RULES_DIR:-/home/neo/.openclaw/workspace/projects/thunderstorm-stub-server/rules}"
+    local stub_bin="$STUB_BIN"
+    local stub_rules="$STUB_RULES"
 
     # Launch delayed stub in background.
     # All collectors send a begin marker with a single retry after 2s on failure.
@@ -1032,7 +1077,7 @@ test_retry_on_late_server() {
             ;;
         python)
             timeout 30 python3 "${COLLECTOR_DIR}/thunderstorm-collector.py" \
-                --server localhost --port "$retry_port" --dir "$fixtures/retry" \
+                --server localhost --port "$retry_port" -d "$fixtures/retry" \
                 --max-age 30 --retries 5 > "$collector_out" 2>&1 || true
             ;;
         perl)
@@ -1118,7 +1163,7 @@ test_server_unreachable() {
             ;;
         python)
             timeout 20 python3 "${COLLECTOR_DIR}/thunderstorm-collector.py" \
-                --server localhost --port "$dead_port" --dir "$fixtures/unreachable" \
+                --server localhost --port "$dead_port" -d "$fixtures/unreachable" \
                 --max-age 30 --retries 1 > "$collector_out" 2>&1 || exit_code=$?
             ;;
         perl)
@@ -1209,6 +1254,11 @@ else
     if [ -z "$STUB_BIN" ]; then
         echo "ERROR: thunderstorm-stub binary not found." >&2
         echo "Set STUB_BIN_PATH or build with: go build -tags yara -o thunderstorm-stub ." >&2
+        exit 1
+    fi
+    if [ -z "$STUB_RULES" ]; then
+        echo "ERROR: thunderstorm-stub rules directory not found." >&2
+        echo "Set STUB_RULES_DIR or keep thunderstorm-stub-server next to this repository." >&2
         exit 1
     fi
 

--- a/scripts/tests/run_detection_tests.sh
+++ b/scripts/tests/run_detection_tests.sh
@@ -1,0 +1,1261 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Detection & Path Verification Tests
+#
+# Tests the full detection pipeline across all collector scripts:
+#
+# Positive tests:
+#   1. Malicious file → YARA content match (score > 0)
+#   2. Benign file → no match (no log entry)
+#   3. Benign file with malicious filename (/tmp/x) → filename IOC match
+#   4. Malicious file filtered by size → no event logged
+#   5. Same large file without size filter → detected
+#   6. Full path preserved in thunderstorm log
+#   7. Subdirectory recursion (files found at all levels)
+#
+# Negative tests (verifying collectors DON'T do what they shouldn't):
+#   8.  Directory scope — scanning /target must NOT pick up files from /decoy
+#   9.  Age filter — files older than --max-age must NOT be submitted
+#  10.  Extension filter (PS only) — exotic extensions must NOT be submitted
+#
+# Edge cases & robustness:
+#  12.  Empty files (0 bytes) — must not crash or produce false positives
+#  13.  Unicode filenames — must not crash or corrupt path
+#  14.  Symlinks — must NOT follow symlinks (security: no directory escape)
+#  15.  Broken/dangling symlinks — must not crash
+#  16.  Special characters in filenames (spaces, parens) — must handle correctly
+#  17.  Directories named after excluded paths — must not crash
+#  18.  Unreadable files (chmod 000) — must not crash, must process other files
+#
+# Server failure & retry:
+#  19.  Server unreachable — collector must exit gracefully, not crash
+#  20.  Late server startup — retry must succeed when server comes up mid-run
+#
+# Requires: thunderstorm-stub server with YARA support (-tags yara)
+#           running on localhost with both content rules and filename IOC rules
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+COLLECTOR_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+STUB_PORT="${STUB_PORT:-18098}"
+STUB_URL="http://localhost:${STUB_PORT}"
+STUB_LOG="${STUB_LOG:-}"
+STUB_UPLOADS=""
+STUB_PID=""
+COLLECTOR_FILTER_RAW="${THUNDERSTORM_TEST_COLLECTORS:-}"
+COLLECTOR_REQUIRE_MATCH="${THUNDERSTORM_TEST_REQUIRE_MATCH:-0}"
+COLLECTOR_REQUIRE_ALL="${THUNDERSTORM_TEST_REQUIRE_ALL:-0}"
+
+# Colours
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[1;36m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_SKIPPED=0
+FAILED_NAMES=""
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+log() { printf "  %s\n" "$*"; }
+pass() { printf "  ${GREEN}PASS${RESET} %s\n" "$*"; TESTS_PASSED=$((TESTS_PASSED + 1)); }
+fail() { printf "  ${RED}FAIL${RESET} %s\n" "$*"; TESTS_FAILED=$((TESTS_FAILED + 1)); FAILED_NAMES="$FAILED_NAMES  - $1\n"; }
+skip() { printf "  ${YELLOW}SKIP${RESET} %s\n" "$*"; TESTS_SKIPPED=$((TESTS_SKIPPED + 1)); }
+
+normalize_collector() {
+    case "$1" in
+        bash|ash|perl|ps3|ps2) printf '%s\n' "$1" ;;
+        python|python3) printf 'python\n' ;;
+        powershell|powershell3|pwsh|ps) printf 'ps3\n' ;;
+        powershell2|psv2) printf 'ps2\n' ;;
+        *) printf '%s\n' "$1" ;;
+    esac
+}
+
+collector_enabled() {
+    local current wanted
+    current="$(normalize_collector "$1")"
+    [ -z "$COLLECTOR_FILTER_RAW" ] && return 0
+
+    for wanted in ${COLLECTOR_FILTER_RAW//,/ }; do
+        if [ "$(normalize_collector "$wanted")" = "$current" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+is_truthy() {
+    case "${1:-0}" in
+        1|true|TRUE|yes|YES|on|ON) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+list_contains() {
+    local needle="$1" item
+    shift
+    for item in "$@"; do
+        [ "$item" = "$needle" ] && return 0
+    done
+    return 1
+}
+
+collector_script_path() {
+    case "$(normalize_collector "$1")" in
+        bash) printf '%s/thunderstorm-collector.sh\n' "$COLLECTOR_DIR" ;;
+        ash) printf '%s/thunderstorm-collector-ash.sh\n' "$COLLECTOR_DIR" ;;
+        python) printf '%s/thunderstorm-collector.py\n' "$COLLECTOR_DIR" ;;
+        perl) printf '%s/thunderstorm-collector.pl\n' "$COLLECTOR_DIR" ;;
+        ps3) printf '%s/thunderstorm-collector.ps1\n' "$COLLECTOR_DIR" ;;
+        ps2) printf '%s/thunderstorm-collector-ps2.ps1\n' "$COLLECTOR_DIR" ;;
+        *) return 1 ;;
+    esac
+}
+
+collector_runnable() {
+    local current script_path
+    current="$(normalize_collector "$1")"
+    script_path="$(collector_script_path "$current")" || return 1
+    [ -f "$script_path" ] || return 1
+
+    case "$current" in
+        bash) command -v bash >/dev/null 2>&1 ;;
+        ash) [ -n "$ASH_SHELL" ] ;;
+        python) command -v python3 >/dev/null 2>&1 ;;
+        perl) command -v perl >/dev/null 2>&1 && perl -MLWP::UserAgent -e1 2>/dev/null ;;
+        ps3|ps2) command -v pwsh >/dev/null 2>&1 ;;
+        *) return 1 ;;
+    esac
+}
+
+validate_available_collectors() {
+    local available=("$@")
+    local wanted normalized missing=()
+
+    if is_truthy "$COLLECTOR_REQUIRE_MATCH" && [ "${#available[@]}" -eq 0 ]; then
+        echo "ERROR: no runnable collectors matched THUNDERSTORM_TEST_COLLECTORS='${COLLECTOR_FILTER_RAW}'" >&2
+        exit 1
+    fi
+
+    if is_truthy "$COLLECTOR_REQUIRE_ALL" && [ -n "$COLLECTOR_FILTER_RAW" ]; then
+        for wanted in ${COLLECTOR_FILTER_RAW//,/ }; do
+            normalized="$(normalize_collector "$wanted")"
+            if ! list_contains "$normalized" "${available[@]}"; then
+                missing+=("$normalized")
+            fi
+        done
+        if [ "${#missing[@]}" -gt 0 ]; then
+            echo "ERROR: requested collectors are not runnable: ${missing[*]}" >&2
+            exit 1
+        fi
+    fi
+}
+
+detect_ash_shell() {
+    if command -v ash >/dev/null 2>&1; then
+        echo "ash"
+    elif command -v dash >/dev/null 2>&1; then
+        echo "dash"
+    elif command -v busybox >/dev/null 2>&1; then
+        echo "busybox sh"
+    else
+        echo ""
+    fi
+}
+
+ASH_SHELL="${ASH_SHELL:-$(detect_ash_shell)}"
+
+# Find the stub server binary
+find_stub() {
+    local candidates=(
+        "${STUB_BIN_PATH:-}"
+        "$SCRIPT_DIR/../../../thunderstorm-stub-server/thunderstorm-stub"
+        "$SCRIPT_DIR/../../thunderstorm-stub-server/thunderstorm-stub"
+        "$(command -v thunderstorm-stub 2>/dev/null || true)"
+    )
+    for c in "${candidates[@]}"; do
+        [ -n "$c" ] && [ -x "$c" ] && echo "$c" && return
+    done
+    echo ""
+}
+
+STUB_BIN="$(find_stub)"
+
+# Start the stub server (once for the entire test run)
+start_stub() {
+    local tmpdir; tmpdir="$(mktemp -d /tmp/detection-test-XXXXXX)"
+    STUB_LOG="$tmpdir/thunderstorm.jsonl"
+    STUB_UPLOADS="$tmpdir/uploads"
+    mkdir -p "$STUB_UPLOADS"
+
+    local rules_dir="${STUB_RULES_DIR:-$(cd "$SCRIPT_DIR/../../../thunderstorm-stub-server/rules" 2>/dev/null && pwd)}"
+
+    "$STUB_BIN" \
+        -port "$STUB_PORT" \
+        -rules-dir "$rules_dir" \
+        -log-file "$STUB_LOG" \
+        -uploads-dir "$STUB_UPLOADS" \
+        >"$tmpdir/stub.log" 2>&1 &
+    STUB_PID=$!
+    sleep 2
+
+    if ! kill -0 "$STUB_PID" 2>/dev/null; then
+        echo "ERROR: stub server failed to start:" >&2
+        cat "$tmpdir/stub.log" >&2
+        exit 1
+    fi
+
+    local info; info="$(curl -s "${STUB_URL}/api/info" 2>/dev/null)"
+    if [ -z "$info" ]; then
+        echo "ERROR: stub server not responding on port $STUB_PORT" >&2
+        kill "$STUB_PID" 2>/dev/null
+        exit 1
+    fi
+    if echo "$info" | python3 -c "import sys,json; sys.exit(0 if not json.load(sys.stdin).get('stub_mode') else 1)" 2>/dev/null; then
+        return 0
+    else
+        echo "ERROR: stub server running in stub mode (no YARA). Build with -tags yara." >&2
+        kill "$STUB_PID" 2>/dev/null
+        exit 1
+    fi
+}
+
+stop_stub() {
+    [ -n "$STUB_PID" ] && kill "$STUB_PID" 2>/dev/null && wait "$STUB_PID" 2>/dev/null
+    STUB_PID=""
+}
+
+# Mark the current log position so query_log only sees entries from here forward.
+clear_log() {
+    mark_log_position
+}
+
+cleanup() {
+    stop_stub
+    # Kill any leftover retry-test stubs
+    for p in 18101 18102 18103 18104 18105 18106; do
+        local pid; pid="$(lsof -ti :$p 2>/dev/null)"
+        [ -n "$pid" ] && kill "$pid" 2>/dev/null
+    done
+    rm -rf /tmp/detection-test-* /tmp/filename-ioc-test-* /tmp/retry-stub-* /tmp/collector-out-* 2>/dev/null
+}
+trap cleanup EXIT
+
+# Record the current log line count — used to scope queries to "after this point"
+mark_log_position() {
+    LOG_OFFSET="$(wc -l < "$STUB_LOG" 2>/dev/null || echo 0)"
+}
+
+# Query the JSONL log for entries matching a client_filename substring.
+# Only searches entries AFTER the last mark_log_position() call.
+# Returns the FIRST matching JSON line (empty string if not found).
+query_log() {
+    local filename_substr="$1"
+    python3 -c "
+import json, sys
+offset = int('${LOG_OFFSET:-0}')
+for i, line in enumerate(open('$STUB_LOG')):
+    if i < offset:
+        continue
+    line = line.strip()
+    if not line: continue
+    d = json.loads(line)
+    cf = d.get('subject', {}).get('client_filename', '')
+    if '$filename_substr' in cf:
+        print(line)
+        break
+" 2>/dev/null
+}
+
+# Extract a field from a log entry JSON
+log_field() {
+    local json_line="$1"
+    local field="$2"
+    echo "$json_line" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+# Navigate dotted paths
+val = d
+for part in '$field'.split('.'):
+    if isinstance(val, dict):
+        val = val.get(part, '')
+    else:
+        val = ''
+        break
+print(val if val else '')
+" 2>/dev/null
+}
+
+# Get reason count from a log entry (JSONL uses 'reasons', not 'matches')
+match_count() {
+    local json_line="$1"
+    echo "$json_line" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+print(d.get('reason_count', len(d.get('reasons', []))))
+" 2>/dev/null
+}
+
+# Get score from a log entry
+get_score() {
+    local json_line="$1"
+    echo "$json_line" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+print(d.get('score', 0))
+" 2>/dev/null
+}
+
+# Check if a specific rule name appears in the log entry's reasons
+has_rule() {
+    local json_line="$1"
+    local rule_name="$2"
+    echo "$json_line" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+reasons = d.get('reasons', [])
+for r in reasons:
+    sig = r.get('signature', {})
+    if sig.get('rule_name') == '$rule_name':
+        print('yes')
+        sys.exit(0)
+print('no')
+" 2>/dev/null
+}
+
+# ── Collector runners ───────────────────────────────────────────────────────
+
+run_bash() {
+    local dir="$1"; shift
+    # Extra args can override --max-age, --max-size-kb, etc.
+    bash "${COLLECTOR_DIR}/thunderstorm-collector.sh" \
+        --server localhost --port "$STUB_PORT" --dir "$dir" \
+        "$@" 2>&1
+}
+
+run_ash() {
+    local dir="$1"; shift
+    [ -n "$ASH_SHELL" ] || return 127
+    # Intentionally rely on shell word splitting so "busybox sh" works.
+    # shellcheck disable=SC2086
+    $ASH_SHELL "${COLLECTOR_DIR}/thunderstorm-collector-ash.sh" \
+        --server localhost --port "$STUB_PORT" --dir "$dir" \
+        "$@" 2>&1
+}
+
+run_python() {
+    local dir="$1"; shift
+    python3 "${COLLECTOR_DIR}/thunderstorm-collector.py" \
+        --server localhost --port "$STUB_PORT" --dir "$dir" \
+        "$@" 2>&1
+}
+
+run_perl() {
+    local dir="$1"; shift
+    perl "${COLLECTOR_DIR}/thunderstorm-collector.pl" \
+        -s localhost -p "$STUB_PORT" --dir "$dir" \
+        "$@" 2>&1
+}
+
+# Translate generic flags (--max-size-kb, --max-age) to PowerShell parameter names
+_translate_ps_args() {
+    local -n out_args=$1; shift
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --max-size-kb) out_args+=("-MaxSize" "$(( $2 / 1024 ))"); shift 2 ;;
+            --max-age)     out_args+=("-MaxAge" "$2"); shift 2 ;;
+            *)             out_args+=("$1"); shift ;;
+        esac
+    done
+}
+
+run_ps3() {
+    local dir="$1"; shift
+    local args=()
+    _translate_ps_args args "$@"
+    pwsh -NoProfile -File "${COLLECTOR_DIR}/thunderstorm-collector.ps1" \
+        -ThunderstormServer localhost -ThunderstormPort "$STUB_PORT" -Folder "$dir" \
+        "${args[@]}" 2>&1
+}
+
+run_ps2() {
+    local dir="$1"; shift
+    local args=()
+    _translate_ps_args args "$@"
+    pwsh -NoProfile -File "${COLLECTOR_DIR}/thunderstorm-collector-ps2.ps1" \
+        -ThunderstormServer localhost -ThunderstormPort "$STUB_PORT" -Folder "$dir" \
+        "${args[@]}" 2>&1
+}
+
+# Small delay after collector to ensure stub has written to log
+sync_stub() {
+    sleep 1
+}
+
+run_collector() {
+    local name="$1"; shift
+    case "$name" in
+        bash)   run_bash "$@" ;;
+        ash)    run_ash "$@" ;;
+        python) run_python "$@" ;;
+        perl)   run_perl "$@" ;;
+        ps3)    run_ps3 "$@" ;;
+        ps2)    run_ps2 "$@" ;;
+    esac
+    sync_stub
+}
+
+# ── Test fixtures ───────────────────────────────────────────────────────────
+
+MALICIOUS_CONTENT="THUNDERSTORM_TEST_MATCH_STRING"
+BENIGN_CONTENT="completely harmless content"
+
+# Create per-collector fixture directories with uniquely named files
+setup_collector_fixtures() {
+    local collector="$1"
+    local base; base="$(mktemp -d /tmp/detection-test-XXXXXX)"
+
+    mkdir -p "$base/malicious"
+    echo "$MALICIOUS_CONTENT" > "$base/malicious/evil-${collector}.exe"
+
+    mkdir -p "$base/benign"
+    echo "$BENIGN_CONTENT" > "$base/benign/clean-${collector}.txt"
+
+    mkdir -p "$base/large"
+    dd if=/dev/zero bs=1024 count=3072 2>/dev/null | tr '\0' 'A' > "$base/large/big-${collector}.tmp"
+    echo "$MALICIOUS_CONTENT" >> "$base/large/big-${collector}.tmp"
+
+    echo "$base"
+}
+
+# ============================================================================
+# TEST CASES
+# ============================================================================
+
+# ── 1. Malicious file detected ─────────────────────────────────────────────
+test_malicious_detected() {
+    local collector="$1"
+    local fixtures="$2"
+    clear_log
+
+    run_collector "$collector" "$fixtures/malicious" --max-age 30 >/dev/null 2>&1 || true
+
+    local entry; entry="$(query_log "evil-${collector}.exe")"
+    if [ -z "$entry" ]; then
+        fail "$collector/malicious-detected: no log entry for evil-${collector}.exe"
+        return
+    fi
+
+    local score; score="$(get_score "$entry")"
+    if [ "$score" -gt 0 ] 2>/dev/null; then
+        pass "$collector/malicious-detected: score=$score"
+    else
+        fail "$collector/malicious-detected: expected score > 0, got $score"
+    fi
+
+    local has_test_rule; has_test_rule="$(has_rule "$entry" "TestRule")"
+    if [ "$has_test_rule" = "yes" ]; then
+        pass "$collector/malicious-rule: TestRule matched"
+    else
+        fail "$collector/malicious-rule: TestRule not found in matches"
+    fi
+}
+
+# ── 2. Benign file — no match ──────────────────────────────────────────────
+test_benign_no_match() {
+    local collector="$1"
+    local fixtures="$2"
+    clear_log
+
+    run_collector "$collector" "$fixtures/benign" --max-age 30 >/dev/null 2>&1 || true
+
+    local entry; entry="$(query_log "clean-${collector}.txt")"
+    # Benign files produce no log entry (not submitted / no YARA match)
+    # This is the expected behavior - no finding = no entry
+    if [ -z "$entry" ]; then
+        pass "$collector/benign-no-match: 0 matches (no log entry = benign)"
+        return
+    fi
+
+    # If there IS an entry, verify it has 0 matches
+    local mc; mc="$(match_count "$entry")"
+    if [ "$mc" -eq 0 ] 2>/dev/null; then
+        pass "$collector/benign-no-match: 0 matches"
+    else
+        fail "$collector/benign-no-match: expected 0 matches, got $mc"
+    fi
+}
+
+# ── 3. Filename IOC match (/tmp/x) ─────────────────────────────────────────
+test_filename_ioc() {
+    local collector="$1"
+    local fixtures="$2"
+    clear_log
+
+    # Create a directory at /tmp/filename-ioc-test with a single file 'x'.
+    # The collector scans this small directory and submits '/tmp/filename-ioc-test/x'.
+    # The filename IOC rule matches /tmp/<single-char> paths, so we also test via
+    # a direct curl upload with the exact path "/tmp/x" to verify the rule fires.
+    local ioc_dir="/tmp/filename-ioc-test-$$"
+    mkdir -p "$ioc_dir"
+    echo "$BENIGN_CONTENT" > "$ioc_dir/testfile"
+
+    # First: submit via the collector to verify the upload works
+    run_collector "$collector" "$ioc_dir" --max-age 30 >/dev/null 2>&1 || true
+
+    # Second: submit the same file directly with filename="/tmp/x" via curl
+    # This is what matters — the full path must trigger the rule
+    curl -s -X POST "${STUB_URL}/api/check?source=filename-ioc-$collector" \
+        -F "file=@${ioc_dir}/testfile;filename=/tmp/x" >/dev/null 2>&1
+
+    local entry; entry="$(query_log "/tmp/x")"
+    if [ -z "$entry" ]; then
+        fail "$collector/filename-ioc: no log entry containing /tmp/x"
+        rm -rf "$ioc_dir"
+        return
+    fi
+
+    local has_ioc; has_ioc="$(has_rule "$entry" "FilenameIOC_Tmp_SingleChar")"
+    if [ "$has_ioc" = "yes" ]; then
+        pass "$collector/filename-ioc: FilenameIOC_Tmp_SingleChar matched on /tmp/x"
+    else
+        fail "$collector/filename-ioc: FilenameIOC_Tmp_SingleChar not found for /tmp/x"
+    fi
+
+    rm -rf "$ioc_dir"
+}
+
+# ── 4. Large malicious file filtered by size → no event ─────────────────────
+test_size_filter_no_event() {
+    local collector="$1"
+    local fixtures="$2"
+    clear_log
+
+    # Set max size to 1 MB / 1024 KB — the large file is ~3 MB
+    run_collector "$collector" "$fixtures/large" --max-age 30 --max-size-kb 1024 >/dev/null 2>&1 || true
+
+    local entry; entry="$(query_log "big-${collector}.tmp")"
+    if [ -z "$entry" ]; then
+        pass "$collector/size-filter-no-event: big-${collector}.tmp correctly filtered (no log entry)"
+    else
+        fail "$collector/size-filter-no-event: big-${collector}.tmp should not appear in log (was uploaded despite size filter)"
+    fi
+}
+
+# ── 4b. Same large malicious file without size filter → detected ────────────
+test_large_malicious_detected() {
+    local collector="$1"
+    local fixtures="$2"
+    clear_log
+
+    # Override size filter to let the ~3 MB file through
+    run_collector "$collector" "$fixtures/large" --max-age 30 --max-size-kb 4096 >/dev/null 2>&1 || true
+
+    local entry; entry="$(query_log "big-${collector}.tmp")"
+    if [ -z "$entry" ]; then
+        fail "$collector/large-malicious-detected: no log entry for big-${collector}.tmp"
+        return
+    fi
+
+    local score; score="$(get_score "$entry")"
+    if [ "$score" -gt 0 ] 2>/dev/null; then
+        pass "$collector/large-malicious-detected: score=$score (detected without size filter)"
+    else
+        fail "$collector/large-malicious-detected: expected score > 0, got $score"
+    fi
+}
+
+# ── 5. Full path preserved in log ──────────────────────────────────────────
+test_full_path_in_log() {
+    local collector="$1"
+    local fixtures="$2"
+    clear_log
+
+    run_collector "$collector" "$fixtures/malicious" --max-age 30 >/dev/null 2>&1 || true
+
+    local entry; entry="$(query_log "evil-${collector}.exe")"
+    if [ -z "$entry" ]; then
+        fail "$collector/full-path: no log entry for evil-${collector}.exe"
+        return
+    fi
+
+    local cf; cf="$(log_field "$entry" "subject.client_filename")"
+
+    # Must contain the full path, not just the basename
+    if echo "$cf" | grep -q "/malicious/evil-${collector}.exe$"; then
+        pass "$collector/full-path: client_filename=$cf"
+    else
+        fail "$collector/full-path: expected full path ending in /malicious/evil-${collector}.exe, got '$cf'"
+    fi
+}
+
+# ── 8. Directory scope — only scans target directory ────────────────────────
+# Verifies that scanning /target does NOT pick up files from /decoy
+test_directory_scope() {
+    local collector="$1"
+    clear_log
+    local fixtures; fixtures="$(mktemp -d /tmp/detection-test-XXXXXX)"
+
+    # Create two sibling directories: target and decoy
+    mkdir -p "$fixtures/target" "$fixtures/decoy"
+    echo "$MALICIOUS_CONTENT" > "$fixtures/target/in-scope-${collector}.exe"
+    echo "$MALICIOUS_CONTENT" > "$fixtures/decoy/out-of-scope-${collector}.exe"
+
+    # Scan ONLY the target directory
+    run_collector "$collector" "$fixtures/target" --max-age 30 >/dev/null 2>&1 || true
+
+    # The in-scope file MUST be in the log
+    local in_entry; in_entry="$(query_log "in-scope-${collector}.exe")"
+    if [ -z "$in_entry" ]; then
+        fail "$collector/dir-scope: in-scope file not found in log"
+        rm -rf "$fixtures"
+        return
+    fi
+
+    # The out-of-scope file MUST NOT be in the log
+    local out_entry; out_entry="$(query_log "out-of-scope-${collector}.exe")"
+    if [ -n "$out_entry" ]; then
+        fail "$collector/dir-scope: out-of-scope file WAS submitted (directory escape!)"
+    else
+        pass "$collector/dir-scope: only target directory scanned"
+    fi
+
+    rm -rf "$fixtures"
+}
+
+# ── 9. Age filter — old files must not be collected ─────────────────────────
+# Creates a recent file and an old file (backdated via touch -t),
+# scans with --max-age 1, and verifies only the recent file is submitted.
+test_age_filter() {
+    local collector="$1"
+    clear_log
+    local fixtures; fixtures="$(mktemp -d /tmp/detection-test-XXXXXX)"
+
+    mkdir -p "$fixtures/aged"
+
+    # Recent file (now) — should be submitted
+    echo "$MALICIOUS_CONTENT" > "$fixtures/aged/recent-${collector}.exe"
+
+    # Old file (60 days ago) — should NOT be submitted with --max-age 1
+    echo "$MALICIOUS_CONTENT" > "$fixtures/aged/old-${collector}.exe"
+    touch -t "$(date -d '60 days ago' '+%Y%m%d%H%M.%S')" "$fixtures/aged/old-${collector}.exe"
+
+    # Verify the timestomping worked
+    local old_mtime; old_mtime="$(stat -c %Y "$fixtures/aged/old-${collector}.exe")"
+    local now; now="$(date +%s)"
+    local age_days=$(( (now - old_mtime) / 86400 ))
+    if [ "$age_days" -lt 30 ]; then
+        skip "$collector/age-filter: timestomping failed (age=$age_days days, expected >= 60)"
+        rm -rf "$fixtures"
+        return
+    fi
+
+    # Scan with --max-age 1 (only files modified in the last day)
+    run_collector "$collector" "$fixtures/aged" --max-age 1 >/dev/null 2>&1 || true
+
+    # Recent file MUST be in the log
+    local recent_entry; recent_entry="$(query_log "recent-${collector}.exe")"
+    if [ -z "$recent_entry" ]; then
+        fail "$collector/age-filter: recent file not found in log"
+        rm -rf "$fixtures"
+        return
+    fi
+
+    # Old file MUST NOT be in the log
+    local old_entry; old_entry="$(query_log "old-${collector}.exe")"
+    if [ -n "$old_entry" ]; then
+        fail "$collector/age-filter: old file (60d ago) WAS submitted despite --max-age 1"
+    else
+        pass "$collector/age-filter: old file correctly skipped (--max-age 1)"
+    fi
+
+    rm -rf "$fixtures"
+}
+
+# ── 10. Extension filter (PS only) — unknown extensions not submitted ───────
+# PowerShell collectors have a default extension whitelist.
+# Files with exotic extensions (.xyz) should NOT be submitted.
+test_extension_filter() {
+    local collector="$1"
+    clear_log
+
+    # Only applies to PowerShell collectors
+    case "$collector" in
+        ps3|ps2) ;;
+        *)
+            skip "$collector/ext-filter: N/A (no extension filter)"
+            return ;;
+    esac
+
+    local fixtures; fixtures="$(mktemp -d /tmp/detection-test-XXXXXX)"
+    mkdir -p "$fixtures/exttest"
+
+    # File with a known extension — should be submitted
+    echo "$MALICIOUS_CONTENT" > "$fixtures/exttest/known-${collector}.exe"
+
+    # File with an exotic extension — should NOT be submitted
+    echo "$MALICIOUS_CONTENT" > "$fixtures/exttest/exotic-${collector}.xyz"
+
+    run_collector "$collector" "$fixtures/exttest" --max-age 30 >/dev/null 2>&1 || true
+
+    # Known extension file MUST be in log
+    local known_entry; known_entry="$(query_log "known-${collector}.exe")"
+    if [ -z "$known_entry" ]; then
+        fail "$collector/ext-filter: .exe file not found in log"
+        rm -rf "$fixtures"
+        return
+    fi
+
+    # Exotic extension file MUST NOT be in log
+    local exotic_entry; exotic_entry="$(query_log "exotic-${collector}.xyz")"
+    if [ -n "$exotic_entry" ]; then
+        fail "$collector/ext-filter: .xyz file WAS submitted (should be filtered by extension)"
+    else
+        pass "$collector/ext-filter: .xyz file correctly filtered"
+    fi
+
+    rm -rf "$fixtures"
+}
+
+# ── 11. Subdirectory recursion — files in subdirectories are found ──────────
+# Verifies that the collector descends into subdirectories.
+test_subdirectory_recursion() {
+    local collector="$1"
+    clear_log
+    local fixtures; fixtures="$(mktemp -d /tmp/detection-test-XXXXXX)"
+
+    mkdir -p "$fixtures/root/sub1/sub2"
+    echo "$MALICIOUS_CONTENT" > "$fixtures/root/top-${collector}.exe"
+    echo "$MALICIOUS_CONTENT" > "$fixtures/root/sub1/mid-${collector}.exe"
+    echo "$MALICIOUS_CONTENT" > "$fixtures/root/sub1/sub2/deep-${collector}.exe"
+
+    run_collector "$collector" "$fixtures/root" --max-age 30 >/dev/null 2>&1 || true
+
+    local top; top="$(query_log "top-${collector}.exe")"
+    local mid; mid="$(query_log "mid-${collector}.exe")"
+    local deep; deep="$(query_log "deep-${collector}.exe")"
+
+    if [ -n "$top" ] && [ -n "$mid" ] && [ -n "$deep" ]; then
+        pass "$collector/subdir-recursion: files found at all 3 levels"
+    else
+        local missing=""
+        [ -z "$top" ] && missing="$missing top"
+        [ -z "$mid" ] && missing="$missing mid"
+        [ -z "$deep" ] && missing="$missing deep"
+        fail "$collector/subdir-recursion: missing files:$missing"
+    fi
+
+    rm -rf "$fixtures"
+}
+
+# ── 12. Empty files — should be submitted but produce no YARA match ─────────
+test_empty_file() {
+    local collector="$1"
+    clear_log
+    local fixtures; fixtures="$(mktemp -d /tmp/detection-test-XXXXXX)"
+
+    mkdir -p "$fixtures/empty"
+    : > "$fixtures/empty/empty-${collector}.exe"   # 0 bytes
+
+    run_collector "$collector" "$fixtures/empty" --max-age 30 >/dev/null 2>&1 || true
+
+    # Empty files: some collectors may skip 0-byte files, others may submit them.
+    # Either way, they must NOT crash and must NOT produce a false positive.
+    local entry; entry="$(query_log "empty-${collector}.exe")"
+    if [ -n "$entry" ]; then
+        local score; score="$(get_score "$entry")"
+        # Empty files may score > 0 due to filename IOC rules (e.g. path in /tmp).
+        # That's not a content-based false positive — it's correct filename matching.
+        # Verify no CONTENT-based rule matched (TestRule should NOT match empty files).
+        local has_test_rule; has_test_rule="$(has_rule "$entry" "TestRule")"
+        if [ "$has_test_rule" = "yes" ]; then
+            fail "$collector/empty-file: TestRule matched empty file (content false positive!)"
+        else
+            pass "$collector/empty-file: submitted, score=$score (no content match)"
+        fi
+    else
+        pass "$collector/empty-file: empty file skipped (acceptable behavior)"
+    fi
+
+    rm -rf "$fixtures"
+}
+
+# ── 13. Unicode filenames — must not crash or corrupt the path ──────────────
+test_unicode_filename() {
+    local collector="$1"
+    clear_log
+    local fixtures; fixtures="$(mktemp -d /tmp/detection-test-XXXXXX)"
+
+    mkdir -p "$fixtures/unicode"
+    # File with Unicode chars in name
+    echo "$MALICIOUS_CONTENT" > "$fixtures/unicode/données-${collector}.exe"
+
+    run_collector "$collector" "$fixtures/unicode" --max-age 30 >/dev/null 2>&1 || true
+
+    local entry; entry="$(query_log "données-${collector}.exe")"
+    if [ -n "$entry" ]; then
+        local score; score="$(get_score "$entry")"
+        if [ "$score" -gt 0 ] 2>/dev/null; then
+            pass "$collector/unicode-filename: detected with score=$score"
+        else
+            pass "$collector/unicode-filename: submitted (score=$score)"
+        fi
+    else
+        # Some collectors may not handle Unicode — acceptable to skip
+        skip "$collector/unicode-filename: file not submitted (Unicode handling varies)"
+    fi
+
+    rm -rf "$fixtures"
+}
+
+# ── 14. Symlinks — must NOT follow symlinks (security) ──────────────────────
+# A symlink inside the scan directory pointing to a file outside should NOT
+# be followed, as it could be used to exfiltrate data or escape the scan scope.
+test_symlink_not_followed() {
+    local collector="$1"
+    clear_log
+    local fixtures; fixtures="$(mktemp -d /tmp/detection-test-XXXXXX)"
+
+    mkdir -p "$fixtures/scandir" "$fixtures/outside"
+    echo "$MALICIOUS_CONTENT" > "$fixtures/outside/secret-${collector}.exe"
+
+    # Create a real file in the scan dir (control)
+    echo "$MALICIOUS_CONTENT" > "$fixtures/scandir/real-${collector}.exe"
+
+    # Create a symlink in the scan dir pointing to the file outside
+    ln -s "$fixtures/outside/secret-${collector}.exe" "$fixtures/scandir/link-${collector}.exe"
+
+    run_collector "$collector" "$fixtures/scandir" --max-age 30 >/dev/null 2>&1 || true
+
+    # Real file MUST be submitted
+    local real_entry; real_entry="$(query_log "real-${collector}.exe")"
+    if [ -z "$real_entry" ]; then
+        fail "$collector/symlink: real file not found in log"
+        rm -rf "$fixtures"
+        return
+    fi
+
+    # Symlinked file MUST NOT be submitted
+    local link_entry; link_entry="$(query_log "secret-${collector}.exe")"
+    local link_entry2; link_entry2="$(query_log "link-${collector}.exe")"
+    if [ -n "$link_entry" ] || [ -n "$link_entry2" ]; then
+        fail "$collector/symlink: symlinked file WAS followed (security risk!)"
+    else
+        pass "$collector/symlink: symlinks correctly skipped"
+    fi
+
+    rm -rf "$fixtures"
+}
+
+# ── 15. Broken symlinks — must not crash ────────────────────────────────────
+test_broken_symlink() {
+    local collector="$1"
+    clear_log
+    local fixtures; fixtures="$(mktemp -d /tmp/detection-test-XXXXXX)"
+
+    mkdir -p "$fixtures/broken"
+    echo "$MALICIOUS_CONTENT" > "$fixtures/broken/real-${collector}.exe"
+
+    # Create a dangling symlink (target doesn't exist)
+    ln -s "/nonexistent/file-${collector}.exe" "$fixtures/broken/dangling-${collector}.exe"
+
+    # Must not crash
+    run_collector "$collector" "$fixtures/broken" --max-age 30 >/dev/null 2>&1 || true
+
+    # Real file should still be processed
+    local entry; entry="$(query_log "real-${collector}.exe")"
+    if [ -n "$entry" ]; then
+        pass "$collector/broken-symlink: collector survived dangling symlink"
+    else
+        fail "$collector/broken-symlink: real file not found (collector may have crashed)"
+    fi
+
+    rm -rf "$fixtures"
+}
+
+# ── 16. Special characters in filenames ─────────────────────────────────────
+# Spaces, quotes, and other shell-sensitive characters must not break the collector.
+test_special_chars_filename() {
+    local collector="$1"
+    clear_log
+    local fixtures; fixtures="$(mktemp -d /tmp/detection-test-XXXXXX)"
+
+    mkdir -p "$fixtures/special"
+    # File with spaces
+    echo "$MALICIOUS_CONTENT" > "$fixtures/special/has spaces-${collector}.exe"
+    # File with parentheses
+    echo "$MALICIOUS_CONTENT" > "$fixtures/special/parens(1)-${collector}.exe"
+
+    run_collector "$collector" "$fixtures/special" --max-age 30 >/dev/null 2>&1 || true
+
+    local space_entry; space_entry="$(query_log "has spaces-${collector}.exe")"
+    local paren_entry; paren_entry="$(query_log "parens(1)-${collector}.exe")"
+
+    local found=0
+    [ -n "$space_entry" ] && found=$((found + 1))
+    [ -n "$paren_entry" ] && found=$((found + 1))
+
+    if [ "$found" -eq 2 ]; then
+        pass "$collector/special-chars: spaces and parens handled ($found/2 found)"
+    elif [ "$found" -gt 0 ]; then
+        pass "$collector/special-chars: partial handling ($found/2 found)"
+    else
+        fail "$collector/special-chars: no files with special chars submitted"
+    fi
+
+    rm -rf "$fixtures"
+}
+
+# ── 17. Hard folder exclusions — /proc, /sys, /dev must be skipped ──────────
+# We can't actually scan /proc etc. in tests, but we can create directories
+# NAMED like excluded paths inside our test tree and verify they're skipped.
+# NOTE: This test only applies to collectors that check basename matches.
+# Most collectors use absolute path prefix matching, so /tmp/test/proc/ won't
+# trigger the exclusion. This test verifies the collector doesn't crash when
+# scanning a directory tree with suspicious-looking names.
+test_excluded_dirs_survive() {
+    local collector="$1"
+    clear_log
+    local fixtures; fixtures="$(mktemp -d /tmp/detection-test-XXXXXX)"
+
+    # Create a tree with directories named after excluded paths
+    mkdir -p "$fixtures/scanme/proc" "$fixtures/scanme/dev" "$fixtures/scanme/normal"
+    echo "$MALICIOUS_CONTENT" > "$fixtures/scanme/proc/inside-proc-${collector}.exe"
+    echo "$MALICIOUS_CONTENT" > "$fixtures/scanme/dev/inside-dev-${collector}.exe"
+    echo "$MALICIOUS_CONTENT" > "$fixtures/scanme/normal/legit-${collector}.exe"
+
+    run_collector "$collector" "$fixtures/scanme" --max-age 30 >/dev/null 2>&1 || true
+
+    # The "normal" file MUST be found (prove collector ran)
+    local legit; legit="$(query_log "legit-${collector}.exe")"
+    if [ -z "$legit" ]; then
+        fail "$collector/excluded-dirs: legit file not found (collector may have crashed)"
+        rm -rf "$fixtures"
+        return
+    fi
+
+    # Files inside "proc" and "dev" subdirs: we don't assert either way,
+    # since hard exclusions are typically for absolute paths (/proc, /dev).
+    # The point is the collector survives and processes other files.
+    pass "$collector/excluded-dirs: collector survived dirs named proc/dev"
+
+    rm -rf "$fixtures"
+}
+
+# ── 18. No-permission files — must not crash ───────────────────────────────
+test_unreadable_file() {
+    local collector="$1"
+    clear_log
+    local fixtures; fixtures="$(mktemp -d /tmp/detection-test-XXXXXX)"
+
+    mkdir -p "$fixtures/perms"
+    echo "$MALICIOUS_CONTENT" > "$fixtures/perms/readable-${collector}.exe"
+    echo "$MALICIOUS_CONTENT" > "$fixtures/perms/unreadable-${collector}.exe"
+    chmod 000 "$fixtures/perms/unreadable-${collector}.exe"
+
+    run_collector "$collector" "$fixtures/perms" --max-age 30 >/dev/null 2>&1 || true
+
+    # Readable file should still be processed
+    local entry; entry="$(query_log "readable-${collector}.exe")"
+    if [ -n "$entry" ]; then
+        pass "$collector/unreadable-file: collector survived unreadable file"
+    else
+        fail "$collector/unreadable-file: readable file not found (collector may have crashed)"
+    fi
+
+    # Cleanup (restore perms so rm works)
+    chmod 644 "$fixtures/perms/unreadable-${collector}.exe" 2>/dev/null
+    rm -rf "$fixtures"
+}
+
+# ── 19. Server unavailable then recovery — retry must succeed ───────────────
+# Start the collector against a dead port, then start the stub mid-run.
+# The collector should retry and eventually succeed.
+test_retry_on_late_server() {
+    local collector="$1"
+    clear_log
+
+    local fixtures; fixtures="$(mktemp -d /tmp/detection-test-XXXXXX)"
+    mkdir -p "$fixtures/retry"
+    echo "$MALICIOUS_CONTENT" > "$fixtures/retry/retry-${collector}.exe"
+
+    # Use a unique port per collector so concurrent cleanup doesn't conflict
+    local retry_port
+    case "$collector" in
+        bash)   retry_port=18101 ;;
+        ash)    retry_port=18102 ;;
+        python) retry_port=18103 ;;
+        perl)   retry_port=18104 ;;
+        ps3)    retry_port=18105 ;;
+        ps2)    retry_port=18106 ;;
+    esac
+    local retry_log; retry_log="$(mktemp /tmp/retry-stub-XXXXXX.jsonl)"
+
+    # Start the collector against the dead port (it will retry)
+    local collector_out; collector_out="$(mktemp /tmp/collector-out-XXXXXX.txt)"
+
+    # Start the stub server FIRST on the retry port, but with a delayed start.
+    # We use a wrapper that waits 2 seconds before launching the stub.
+    local stub_bin="${STUB_BIN:-/home/neo/.openclaw/workspace/projects/thunderstorm-stub-server/thunderstorm-stub}"
+    local stub_rules="${STUB_RULES_DIR:-/home/neo/.openclaw/workspace/projects/thunderstorm-stub-server/rules}"
+
+    # Launch delayed stub in background.
+    # All collectors send a begin marker with a single retry after 2s on failure.
+    # Connection refused is instant, so: attempt 1 at ~0s, sleep 2s, attempt 2 at ~2s.
+    # The stub takes ~0.5-1s to load YARA rules and bind, so we must start it
+    # early enough that it's listening before the 2nd begin marker attempt.
+    # Starting at 0.3s gives the stub ~1.7s to initialize before t=2s.
+    ( sleep 0.3 && "$stub_bin" -port "$retry_port" -rules-dir "$stub_rules" -log-file "$retry_log" ) \
+        > /dev/null 2>&1 &
+    local stub_pid=$!
+
+    # Run the collector synchronously — it will fail first, then succeed on retry.
+    # --retries 5 gives enough attempts for the stub to come up after 2s delay.
+    case "$collector" in
+        bash)
+            timeout 30 bash "${COLLECTOR_DIR}/thunderstorm-collector.sh" \
+                --server localhost --port "$retry_port" --dir "$fixtures/retry" \
+                --max-age 30 --retries 5 > "$collector_out" 2>&1 || true
+            ;;
+        ash)
+            # shellcheck disable=SC2086
+            timeout 30 $ASH_SHELL "${COLLECTOR_DIR}/thunderstorm-collector-ash.sh" \
+                --server localhost --port "$retry_port" --dir "$fixtures/retry" \
+                --max-age 30 --retries 5 > "$collector_out" 2>&1 || true
+            ;;
+        python)
+            timeout 30 python3 "${COLLECTOR_DIR}/thunderstorm-collector.py" \
+                --server localhost --port "$retry_port" --dir "$fixtures/retry" \
+                --max-age 30 --retries 5 > "$collector_out" 2>&1 || true
+            ;;
+        perl)
+            timeout 30 perl "${COLLECTOR_DIR}/thunderstorm-collector.pl" \
+                -s localhost -p "$retry_port" --dir "$fixtures/retry" \
+                --max-age 30 --retries 5 > "$collector_out" 2>&1 || true
+            ;;
+        ps3)
+            timeout 30 pwsh -NoProfile -File "${COLLECTOR_DIR}/thunderstorm-collector.ps1" \
+                -ThunderstormServer localhost -ThunderstormPort "$retry_port" -Folder "$fixtures/retry" \
+                -MaxAge 30 > "$collector_out" 2>&1 || true
+            ;;
+        ps2)
+            timeout 30 pwsh -NoProfile -File "${COLLECTOR_DIR}/thunderstorm-collector-ps2.ps1" \
+                -ThunderstormServer localhost -ThunderstormPort "$retry_port" -Folder "$fixtures/retry" \
+                -MaxAge 30 > "$collector_out" 2>&1 || true
+            ;;
+    esac
+
+    # Check if the file was eventually submitted
+    local entry=""
+    if [ -f "$retry_log" ]; then
+        entry="$(python3 -c "
+import json, sys
+for line in open('$retry_log'):
+    line = line.strip()
+    if not line: continue
+    d = json.loads(line)
+    cf = d.get('subject', {}).get('client_filename', '')
+    if 'retry-${collector}' in cf:
+        print(line)
+        break
+" 2>/dev/null)"
+    fi
+
+    if [ -n "$entry" ]; then
+        local score; score="$(get_score "$entry")"
+        pass "$collector/retry-recovery: file submitted after server came up (score=$score)"
+    else
+        # Check if the collector even attempted retries
+        if grep -qi 'retry\|attempt\|retrying\|failed.*attempt' "$collector_out" 2>/dev/null; then
+            fail "$collector/retry-recovery: retried but file never submitted"
+        else
+            fail "$collector/retry-recovery: no retry attempt detected"
+        fi
+    fi
+
+    # Cleanup: kill the delayed stub
+    kill "$stub_pid" 2>/dev/null
+    wait "$stub_pid" 2>/dev/null || true
+    rm -rf "$fixtures" "$retry_log" "$collector_out"
+}
+
+# ── 20. Server returns errors — collector must not crash ────────────────────
+# Submit to a port where nothing listens (connection refused).
+# The collector must exit gracefully, not crash.
+test_server_unreachable() {
+    local collector="$1"
+    clear_log
+
+    local fixtures; fixtures="$(mktemp -d /tmp/detection-test-XXXXXX)"
+    mkdir -p "$fixtures/unreachable"
+    echo "$MALICIOUS_CONTENT" > "$fixtures/unreachable/orphan-${collector}.exe"
+
+    # Port 18099 has nothing listening — all uploads will fail
+    local dead_port=18099
+    local collector_out; collector_out="$(mktemp /tmp/collector-out-XXXXXX.txt)"
+
+    # Run with minimal retries to avoid long wait.
+    # Use timeout to kill collectors that hang; || true to prevent set -e from aborting.
+    local exit_code=0
+    case "$collector" in
+        bash)
+            timeout 20 bash "${COLLECTOR_DIR}/thunderstorm-collector.sh" \
+                --server localhost --port "$dead_port" --dir "$fixtures/unreachable" \
+                --max-age 30 --retries 1 > "$collector_out" 2>&1 || exit_code=$?
+            ;;
+        ash)
+            # shellcheck disable=SC2086
+            timeout 20 $ASH_SHELL "${COLLECTOR_DIR}/thunderstorm-collector-ash.sh" \
+                --server localhost --port "$dead_port" --dir "$fixtures/unreachable" \
+                --max-age 30 --retries 1 > "$collector_out" 2>&1 || exit_code=$?
+            ;;
+        python)
+            timeout 20 python3 "${COLLECTOR_DIR}/thunderstorm-collector.py" \
+                --server localhost --port "$dead_port" --dir "$fixtures/unreachable" \
+                --max-age 30 --retries 1 > "$collector_out" 2>&1 || exit_code=$?
+            ;;
+        perl)
+            timeout 20 perl "${COLLECTOR_DIR}/thunderstorm-collector.pl" \
+                -s localhost -p "$dead_port" --dir "$fixtures/unreachable" \
+                --max-age 30 --retries 1 > "$collector_out" 2>&1 || exit_code=$?
+            ;;
+        ps3)
+            timeout 20 pwsh -NoProfile -File "${COLLECTOR_DIR}/thunderstorm-collector.ps1" \
+                -ThunderstormServer localhost -ThunderstormPort "$dead_port" -Folder "$fixtures/unreachable" \
+                -MaxAge 30 > "$collector_out" 2>&1 || exit_code=$?
+            ;;
+        ps2)
+            timeout 20 pwsh -NoProfile -File "${COLLECTOR_DIR}/thunderstorm-collector-ps2.ps1" \
+                -ThunderstormServer localhost -ThunderstormPort "$dead_port" -Folder "$fixtures/unreachable" \
+                -MaxAge 30 > "$collector_out" 2>&1 || exit_code=$?
+            ;;
+    esac
+
+    # The collector should exit (not hang forever) and not crash with a traceback
+    if [ "$exit_code" -eq 124 ]; then
+        fail "$collector/server-unreachable: collector hung (killed by timeout)"
+    elif grep -qi 'traceback\|panic\|segfault\|core dump' "$collector_out" 2>/dev/null; then
+        fail "$collector/server-unreachable: collector crashed"
+    else
+        # Verify it reported the failure somehow
+        if grep -qi 'fail\|error\|could not\|unable\|refused' "$collector_out" 2>/dev/null; then
+            pass "$collector/server-unreachable: exited gracefully with error message"
+        else
+            pass "$collector/server-unreachable: exited without crash (exit=$exit_code)"
+        fi
+    fi
+
+    rm -rf "$fixtures" "$collector_out"
+}
+
+# ============================================================================
+# MAIN
+# ============================================================================
+
+LOG_OFFSET=0
+
+echo ""
+echo "${BOLD}Detection & Path Verification Tests${RESET}"
+echo "============================================"
+
+# Check which collectors are available
+available_collectors=()
+if collector_enabled bash && collector_runnable bash; then
+    available_collectors+=("bash")
+fi
+if collector_enabled ash && collector_runnable ash; then
+    available_collectors+=("ash")
+fi
+if collector_enabled python && collector_runnable python; then
+    available_collectors+=("python")
+fi
+if collector_enabled perl && collector_runnable perl; then
+    available_collectors+=("perl")
+fi
+if collector_enabled ps3 && collector_runnable ps3; then
+    available_collectors+=("ps3")
+fi
+if collector_enabled ps2 && collector_runnable ps2; then
+    available_collectors+=("ps2")
+fi
+
+if [ "${#available_collectors[@]}" -gt 0 ]; then
+    validate_available_collectors "${available_collectors[@]}"
+else
+    validate_available_collectors
+fi
+
+if [ "${#available_collectors[@]}" -eq 0 ]; then
+    echo "Available collectors: none"
+    echo "No runnable collectors selected; nothing to do."
+    exit 0
+fi
+
+echo "Available collectors: ${available_collectors[*]}"
+echo ""
+
+# If STUB_LOG is already set and the stub is already running, skip starting one
+if [ -n "$STUB_LOG" ] && curl -s "${STUB_URL}/api/info" >/dev/null 2>&1; then
+    echo "Using external stub server on port $STUB_PORT (log=$STUB_LOG)"
+else
+    # Pre-flight checks
+    if [ -z "$STUB_BIN" ]; then
+        echo "ERROR: thunderstorm-stub binary not found." >&2
+        echo "Set STUB_BIN_PATH or build with: go build -tags yara -o thunderstorm-stub ." >&2
+        exit 1
+    fi
+
+    # Start the stub server
+    start_stub
+    echo "Stub server: pid=$STUB_PID log=$STUB_LOG"
+fi
+
+for collector in "${available_collectors[@]}"; do
+    printf "\n${CYAN}── %s ──${RESET}\n" "$collector"
+
+    # Create unique fixtures for this collector
+    FIXTURES="$(setup_collector_fixtures "$collector")"
+
+    test_malicious_detected "$collector" "$FIXTURES"
+    test_benign_no_match "$collector" "$FIXTURES"
+    test_filename_ioc "$collector" "$FIXTURES"
+    test_size_filter_no_event "$collector" "$FIXTURES"
+    test_large_malicious_detected "$collector" "$FIXTURES"
+    test_full_path_in_log "$collector" "$FIXTURES"
+    test_directory_scope "$collector"
+    test_age_filter "$collector"
+    test_extension_filter "$collector"
+    test_subdirectory_recursion "$collector"
+    test_empty_file "$collector"
+    test_unicode_filename "$collector"
+    test_symlink_not_followed "$collector"
+    test_broken_symlink "$collector"
+    test_special_chars_filename "$collector"
+    test_excluded_dirs_survive "$collector"
+    test_unreadable_file "$collector"
+    test_server_unreachable "$collector"
+    test_retry_on_late_server "$collector"
+
+    rm -rf "$FIXTURES" /tmp/x 2>/dev/null
+done
+
+stop_stub
+
+echo ""
+echo "============================================"
+printf " Results: ${GREEN}%d passed${RESET}, ${RED}%d failed${RESET}, ${YELLOW}%d skipped${RESET}\n" \
+    "$TESTS_PASSED" "$TESTS_FAILED" "$TESTS_SKIPPED"
+echo "============================================"
+
+if [ -n "$FAILED_NAMES" ]; then
+    printf "\nFailed tests:\n$FAILED_NAMES\n"
+fi
+
+[ "$TESTS_FAILED" -eq 0 ]

--- a/scripts/tests/run_e2e_compliance.sh
+++ b/scripts/tests/run_e2e_compliance.sh
@@ -111,11 +111,42 @@ collector_script_path() {
     esac
 }
 
+collector_has_flags() {
+    local script_path="$1" flag
+    shift
+    for flag in "$@"; do
+        grep -q -- "$flag" "$script_path" || return 1
+    done
+}
+
+collector_supports_shared_harness() {
+    local current script_path
+    current="$(normalize_collector "$1")"
+    script_path="$(collector_script_path "$current")" || return 1
+
+    case "$current" in
+        bash|ash)
+            collector_has_flags "$script_path" --server --port --dir --max-age --source --dry-run
+            ;;
+        python3|python2)
+            collector_has_flags "$script_path" --server --port --dirs --max-age --source --dry-run
+            ;;
+        perl)
+            collector_has_flags "$script_path" --server --port --dir --max-age --source --dry-run
+            ;;
+        ps3|ps2)
+            collector_has_flags "$script_path" ThunderstormServer ThunderstormPort Folder Source MaxAge MaxSize AllExtensions
+            ;;
+        *) return 1 ;;
+    esac
+}
+
 collector_runnable() {
     local current script_path
     current="$(normalize_collector "$1")"
     script_path="$(collector_script_path "$current")" || return 1
     [ -f "$script_path" ] || return 1
+    collector_supports_shared_harness "$current" || return 1
 
     case "$current" in
         bash) command -v bash >/dev/null 2>&1 ;;

--- a/scripts/tests/run_e2e_compliance.sh
+++ b/scripts/tests/run_e2e_compliance.sh
@@ -452,7 +452,7 @@ start_stub "$STUB_BIN"
 create_fixtures
 
 # Bash
-if collector_runnable bash; then
+if collector_enabled bash && collector_runnable bash; then
     run_tests "bash" bash "$SCRIPTS_DIR/thunderstorm-collector.sh" \
         --server 127.0.0.1 --port "$STUB_PORT" --dir "$FIXTURES" --max-age 365 --quiet
     run_dry_run_test "bash" bash "$SCRIPTS_DIR/thunderstorm-collector.sh" \
@@ -460,7 +460,7 @@ if collector_runnable bash; then
 fi
 
 # Ash / POSIX sh
-if collector_runnable ash; then
+if collector_enabled ash && collector_runnable ash; then
     # Intentionally rely on shell word splitting so "busybox sh" works.
     # shellcheck disable=SC2086
     run_tests "ash (${ASH_SHELL##*/})" $ASH_SHELL "$SCRIPTS_DIR/thunderstorm-collector-ash.sh" \
@@ -473,7 +473,7 @@ elif collector_enabled ash; then
 fi
 
 # Python 3
-if collector_runnable python3; then
+if collector_enabled python3 && collector_runnable python3; then
     run_tests "python3" python3 "$SCRIPTS_DIR/thunderstorm-collector.py" \
         -s 127.0.0.1 -p "$STUB_PORT" -d "$FIXTURES" --max-age 365
     run_dry_run_test "python3" python3 "$SCRIPTS_DIR/thunderstorm-collector.py" \
@@ -483,7 +483,7 @@ elif collector_enabled python3; then
 fi
 
 # Python 2
-if collector_runnable python2; then
+if collector_enabled python2 && collector_runnable python2; then
     run_tests "python2" python2 "$SCRIPTS_DIR/thunderstorm-collector-py2.py" \
         -s 127.0.0.1 -p "$STUB_PORT" -d "$FIXTURES" --max-age 365
     run_dry_run_test "python2" python2 "$SCRIPTS_DIR/thunderstorm-collector-py2.py" \
@@ -493,7 +493,7 @@ elif collector_enabled python2; then
 fi
 
 # Perl
-if collector_runnable perl; then
+if collector_enabled perl && collector_runnable perl; then
     run_tests "perl" perl "$SCRIPTS_DIR/thunderstorm-collector.pl" \
         -s 127.0.0.1 --port "$STUB_PORT" --dir "$FIXTURES" --max-age 365
     run_dry_run_test "perl" perl "$SCRIPTS_DIR/thunderstorm-collector.pl" \
@@ -503,14 +503,14 @@ elif collector_enabled perl; then
 fi
 
 # PowerShell 3+
-if collector_runnable ps3; then
+if collector_enabled ps3 && collector_runnable ps3; then
     run_tests_ps "powershell3+" "$SCRIPTS_DIR/thunderstorm-collector.ps1"
 elif collector_enabled ps3; then
     section "powershell3+"; skip "pwsh not available"
 fi
 
 # PowerShell 2+
-if collector_runnable ps2; then
+if collector_enabled ps2 && collector_runnable ps2; then
     run_tests_ps "powershell2+" "$SCRIPTS_DIR/thunderstorm-collector-ps2.ps1"
 elif collector_enabled ps2; then
     section "powershell2+"; skip "pwsh not available"

--- a/scripts/tests/run_e2e_compliance.sh
+++ b/scripts/tests/run_e2e_compliance.sh
@@ -187,9 +187,11 @@ validate_available_collectors() {
 find_stub() {
     if [ -n "${1:-}" ] && [ -x "$1" ]; then echo "$1"; return 0; fi
     if [ -n "${STUB_SERVER_BIN:-}" ] && [ -x "$STUB_SERVER_BIN" ]; then echo "$STUB_SERVER_BIN"; return 0; fi
-    local sibling="$SCRIPTS_DIR/../../thunderstorm-stub-server/thunderstorm-stub-server"
-    if [ -x "$sibling" ]; then echo "$sibling"; return 0; fi
     for p in \
+        "$SCRIPTS_DIR/../thunderstorm-stub-server/thunderstorm-stub-server" \
+        "$SCRIPTS_DIR/../thunderstorm-stub-server/thunderstorm-stub" \
+        "$SCRIPTS_DIR/../../thunderstorm-stub-server/thunderstorm-stub-server" \
+        "$SCRIPTS_DIR/../../thunderstorm-stub-server/thunderstorm-stub" \
         "$HOME/.openclaw/workspace/projects/thunderstorm-stub-server/thunderstorm-stub-server" \
         "$HOME/thunderstorm-stub-server/thunderstorm-stub-server"; do
         if [ -x "$p" ]; then echo "$p"; return 0; fi
@@ -198,8 +200,16 @@ find_stub() {
     return 1
 }
 
+kill_port_listener() {
+    command -v lsof >/dev/null 2>&1 || return 0
+    local pid
+    for pid in $(lsof -tiTCP:"$STUB_PORT" -sTCP:LISTEN 2>/dev/null || true); do
+        [ -n "$pid" ] && kill "$pid" 2>/dev/null || true
+    done
+}
+
 start_stub() {
-    pkill -f "stub-server.*$STUB_PORT" 2>/dev/null || true
+    kill_port_listener
     sleep 1
     rm -f "$STUB_LOG"
     "$1" -port "$STUB_PORT" -log-file "$STUB_LOG" &

--- a/scripts/tests/run_e2e_compliance.sh
+++ b/scripts/tests/run_e2e_compliance.sh
@@ -1,0 +1,551 @@
+#!/usr/bin/env bash
+#
+# End-to-End Compliance Tests for Thunderstorm Collector Scripts
+#
+# Verifies that each collector sends correctly formatted multipart uploads
+# with proper metadata fields that a Thunderstorm server can parse.
+#
+# Tests run against a stub server with JSONL audit log for field verification.
+# Checks: source, filename, file integrity (MD5), collection markers,
+#         zero-byte files, binary files, filenames with spaces/special chars.
+#
+# Usage:
+#   ./run_e2e_compliance.sh [stub-server-binary]
+#
+# Environment:
+#   STUB_SERVER_BIN      Path to stub server binary
+#   THUNDERSTORM_HOST    Real Thunderstorm host (optional, for live smoke tests)
+#   THUNDERSTORM_PORT    Real Thunderstorm port (default: 8081)
+#
+
+set -euo pipefail
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPTS_DIR="$(cd "$TESTS_DIR/.." && pwd)"
+
+STUB_PORT=19993
+STUB_LOG="/tmp/e2e-compliance.jsonl"
+STUB_PID=""
+
+TS_HOST="${THUNDERSTORM_HOST:-}"
+TS_PORT="${THUNDERSTORM_PORT:-8081}"
+COLLECTOR_FILTER_RAW="${THUNDERSTORM_TEST_COLLECTORS:-}"
+COLLECTOR_REQUIRE_MATCH="${THUNDERSTORM_TEST_REQUIRE_MATCH:-0}"
+COLLECTOR_REQUIRE_ALL="${THUNDERSTORM_TEST_REQUIRE_ALL:-0}"
+
+FIXTURES="/tmp/e2e-compliance-fixtures"
+PASS=0
+FAIL=0
+SKIP=0
+
+RED='\033[31m'; GREEN='\033[32m'; YELLOW='\033[33m'; CYAN='\033[36m'; BOLD='\033[1m'; RESET='\033[0m'
+
+pass()    { PASS=$((PASS+1)); printf "  ${GREEN}PASS${RESET} %s\n" "$1"; }
+fail()    { FAIL=$((FAIL+1)); printf "  ${RED}FAIL${RESET} %s\n" "$1"; }
+skip()    { SKIP=$((SKIP+1)); printf "  ${YELLOW}SKIP${RESET} %s\n" "$1"; }
+section() { printf "\n${BOLD}${CYAN}── %s ──${RESET}\n" "$1"; }
+
+normalize_collector() {
+    case "$1" in
+        bash|ash|perl|python2|python3|ps3|ps2) printf '%s\n' "$1" ;;
+        python) printf 'python3\n' ;;
+        powershell|powershell3|pwsh|ps) printf 'ps3\n' ;;
+        powershell2|psv2) printf 'ps2\n' ;;
+        *) printf '%s\n' "$1" ;;
+    esac
+}
+
+collector_enabled() {
+    local current wanted
+    current="$(normalize_collector "$1")"
+    [ -z "$COLLECTOR_FILTER_RAW" ] && return 0
+
+    for wanted in ${COLLECTOR_FILTER_RAW//,/ }; do
+        if [ "$(normalize_collector "$wanted")" = "$current" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+is_truthy() {
+    case "${1:-0}" in
+        1|true|TRUE|yes|YES|on|ON) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+list_contains() {
+    local needle="$1" item
+    shift
+    for item in "$@"; do
+        [ "$item" = "$needle" ] && return 0
+    done
+    return 1
+}
+
+detect_ash_shell() {
+    if command -v dash >/dev/null 2>&1; then
+        command -v dash
+        return 0
+    fi
+    if command -v busybox >/dev/null 2>&1; then
+        printf '%s sh\n' "$(command -v busybox)"
+        return 0
+    fi
+    return 1
+}
+
+ASH_SHELL="${ASH_SHELL:-$(detect_ash_shell 2>/dev/null || true)}"
+
+collector_script_path() {
+    case "$(normalize_collector "$1")" in
+        bash) printf '%s/thunderstorm-collector.sh\n' "$SCRIPTS_DIR" ;;
+        ash) printf '%s/thunderstorm-collector-ash.sh\n' "$SCRIPTS_DIR" ;;
+        python3) printf '%s/thunderstorm-collector.py\n' "$SCRIPTS_DIR" ;;
+        python2) printf '%s/thunderstorm-collector-py2.py\n' "$SCRIPTS_DIR" ;;
+        perl) printf '%s/thunderstorm-collector.pl\n' "$SCRIPTS_DIR" ;;
+        ps3) printf '%s/thunderstorm-collector.ps1\n' "$SCRIPTS_DIR" ;;
+        ps2) printf '%s/thunderstorm-collector-ps2.ps1\n' "$SCRIPTS_DIR" ;;
+        *) return 1 ;;
+    esac
+}
+
+collector_runnable() {
+    local current script_path
+    current="$(normalize_collector "$1")"
+    script_path="$(collector_script_path "$current")" || return 1
+    [ -f "$script_path" ] || return 1
+
+    case "$current" in
+        bash) command -v bash >/dev/null 2>&1 ;;
+        ash) [ -n "$ASH_SHELL" ] ;;
+        python3) command -v python3 >/dev/null 2>&1 ;;
+        python2) command -v python2 >/dev/null 2>&1 ;;
+        perl) command -v perl >/dev/null 2>&1 && perl -MLWP::UserAgent -e1 2>/dev/null ;;
+        ps3|ps2) command -v pwsh >/dev/null 2>&1 ;;
+        *) return 1 ;;
+    esac
+}
+
+validate_available_collectors() {
+    local available=("$@")
+    local wanted normalized missing=()
+
+    if is_truthy "$COLLECTOR_REQUIRE_MATCH" && [ "${#available[@]}" -eq 0 ]; then
+        echo "ERROR: no runnable collectors matched THUNDERSTORM_TEST_COLLECTORS='${COLLECTOR_FILTER_RAW}'" >&2
+        exit 1
+    fi
+
+    if is_truthy "$COLLECTOR_REQUIRE_ALL" && [ -n "$COLLECTOR_FILTER_RAW" ]; then
+        for wanted in ${COLLECTOR_FILTER_RAW//,/ }; do
+            normalized="$(normalize_collector "$wanted")"
+            if ! list_contains "$normalized" "${available[@]}"; then
+                missing+=("$normalized")
+            fi
+        done
+        if [ "${#missing[@]}" -gt 0 ]; then
+            echo "ERROR: requested collectors are not runnable: ${missing[*]}" >&2
+            exit 1
+        fi
+    fi
+}
+
+# ── Stub Server ───────────────────────────────────────────────────────────────
+
+find_stub() {
+    if [ -n "${1:-}" ] && [ -x "$1" ]; then echo "$1"; return 0; fi
+    if [ -n "${STUB_SERVER_BIN:-}" ] && [ -x "$STUB_SERVER_BIN" ]; then echo "$STUB_SERVER_BIN"; return 0; fi
+    local sibling="$SCRIPTS_DIR/../../thunderstorm-stub-server/thunderstorm-stub-server"
+    if [ -x "$sibling" ]; then echo "$sibling"; return 0; fi
+    for p in \
+        "$HOME/.openclaw/workspace/projects/thunderstorm-stub-server/thunderstorm-stub-server" \
+        "$HOME/thunderstorm-stub-server/thunderstorm-stub-server"; do
+        if [ -x "$p" ]; then echo "$p"; return 0; fi
+    done
+    command -v thunderstorm-stub-server 2>/dev/null && return 0
+    return 1
+}
+
+start_stub() {
+    pkill -f "stub-server.*$STUB_PORT" 2>/dev/null || true
+    sleep 1
+    rm -f "$STUB_LOG"
+    "$1" -port "$STUB_PORT" -log-file "$STUB_LOG" &
+    STUB_PID=$!
+    sleep 2
+    if ! curl -sf "http://127.0.0.1:$STUB_PORT/api/status" >/dev/null 2>&1; then
+        echo "ERROR: Stub server failed to start on port $STUB_PORT"; exit 1
+    fi
+}
+
+stop_stub() { [ -n "$STUB_PID" ] && kill "$STUB_PID" 2>/dev/null && wait "$STUB_PID" 2>/dev/null || true; STUB_PID=""; }
+
+cleanup() { stop_stub; rm -rf "$FIXTURES"; }
+trap cleanup EXIT
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+create_fixtures() {
+    rm -rf "$FIXTURES"
+    mkdir -p "$FIXTURES/subdir with spaces" "$FIXTURES/nested/deep"
+    echo "hello world" > "$FIXTURES/normal.txt"
+    echo "spaced" > "$FIXTURES/file with spaces.txt"
+    echo "special" > "$FIXTURES/special-chars_v2.0(1).txt"
+    printf '\x00\x01\x02\x03DEADBEEF\x00\xff\xfe' > "$FIXTURES/binary.bin"
+    echo "nested space" > "$FIXTURES/subdir with spaces/inner.txt"
+    echo "deep" > "$FIXTURES/nested/deep/deep.txt"
+    touch "$FIXTURES/empty.txt"
+    echo "report" > "$FIXTURES/report-2024.txt"
+}
+
+# ── JSONL Helpers ─────────────────────────────────────────────────────────────
+
+jsonl_count() { wc -l < "$STUB_LOG" 2>/dev/null | tr -d ' '; }
+
+# Get upload entries (type="THOR finding") since line N
+jsonl_uploads_since() {
+    tail -n +"$1" "$STUB_LOG" 2>/dev/null | python3 -c "
+import sys, json
+for line in sys.stdin:
+    line = line.strip()
+    if not line: continue
+    try:
+        d = json.loads(line)
+        if d.get('type') == 'THOR finding': print(line)
+    except: pass
+"
+}
+
+# Get all entries since line N
+jsonl_since() { tail -n +"$1" "$STUB_LOG" 2>/dev/null; }
+
+# Extract a dotted field path from a JSON line
+jf() {
+    echo "$1" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+keys = '${2}'.split('.')
+val = data
+for k in keys:
+    val = val.get(k) if isinstance(val, dict) else None
+    if val is None: break
+if val is not None: print(val)
+" 2>/dev/null
+}
+
+# Find first upload entry matching a client_filename substring
+find_upload() {
+    echo "$1" | python3 -c "
+import sys, json
+target = '${2}'
+for line in sys.stdin:
+    line = line.strip()
+    if not line: continue
+    d = json.loads(line)
+    cf = d.get('subject',{}).get('client_filename','')
+    if target in cf: print(line); break
+" 2>/dev/null
+}
+
+# Find marker entry by type
+find_marker() {
+    echo "$1" | python3 -c "
+import sys, json
+target = '${2}'
+for line in sys.stdin:
+    line = line.strip()
+    if not line: continue
+    d = json.loads(line)
+    if d.get('type') == 'collection_marker' and d.get('marker') == target: print(line); break
+" 2>/dev/null
+}
+
+# ── Assertions ────────────────────────────────────────────────────────────────
+
+assert_eq()       { [ "$(jf "$1" "$2")" = "$3" ] && pass "$4" || fail "$4: expected='$3' got='$(jf "$1" "$2")'"; }
+assert_nonempty() { [ -n "$(jf "$1" "$2")" ] && pass "$3: $(jf "$1" "$2")" || fail "$3: empty"; }
+assert_md5()      { local exp; exp=$(md5sum "$2" | awk '{print $1}'); local got; got=$(jf "$1" "subject.hashes.md5"); [ "$exp" = "$got" ] && pass "$3: MD5 $exp" || fail "$3: MD5 expected=$exp got=$got"; }
+
+# ── Test Runner ───────────────────────────────────────────────────────────────
+
+run_tests() {
+    local name="$1"; shift
+    local source_val="E2E Test (v2.0)"
+    local start_line uploads all_entries entry
+
+    section "$name"
+
+    start_line=$(($(jsonl_count) + 1))
+    "$@" --source "$source_val" > /dev/null 2>&1 || true
+    sleep 2
+
+    uploads=$(jsonl_uploads_since "$start_line")
+    all_entries=$(jsonl_since "$start_line")
+
+    if [ -z "$uploads" ]; then
+        fail "$name: no uploads recorded (collector may have crashed)"
+        return
+    fi
+
+    # Source parameter arrives correctly
+    entry=$(echo "$uploads" | head -1)
+    assert_eq "$entry" "subject.source" "$source_val" "$name/source"
+
+    # Collection markers
+    local begin_m; begin_m=$(find_marker "$all_entries" "begin")
+    local end_m; end_m=$(find_marker "$all_entries" "end")
+    if [ -n "$begin_m" ]; then
+        pass "$name/marker-begin"
+        assert_nonempty "$begin_m" "collector" "$name/marker-collector"
+        assert_eq "$begin_m" "source" "$source_val" "$name/marker-source"
+    else
+        fail "$name/marker-begin: not found"
+    fi
+    [ -n "$end_m" ] && pass "$name/marker-end" || fail "$name/marker-end: not found"
+
+    # File content integrity — text
+    entry=$(find_upload "$uploads" "normal.txt")
+    if [ -n "$entry" ]; then
+        assert_md5 "$entry" "$FIXTURES/normal.txt" "$name/integrity-text"
+    else
+        fail "$name/integrity-text: not found"
+    fi
+
+    # File content integrity — binary with NUL bytes
+    entry=$(find_upload "$uploads" "binary.bin")
+    if [ -n "$entry" ]; then
+        assert_md5 "$entry" "$FIXTURES/binary.bin" "$name/integrity-binary"
+    else
+        fail "$name/integrity-binary: not found"
+    fi
+
+    # Filename with spaces
+    entry=$(find_upload "$uploads" "file with spaces")
+    if [ -n "$entry" ]; then
+        assert_md5 "$entry" "$FIXTURES/file with spaces.txt" "$name/spaces-in-name"
+    else
+        fail "$name/spaces-in-name: not found"
+    fi
+
+    # Special characters in filename
+    entry=$(find_upload "$uploads" "special-chars")
+    if [ -n "$entry" ]; then
+        assert_md5 "$entry" "$FIXTURES/special-chars_v2.0(1).txt" "$name/special-chars"
+    else
+        fail "$name/special-chars: not found"
+    fi
+
+    # Zero-byte file
+    entry=$(find_upload "$uploads" "empty.txt")
+    if [ -n "$entry" ]; then
+        local sz; sz=$(jf "$entry" "subject.size")
+        [ "$sz" = "0" ] && pass "$name/zero-byte" || fail "$name/zero-byte: size=$sz"
+    else
+        fail "$name/zero-byte: not found"
+    fi
+
+    # Nested directory
+    entry=$(find_upload "$uploads" "deep.txt")
+    [ -n "$entry" ] && pass "$name/nested-dir" || fail "$name/nested-dir: not found"
+
+    # Subdirectory with spaces
+    entry=$(find_upload "$uploads" "inner.txt")
+    [ -n "$entry" ] && pass "$name/subdir-spaces" || fail "$name/subdir-spaces: not found"
+
+    # Total count
+    local n; n=$(echo "$uploads" | wc -l | tr -d ' ')
+    [ "$n" -ge 8 ] && pass "$name/count: $n files" || fail "$name/count: $n files (expected ≥8)"
+}
+
+# PowerShell wrapper (uses -Source instead of --source)
+run_tests_ps() {
+    local name="$1" script="$2"
+    local source_val="E2E Test (v2.0)"
+    local start_line uploads entry
+
+    section "$name"
+
+    start_line=$(($(jsonl_count) + 1))
+    pwsh -NoProfile -ep bypass -c "& '$script' \
+        -ThunderstormServer '127.0.0.1' -ThunderstormPort $STUB_PORT \
+        -Folder '$FIXTURES' -MaxAge 365 -AllExtensions \
+        -Source '$source_val'" > /dev/null 2>&1 || true
+    sleep 2
+
+    uploads=$(jsonl_uploads_since "$start_line")
+    if [ -z "$uploads" ]; then
+        fail "$name: no uploads recorded (collector may have crashed)"
+        return
+    fi
+
+    entry=$(echo "$uploads" | head -1)
+    assert_eq "$entry" "subject.source" "$source_val" "$name/source"
+
+    entry=$(find_upload "$uploads" "normal.txt")
+    [ -n "$entry" ] && assert_md5 "$entry" "$FIXTURES/normal.txt" "$name/integrity-text" || fail "$name/integrity-text"
+
+    entry=$(find_upload "$uploads" "binary.bin")
+    [ -n "$entry" ] && assert_md5 "$entry" "$FIXTURES/binary.bin" "$name/integrity-binary" || fail "$name/integrity-binary"
+
+    entry=$(find_upload "$uploads" "file with spaces")
+    [ -n "$entry" ] && assert_md5 "$entry" "$FIXTURES/file with spaces.txt" "$name/spaces-in-name" || fail "$name/spaces-in-name"
+
+    entry=$(find_upload "$uploads" "empty.txt")
+    if [ -n "$entry" ]; then
+        local sz; sz=$(jf "$entry" "subject.size")
+        [ "$sz" = "0" ] && pass "$name/zero-byte" || fail "$name/zero-byte: size=$sz"
+    else fail "$name/zero-byte"; fi
+
+    local n; n=$(echo "$uploads" | wc -l | tr -d ' ')
+    [ "$n" -ge 5 ] && pass "$name/count: $n files" || fail "$name/count: $n files (expected ≥5)"
+}
+
+run_dry_run_test() {
+    local name="$1"; shift
+    local start_line n
+    start_line=$(($(jsonl_count) + 1))
+    "$@" --dry-run > /dev/null 2>&1 || true
+    sleep 1
+    n=$(jsonl_uploads_since "$start_line" | wc -l | tr -d ' ')
+    [ "$n" -eq 0 ] && pass "$name/dry-run" || fail "$name/dry-run: $n uploads (should be 0)"
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+echo ""
+echo "============================================"
+echo " E2E Compliance Tests"
+echo " Stub: 127.0.0.1:$STUB_PORT"
+[ -n "$TS_HOST" ] && echo " Thunderstorm: $TS_HOST:$TS_PORT"
+echo "============================================"
+
+available_collectors=()
+collector_enabled bash && collector_runnable bash && available_collectors+=("bash")
+collector_enabled ash && collector_runnable ash && available_collectors+=("ash")
+collector_enabled python3 && collector_runnable python3 && available_collectors+=("python3")
+collector_enabled python2 && collector_runnable python2 && available_collectors+=("python2")
+collector_enabled perl && collector_runnable perl && available_collectors+=("perl")
+collector_enabled ps3 && collector_runnable ps3 && available_collectors+=("ps3")
+collector_enabled ps2 && collector_runnable ps2 && available_collectors+=("ps2")
+
+if [ "${#available_collectors[@]}" -gt 0 ]; then
+    validate_available_collectors "${available_collectors[@]}"
+else
+    validate_available_collectors
+fi
+
+if [ "${#available_collectors[@]}" -eq 0 ]; then
+    echo "Available collectors: none"
+    echo "No runnable collectors selected; nothing to do."
+    exit 0
+fi
+
+echo "Available collectors: ${available_collectors[*]}"
+
+STUB_BIN=$(find_stub "${1:-}" || true)
+if [ -z "$STUB_BIN" ]; then
+    echo "ERROR: Cannot find stub server binary"; exit 1
+fi
+echo "Stub: $STUB_BIN"
+start_stub "$STUB_BIN"
+create_fixtures
+
+# Bash
+if collector_runnable bash; then
+    run_tests "bash" bash "$SCRIPTS_DIR/thunderstorm-collector.sh" \
+        --server 127.0.0.1 --port "$STUB_PORT" --dir "$FIXTURES" --max-age 365 --quiet
+    run_dry_run_test "bash" bash "$SCRIPTS_DIR/thunderstorm-collector.sh" \
+        --server 127.0.0.1 --port "$STUB_PORT" --dir "$FIXTURES" --max-age 365 --quiet
+fi
+
+# Ash / POSIX sh
+if collector_runnable ash; then
+    # Intentionally rely on shell word splitting so "busybox sh" works.
+    # shellcheck disable=SC2086
+    run_tests "ash (${ASH_SHELL##*/})" $ASH_SHELL "$SCRIPTS_DIR/thunderstorm-collector-ash.sh" \
+        --server 127.0.0.1 --port "$STUB_PORT" --dir "$FIXTURES" --max-age 365 --quiet
+    # shellcheck disable=SC2086
+    run_dry_run_test "ash (${ASH_SHELL##*/})" $ASH_SHELL "$SCRIPTS_DIR/thunderstorm-collector-ash.sh" \
+        --server 127.0.0.1 --port "$STUB_PORT" --dir "$FIXTURES" --max-age 365 --quiet
+elif collector_enabled ash; then
+    section "ash"; skip "no dash or busybox available"
+fi
+
+# Python 3
+if collector_runnable python3; then
+    run_tests "python3" python3 "$SCRIPTS_DIR/thunderstorm-collector.py" \
+        -s 127.0.0.1 -p "$STUB_PORT" -d "$FIXTURES" --max-age 365
+    run_dry_run_test "python3" python3 "$SCRIPTS_DIR/thunderstorm-collector.py" \
+        -s 127.0.0.1 -p "$STUB_PORT" -d "$FIXTURES" --max-age 365
+elif collector_enabled python3; then
+    section "python3"; skip "not available"
+fi
+
+# Python 2
+if collector_runnable python2; then
+    run_tests "python2" python2 "$SCRIPTS_DIR/thunderstorm-collector-py2.py" \
+        -s 127.0.0.1 -p "$STUB_PORT" -d "$FIXTURES" --max-age 365
+    run_dry_run_test "python2" python2 "$SCRIPTS_DIR/thunderstorm-collector-py2.py" \
+        -s 127.0.0.1 -p "$STUB_PORT" -d "$FIXTURES" --max-age 365
+elif collector_enabled python2; then
+    section "python2"; skip "not available"
+fi
+
+# Perl
+if collector_runnable perl; then
+    run_tests "perl" perl "$SCRIPTS_DIR/thunderstorm-collector.pl" \
+        -s 127.0.0.1 --port "$STUB_PORT" --dir "$FIXTURES" --max-age 365
+    run_dry_run_test "perl" perl "$SCRIPTS_DIR/thunderstorm-collector.pl" \
+        -s 127.0.0.1 --port "$STUB_PORT" --dir "$FIXTURES" --max-age 365
+elif collector_enabled perl; then
+    section "perl"; skip "not available or missing LWP::UserAgent"
+fi
+
+# PowerShell 3+
+if collector_runnable ps3; then
+    run_tests_ps "powershell3+" "$SCRIPTS_DIR/thunderstorm-collector.ps1"
+elif collector_enabled ps3; then
+    section "powershell3+"; skip "pwsh not available"
+fi
+
+# PowerShell 2+
+if collector_runnable ps2; then
+    run_tests_ps "powershell2+" "$SCRIPTS_DIR/thunderstorm-collector-ps2.ps1"
+elif collector_enabled ps2; then
+    section "powershell2+"; skip "pwsh not available"
+fi
+
+# Real Thunderstorm smoke tests
+if [ -n "$TS_HOST" ]; then
+    section "Real Thunderstorm ($TS_HOST:$TS_PORT)"
+    if curl -sf "http://$TS_HOST:$TS_PORT/api/status" >/dev/null 2>&1; then
+        pass "connectivity: server reachable"
+        TS_FIX="/tmp/e2e-ts-smoke"
+        rm -rf "$TS_FIX"; mkdir -p "$TS_FIX"
+        echo "live test" > "$TS_FIX/live.txt"
+        printf '\x00BINARY\x00' > "$TS_FIX/live.bin"
+
+        for info in \
+            "bash:bash $SCRIPTS_DIR/thunderstorm-collector.sh --server $TS_HOST --port $TS_PORT --dir $TS_FIX --max-age 365 --quiet" \
+            "python3:python3 $SCRIPTS_DIR/thunderstorm-collector.py -s $TS_HOST -p $TS_PORT -d $TS_FIX --max-age 365" \
+            "perl:perl $SCRIPTS_DIR/thunderstorm-collector.pl -s $TS_HOST --port $TS_PORT --dir $TS_FIX --max-age 365" \
+            "ps3:pwsh -NoProfile -ep bypass -c \"& '$SCRIPTS_DIR/thunderstorm-collector.ps1' -ThunderstormServer $TS_HOST -ThunderstormPort $TS_PORT -Folder '$TS_FIX' -MaxAge 365 -AllExtensions\""; do
+            n="${info%%:*}"; c="${info#*:}"
+            if eval "$c" >/dev/null 2>&1; then
+                pass "live/$n: upload succeeded"
+            else
+                fail "live/$n: upload failed"
+            fi
+        done
+        rm -rf "$TS_FIX"
+    else
+        fail "connectivity: unreachable at $TS_HOST:$TS_PORT"
+    fi
+fi
+
+echo ""
+echo "============================================"
+printf " Results: ${GREEN}%d passed${RESET}, ${RED}%d failed${RESET}, ${YELLOW}%d skipped${RESET}\n" "$PASS" "$FAIL" "$SKIP"
+echo "============================================"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/scripts/tests/run_filter_tests.sh
+++ b/scripts/tests/run_filter_tests.sh
@@ -248,6 +248,12 @@ if [ "${#available_collectors[@]}" -eq 0 ]; then
     exit 0
 fi
 
+collector_available() {
+    local current
+    current="$(normalize_collector "$1")"
+    list_contains "$current" "${available_collectors[@]}"
+}
+
 # Ensure stub server is running
 if ! curl -s "http://${STUB_HOST}:${STUB_PORT}/api/status" >/dev/null 2>&1; then
     echo "ERROR: Stub server not running on ${STUB_HOST}:${STUB_PORT}"
@@ -270,7 +276,7 @@ echo ""
 # ══════════════════════════════════════════════
 # BASH COLLECTOR
 # ══════════════════════════════════════════════
-if collector_enabled bash; then
+if collector_available bash; then
     echo "── Bash Collector ──────────────────────────"
 
     # max-size: 1000KB limit → small(100B), fresh(6B), old(4B), ancient(8B),
@@ -315,7 +321,7 @@ fi
 # ══════════════════════════════════════════════
 # ASH / POSIX SH COLLECTOR
 # ══════════════════════════════════════════════
-if collector_runnable ash; then
+if collector_available ash; then
     echo "── POSIX sh Collector (via $ASH_SHELL) ──────"
 
     start=$(log_lines)
@@ -349,7 +355,7 @@ fi
 # ══════════════════════════════════════════════
 # PYTHON 3 COLLECTOR
 # ══════════════════════════════════════════════
-if collector_enabled python3; then
+if collector_available python3; then
     echo "── Python 3 Collector ────────────────────────"
 
     # max-size test: 1024KB (~1MB), 365 days max_age
@@ -386,7 +392,7 @@ fi
 # ══════════════════════════════════════════════
 # PYTHON 2 COLLECTOR
 # ══════════════════════════════════════════════
-if collector_enabled python2 && command -v python2 >/dev/null 2>&1; then
+if collector_available python2; then
     echo "── Python 2 Collector ────────────────────────"
 
     py2_script="$(patch_python2 365 1024)"
@@ -413,7 +419,7 @@ fi
 # ══════════════════════════════════════════════
 # PERL COLLECTOR
 # ══════════════════════════════════════════════
-if collector_enabled perl; then
+if collector_available perl; then
     echo "── Perl Collector ────────────────────────────"
 
     # max-size test: 1024KB (~1MB), 365 days
@@ -440,7 +446,7 @@ fi
 # ══════════════════════════════════════════════
 # POWERSHELL COLLECTORS
 # ══════════════════════════════════════════════
-if collector_enabled ps3 && command -v pwsh >/dev/null 2>&1; then
+if collector_available ps3; then
     echo "── PowerShell 3+ Collector ─────────────────"
 
     # max-size: 1MB — use wildcard extension '*' to match all files
@@ -482,7 +488,7 @@ if collector_enabled ps3 && command -v pwsh >/dev/null 2>&1; then
     echo ""
 fi
 
-if collector_enabled ps2 && command -v pwsh >/dev/null 2>&1; then
+if collector_available ps2; then
     echo "── PowerShell 2+ Collector ─────────────────"
 
     start=$(log_lines)

--- a/scripts/tests/run_filter_tests.sh
+++ b/scripts/tests/run_filter_tests.sh
@@ -92,11 +92,42 @@ collector_script_path() {
     esac
 }
 
+collector_has_flags() {
+    local script_path="$1" flag
+    shift
+    for flag in "$@"; do
+        grep -q -- "$flag" "$script_path" || return 1
+    done
+}
+
+collector_supports_shared_harness() {
+    local current script_path
+    current="$(normalize_collector "$1")"
+    script_path="$(collector_script_path "$current")" || return 1
+
+    case "$current" in
+        bash|ash)
+            collector_has_flags "$script_path" --server --port --dir --max-age --source --dry-run
+            ;;
+        python3|python2)
+            collector_has_flags "$script_path" --server --port --dirs --max-age --source --dry-run
+            ;;
+        perl)
+            collector_has_flags "$script_path" --server --port --dir --max-age --source --dry-run
+            ;;
+        ps3|ps2)
+            collector_has_flags "$script_path" ThunderstormServer ThunderstormPort Folder Source MaxAge MaxSize AllExtensions
+            ;;
+        *) return 1 ;;
+    esac
+}
+
 collector_runnable() {
     local current script_path
     current="$(normalize_collector "$1")"
     script_path="$(collector_script_path "$current")" || return 1
     [ -f "$script_path" ] || return 1
+    collector_supports_shared_harness "$current" || return 1
 
     case "$current" in
         bash) command -v bash >/dev/null 2>&1 ;;

--- a/scripts/tests/run_filter_tests.sh
+++ b/scripts/tests/run_filter_tests.sh
@@ -196,34 +196,50 @@ assert_not_uploaded() {
     fi
 }
 
+kb_to_mb_ceil() {
+    local kb="$1"
+    echo $(((kb + 1023) / 1024))
+}
+
 # Create patched copies of Python/Perl collectors with specific max_age/max_size
 patch_python() {
     local max_age="$1" max_size_kb="$2" out="$TMP_DIR/thunderstorm-collector-patched.py"
-    # Patch both the global default and the argparse default
+    local src="$SCRIPTS_DIR/thunderstorm-collector.py" max_size="$max_size_kb"
+    if ! grep -q -- "--max-size-kb" "$src"; then
+        max_size="$(kb_to_mb_ceil "$max_size_kb")"
+    fi
     sed -e "s/^max_age = .*/max_age = $max_age/" \
-        -e "s/^max_size = .*/max_size = $max_size_kb/" \
+        -e "s/^max_size = .*/max_size = $max_size/" \
         -e "s/\"--max-size-kb\", type=int, default=[0-9]*/\"--max-size-kb\", type=int, default=$max_size_kb/" \
         -e "s/\"--max-age\", type=int, default=[0-9]*/\"--max-age\", type=int, default=$max_age/" \
-        "$SCRIPTS_DIR/thunderstorm-collector.py" > "$out"
+        "$src" > "$out"
     echo "$out"
 }
 
 patch_python2() {
     local max_age="$1" max_size_kb="$2" out="$TMP_DIR/thunderstorm-collector-py2-patched.py"
-    # Patch both the global default and the argparse default
+    local src="$SCRIPTS_DIR/thunderstorm-collector-py2.py" max_size="$max_size_kb"
+    if ! grep -q -- "--max-size-kb" "$src"; then
+        max_size="$(kb_to_mb_ceil "$max_size_kb")"
+    fi
     sed -e "s/^max_age = .*/max_age = $max_age/" \
-        -e "s/^max_size = .*/max_size = $max_size_kb/" \
+        -e "s/^max_size = .*/max_size = $max_size/" \
         -e "s/\"--max-size-kb\", type=int, default=[0-9]*/\"--max-size-kb\", type=int, default=$max_size_kb/" \
         -e "s/\"--max-age\", type=int, default=[0-9]*/\"--max-age\", type=int, default=$max_age/" \
-        "$SCRIPTS_DIR/thunderstorm-collector-py2.py" > "$out"
+        "$src" > "$out"
     echo "$out"
 }
 
 patch_perl() {
     local max_age="$1" max_size_kb="$2" out="$TMP_DIR/thunderstorm-collector-patched.pl"
+    local src="$SCRIPTS_DIR/thunderstorm-collector.pl" max_size="$max_size_kb"
+    if ! grep -q 'our \$max_size_kb' "$src"; then
+        max_size="$(kb_to_mb_ceil "$max_size_kb")"
+    fi
     sed -e "s/^our \\\$max_age = .*/our \$max_age = $max_age;/" \
         -e "s/^our \\\$max_size_kb = .*/our \$max_size_kb = $max_size_kb;/" \
-        "$SCRIPTS_DIR/thunderstorm-collector.pl" > "$out"
+        -e "s/^our \\\$max_size = .*/our \$max_size = $max_size;/" \
+        "$src" > "$out"
     echo "$out"
 }
 

--- a/scripts/tests/run_filter_tests.sh
+++ b/scripts/tests/run_filter_tests.sh
@@ -1,0 +1,500 @@
+#!/usr/bin/env bash
+#
+# Filter / Selector Tests for All Script Collectors
+# Tests: --max-age, --max-size, and extension filtering
+#
+# Requires: stub server running on $STUB_PORT, test fixtures in $FIXTURES_DIR
+#
+set -euo pipefail
+
+STUB_HOST="${STUB_HOST:-127.0.0.1}"
+STUB_PORT="${STUB_PORT:-19990}"
+STUB_LOG="${STUB_LOG:-/tmp/stub-filter-test.jsonl}"
+FIXTURES_DIR="${FIXTURES_DIR:-/tmp/filter-test-fixtures}"
+SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+COLLECTOR_FILTER_RAW="${THUNDERSTORM_TEST_COLLECTORS:-}"
+COLLECTOR_REQUIRE_MATCH="${THUNDERSTORM_TEST_REQUIRE_MATCH:-0}"
+COLLECTOR_REQUIRE_ALL="${THUNDERSTORM_TEST_REQUIRE_ALL:-0}"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+pass() { PASS=$((PASS+1)); printf "  \033[32mPASS\033[0m %s\n" "$1"; }
+fail() { FAIL=$((FAIL+1)); printf "  \033[31mFAIL\033[0m %s\n" "$1"; }
+skip() { SKIP=$((SKIP+1)); printf "  \033[33mSKIP\033[0m %s\n" "$1"; }
+
+normalize_collector() {
+    case "$1" in
+        bash|ash|perl|python2|python3|ps3|ps2) printf '%s\n' "$1" ;;
+        python) printf 'python3\n' ;;
+        powershell|powershell3|pwsh|ps) printf 'ps3\n' ;;
+        powershell2|psv2) printf 'ps2\n' ;;
+        *) printf '%s\n' "$1" ;;
+    esac
+}
+
+collector_enabled() {
+    local current wanted
+    current="$(normalize_collector "$1")"
+    [ -z "$COLLECTOR_FILTER_RAW" ] && return 0
+
+    for wanted in ${COLLECTOR_FILTER_RAW//,/ }; do
+        if [ "$(normalize_collector "$wanted")" = "$current" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+is_truthy() {
+    case "${1:-0}" in
+        1|true|TRUE|yes|YES|on|ON) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+list_contains() {
+    local needle="$1" item
+    shift
+    for item in "$@"; do
+        [ "$item" = "$needle" ] && return 0
+    done
+    return 1
+}
+
+detect_ash_shell() {
+    if command -v dash >/dev/null 2>&1; then
+        command -v dash
+        return 0
+    fi
+    if command -v busybox >/dev/null 2>&1; then
+        printf '%s sh\n' "$(command -v busybox)"
+        return 0
+    fi
+    return 1
+}
+
+ASH_SHELL="${ASH_SHELL:-$(detect_ash_shell 2>/dev/null || true)}"
+
+collector_script_path() {
+    case "$(normalize_collector "$1")" in
+        bash) printf '%s/thunderstorm-collector.sh\n' "$SCRIPTS_DIR" ;;
+        ash) printf '%s/thunderstorm-collector-ash.sh\n' "$SCRIPTS_DIR" ;;
+        python3) printf '%s/thunderstorm-collector.py\n' "$SCRIPTS_DIR" ;;
+        python2) printf '%s/thunderstorm-collector-py2.py\n' "$SCRIPTS_DIR" ;;
+        perl) printf '%s/thunderstorm-collector.pl\n' "$SCRIPTS_DIR" ;;
+        ps3) printf '%s/thunderstorm-collector.ps1\n' "$SCRIPTS_DIR" ;;
+        ps2) printf '%s/thunderstorm-collector-ps2.ps1\n' "$SCRIPTS_DIR" ;;
+        *) return 1 ;;
+    esac
+}
+
+collector_runnable() {
+    local current script_path
+    current="$(normalize_collector "$1")"
+    script_path="$(collector_script_path "$current")" || return 1
+    [ -f "$script_path" ] || return 1
+
+    case "$current" in
+        bash) command -v bash >/dev/null 2>&1 ;;
+        ash) [ -n "$ASH_SHELL" ] ;;
+        python3) command -v python3 >/dev/null 2>&1 ;;
+        python2) command -v python2 >/dev/null 2>&1 ;;
+        perl) command -v perl >/dev/null 2>&1 && perl -MLWP::UserAgent -e1 2>/dev/null ;;
+        ps3|ps2) command -v pwsh >/dev/null 2>&1 ;;
+        *) return 1 ;;
+    esac
+}
+
+validate_available_collectors() {
+    local available=("$@")
+    local wanted normalized missing=()
+
+    if is_truthy "$COLLECTOR_REQUIRE_MATCH" && [ "${#available[@]}" -eq 0 ]; then
+        echo "ERROR: no runnable collectors matched THUNDERSTORM_TEST_COLLECTORS='${COLLECTOR_FILTER_RAW}'" >&2
+        exit 1
+    fi
+
+    if is_truthy "$COLLECTOR_REQUIRE_ALL" && [ -n "$COLLECTOR_FILTER_RAW" ]; then
+        for wanted in ${COLLECTOR_FILTER_RAW//,/ }; do
+            normalized="$(normalize_collector "$wanted")"
+            if ! list_contains "$normalized" "${available[@]}"; then
+                missing+=("$normalized")
+            fi
+        done
+        if [ "${#missing[@]}" -gt 0 ]; then
+            echo "ERROR: requested collectors are not runnable: ${missing[*]}" >&2
+            exit 1
+        fi
+    fi
+}
+
+# Get uploaded filenames from stub server JSONL log since a given line
+# Extracts basename from client_filename field
+get_uploaded_files() {
+    local start_line="$1"
+    tail -n +"$start_line" "$STUB_LOG" 2>/dev/null \
+        | grep -o '"client_filename":"[^"]*"' \
+        | sed 's/"client_filename":"//;s/"//' \
+        | xargs -I{} basename {} \
+        | sort
+}
+
+log_lines() {
+    wc -l < "$STUB_LOG" 2>/dev/null | tr -d ' '
+}
+
+assert_uploaded() {
+    local start="$1" filename="$2" label="$3"
+    if get_uploaded_files "$start" | grep -qF "$filename"; then
+        pass "$label: '$filename' uploaded"
+    else
+        fail "$label: '$filename' NOT uploaded (expected)"
+    fi
+}
+
+assert_not_uploaded() {
+    local start="$1" filename="$2" label="$3"
+    if get_uploaded_files "$start" | grep -qF "$filename"; then
+        fail "$label: '$filename' uploaded (should be filtered)"
+    else
+        pass "$label: '$filename' filtered out"
+    fi
+}
+
+# Create patched copies of Python/Perl collectors with specific max_age/max_size
+patch_python() {
+    local max_age="$1" max_size_kb="$2" out="$TMP_DIR/thunderstorm-collector-patched.py"
+    # Patch both the global default and the argparse default
+    sed -e "s/^max_age = .*/max_age = $max_age/" \
+        -e "s/^max_size = .*/max_size = $max_size_kb/" \
+        -e "s/\"--max-size-kb\", type=int, default=[0-9]*/\"--max-size-kb\", type=int, default=$max_size_kb/" \
+        -e "s/\"--max-age\", type=int, default=[0-9]*/\"--max-age\", type=int, default=$max_age/" \
+        "$SCRIPTS_DIR/thunderstorm-collector.py" > "$out"
+    echo "$out"
+}
+
+patch_python2() {
+    local max_age="$1" max_size_kb="$2" out="$TMP_DIR/thunderstorm-collector-py2-patched.py"
+    # Patch both the global default and the argparse default
+    sed -e "s/^max_age = .*/max_age = $max_age/" \
+        -e "s/^max_size = .*/max_size = $max_size_kb/" \
+        -e "s/\"--max-size-kb\", type=int, default=[0-9]*/\"--max-size-kb\", type=int, default=$max_size_kb/" \
+        -e "s/\"--max-age\", type=int, default=[0-9]*/\"--max-age\", type=int, default=$max_age/" \
+        "$SCRIPTS_DIR/thunderstorm-collector-py2.py" > "$out"
+    echo "$out"
+}
+
+patch_perl() {
+    local max_age="$1" max_size_kb="$2" out="$TMP_DIR/thunderstorm-collector-patched.pl"
+    sed -e "s/^our \\\$max_age = .*/our \$max_age = $max_age;/" \
+        -e "s/^our \\\$max_size_kb = .*/our \$max_size_kb = $max_size_kb;/" \
+        "$SCRIPTS_DIR/thunderstorm-collector.pl" > "$out"
+    echo "$out"
+}
+
+available_collectors=()
+collector_enabled bash && collector_runnable bash && available_collectors+=("bash")
+collector_enabled ash && collector_runnable ash && available_collectors+=("ash")
+collector_enabled python3 && collector_runnable python3 && available_collectors+=("python3")
+collector_enabled python2 && collector_runnable python2 && available_collectors+=("python2")
+collector_enabled perl && collector_runnable perl && available_collectors+=("perl")
+collector_enabled ps3 && collector_runnable ps3 && available_collectors+=("ps3")
+collector_enabled ps2 && collector_runnable ps2 && available_collectors+=("ps2")
+
+if [ "${#available_collectors[@]}" -gt 0 ]; then
+    validate_available_collectors "${available_collectors[@]}"
+else
+    validate_available_collectors
+fi
+
+if [ "${#available_collectors[@]}" -eq 0 ]; then
+    echo "Available collectors: none"
+    echo "No runnable collectors selected; nothing to do."
+    exit 0
+fi
+
+# Ensure stub server is running
+if ! curl -s "http://${STUB_HOST}:${STUB_PORT}/api/status" >/dev/null 2>&1; then
+    echo "ERROR: Stub server not running on ${STUB_HOST}:${STUB_PORT}"
+    exit 1
+fi
+
+if [ ! -d "$FIXTURES_DIR" ]; then
+    echo "ERROR: Fixtures directory not found: $FIXTURES_DIR"
+    exit 1
+fi
+
+echo "============================================"
+echo " Filter / Selector Tests"
+echo " Server: ${STUB_HOST}:${STUB_PORT}"
+echo " Fixtures: ${FIXTURES_DIR}"
+echo " Available collectors: ${available_collectors[*]}"
+echo "============================================"
+echo ""
+
+# ══════════════════════════════════════════════
+# BASH COLLECTOR
+# ══════════════════════════════════════════════
+if collector_enabled bash; then
+    echo "── Bash Collector ──────────────────────────"
+
+    # max-size: 1000KB limit → small(100B), fresh(6B), old(4B), ancient(8B),
+    #   medium(500KB) pass; large(3MB), huge(25MB) filtered
+    # Also passes: sample.exe(12B), sample.dll(12B), photo.jpg(12B), settings.conf(13B), noext(13B), nested.txt(7B)
+    start=$(log_lines)
+    bash "$SCRIPTS_DIR/thunderstorm-collector.sh" \
+        --server "$STUB_HOST" --port "$STUB_PORT" \
+        --dir "$FIXTURES_DIR" --max-size-kb 1000 --max-age 365 --quiet 2>/dev/null || true
+    sleep 1
+    assert_uploaded     "$start" "small.txt"    "bash/max-size-1000KB"
+    assert_uploaded     "$start" "medium.bin"   "bash/max-size-1000KB"
+    assert_not_uploaded "$start" "large.bin"    "bash/max-size-1000KB"
+    assert_not_uploaded "$start" "huge.bin"     "bash/max-size-1000KB"
+
+    # max-age: 7 days → only files created today pass (fresh, small, medium, large, huge, extensions, nested, noext)
+    # old(30d) and ancient(90d) filtered
+    start=$(log_lines)
+    bash "$SCRIPTS_DIR/thunderstorm-collector.sh" \
+        --server "$STUB_HOST" --port "$STUB_PORT" \
+        --dir "$FIXTURES_DIR" --max-age 7 --max-size-kb 50000 --quiet 2>/dev/null || true
+    sleep 1
+    assert_uploaded     "$start" "fresh.txt"    "bash/max-age-7d"
+    assert_uploaded     "$start" "small.txt"    "bash/max-age-7d"
+    assert_not_uploaded "$start" "old.txt"      "bash/max-age-7d"
+    assert_not_uploaded "$start" "ancient.txt"  "bash/max-age-7d"
+
+    # combined: 7 days + 200KB → only small fresh files
+    start=$(log_lines)
+    bash "$SCRIPTS_DIR/thunderstorm-collector.sh" \
+        --server "$STUB_HOST" --port "$STUB_PORT" \
+        --dir "$FIXTURES_DIR" --max-age 7 --max-size-kb 200 --quiet 2>/dev/null || true
+    sleep 1
+    assert_uploaded     "$start" "fresh.txt"    "bash/combined"
+    assert_not_uploaded "$start" "medium.bin"   "bash/combined"
+    assert_not_uploaded "$start" "old.txt"      "bash/combined"
+    assert_not_uploaded "$start" "large.bin"    "bash/combined"
+
+    echo ""
+fi
+
+# ══════════════════════════════════════════════
+# ASH / POSIX SH COLLECTOR
+# ══════════════════════════════════════════════
+if collector_runnable ash; then
+    echo "── POSIX sh Collector (via $ASH_SHELL) ──────"
+
+    start=$(log_lines)
+    # Intentionally rely on word splitting so "busybox sh" works.
+    # shellcheck disable=SC2086
+    $ASH_SHELL "$SCRIPTS_DIR/thunderstorm-collector-ash.sh" \
+        --server "$STUB_HOST" --port "$STUB_PORT" \
+        --dir "$FIXTURES_DIR" --max-size-kb 1000 --max-age 365 --quiet 2>/dev/null || true
+    sleep 1
+    assert_uploaded     "$start" "small.txt"    "ash/max-size-1000KB"
+    assert_uploaded     "$start" "medium.bin"   "ash/max-size-1000KB"
+    assert_not_uploaded "$start" "large.bin"    "ash/max-size-1000KB"
+    assert_not_uploaded "$start" "huge.bin"     "ash/max-size-1000KB"
+
+    start=$(log_lines)
+    $ASH_SHELL "$SCRIPTS_DIR/thunderstorm-collector-ash.sh" \
+        --server "$STUB_HOST" --port "$STUB_PORT" \
+        --dir "$FIXTURES_DIR" --max-age 7 --max-size-kb 50000 --quiet 2>/dev/null || true
+    sleep 1
+    assert_uploaded     "$start" "fresh.txt"    "ash/max-age-7d"
+    assert_not_uploaded "$start" "old.txt"      "ash/max-age-7d"
+    assert_not_uploaded "$start" "ancient.txt"  "ash/max-age-7d"
+
+    echo ""
+elif collector_enabled ash; then
+    echo "── POSIX sh Collector ────────────────────────"
+    skip "neither dash nor busybox available"
+    echo ""
+fi
+
+# ══════════════════════════════════════════════
+# PYTHON 3 COLLECTOR
+# ══════════════════════════════════════════════
+if collector_enabled python3; then
+    echo "── Python 3 Collector ────────────────────────"
+
+    # max-size test: 1024KB (~1MB), 365 days max_age
+    py_script="$(patch_python 365 1024)"
+    start=$(log_lines)
+    python3 "$py_script" -s "$STUB_HOST" -p "$STUB_PORT" -d "$FIXTURES_DIR" 2>/dev/null || true
+    sleep 1
+    assert_uploaded     "$start" "small.txt"    "python3/max-size-1MB"
+    assert_uploaded     "$start" "medium.bin"   "python3/max-size-1MB"
+    assert_not_uploaded "$start" "large.bin"    "python3/max-size-1MB"
+    assert_not_uploaded "$start" "huge.bin"     "python3/max-size-1MB"
+
+    # max-age test: patch to 7 days max_age, 100MB max_size
+    py_script="$(patch_python 7 50000)"
+    start=$(log_lines)
+    python3 "$py_script" -s "$STUB_HOST" -p "$STUB_PORT" -d "$FIXTURES_DIR" 2>/dev/null || true
+    sleep 1
+    assert_uploaded     "$start" "fresh.txt"    "python3/max-age-7d"
+    assert_not_uploaded "$start" "old.txt"      "python3/max-age-7d"
+    assert_not_uploaded "$start" "ancient.txt"  "python3/max-age-7d"
+
+    # combined: 7 days + 200KB (only tiny fresh files; medium.bin is 500KB → filtered)
+    py_script="$(patch_python 7 200)"
+    start=$(log_lines)
+    python3 "$py_script" -s "$STUB_HOST" -p "$STUB_PORT" -d "$FIXTURES_DIR" 2>/dev/null || true
+    sleep 1
+    assert_uploaded     "$start" "fresh.txt"    "python3/combined"
+    assert_not_uploaded "$start" "medium.bin"   "python3/combined"
+    assert_not_uploaded "$start" "old.txt"      "python3/combined"
+
+    echo ""
+fi
+
+# ══════════════════════════════════════════════
+# PYTHON 2 COLLECTOR
+# ══════════════════════════════════════════════
+if collector_enabled python2 && command -v python2 >/dev/null 2>&1; then
+    echo "── Python 2 Collector ────────────────────────"
+
+    py2_script="$(patch_python2 365 1024)"
+    start=$(log_lines)
+    python2 "$py2_script" -s "$STUB_HOST" -p "$STUB_PORT" -d "$FIXTURES_DIR" 2>/dev/null || true
+    sleep 1
+    assert_uploaded     "$start" "small.txt"    "python2/max-size-1MB"
+    assert_not_uploaded "$start" "large.bin"    "python2/max-size-1MB"
+
+    py2_script="$(patch_python2 7 50000)"
+    start=$(log_lines)
+    python2 "$py2_script" -s "$STUB_HOST" -p "$STUB_PORT" -d "$FIXTURES_DIR" 2>/dev/null || true
+    sleep 1
+    assert_uploaded     "$start" "fresh.txt"    "python2/max-age-7d"
+    assert_not_uploaded "$start" "old.txt"      "python2/max-age-7d"
+
+    echo ""
+elif collector_enabled python2; then
+    echo "── Python 2 Collector ────────────────────────"
+    skip "python2 not available"
+    echo ""
+fi
+
+# ══════════════════════════════════════════════
+# PERL COLLECTOR
+# ══════════════════════════════════════════════
+if collector_enabled perl; then
+    echo "── Perl Collector ────────────────────────────"
+
+    # max-size test: 1024KB (~1MB), 365 days
+    pl_script="$(patch_perl 365 1024)"
+    start=$(log_lines)
+    perl "$pl_script" -s "$STUB_HOST" --port "$STUB_PORT" --dir "$FIXTURES_DIR" 2>/dev/null || true
+    sleep 1
+    assert_uploaded     "$start" "small.txt"    "perl/max-size-1MB"
+    assert_not_uploaded "$start" "large.bin"    "perl/max-size-1MB"
+    assert_not_uploaded "$start" "huge.bin"     "perl/max-size-1MB"
+
+    # max-age test: 7 days, 50000KB (~50MB, effectively no size limit)
+    pl_script="$(patch_perl 7 50000)"
+    start=$(log_lines)
+    perl "$pl_script" -s "$STUB_HOST" --port "$STUB_PORT" --dir "$FIXTURES_DIR" 2>/dev/null || true
+    sleep 1
+    assert_uploaded     "$start" "fresh.txt"    "perl/max-age-7d"
+    assert_not_uploaded "$start" "old.txt"      "perl/max-age-7d"
+    assert_not_uploaded "$start" "ancient.txt"  "perl/max-age-7d"
+
+    echo ""
+fi
+
+# ══════════════════════════════════════════════
+# POWERSHELL COLLECTORS
+# ══════════════════════════════════════════════
+if collector_enabled ps3 && command -v pwsh >/dev/null 2>&1; then
+    echo "── PowerShell 3+ Collector ─────────────────"
+
+    # max-size: 1MB — use wildcard extension '*' to match all files
+    start=$(log_lines)
+    pwsh -NoProfile -ep bypass -c "& '$SCRIPTS_DIR/thunderstorm-collector.ps1' \
+        -ThunderstormServer '$STUB_HOST' -ThunderstormPort $STUB_PORT \
+        -Folder '$FIXTURES_DIR' -MaxSize 1 -MaxAge 365 \
+        -Extensions @('.txt','.bin','.exe','.dll','.jpg','.conf')" 2>/dev/null || true
+    sleep 1
+    assert_uploaded     "$start" "small.txt"    "ps3/max-size-1MB"
+    assert_uploaded     "$start" "medium.bin"   "ps3/max-size-1MB"
+    assert_not_uploaded "$start" "large.bin"    "ps3/max-size-1MB"
+    assert_not_uploaded "$start" "huge.bin"     "ps3/max-size-1MB"
+
+    # max-age: 7 days
+    start=$(log_lines)
+    pwsh -NoProfile -ep bypass -c "& '$SCRIPTS_DIR/thunderstorm-collector.ps1' \
+        -ThunderstormServer '$STUB_HOST' -ThunderstormPort $STUB_PORT \
+        -Folder '$FIXTURES_DIR' -MaxAge 7 -MaxSize 100 \
+        -Extensions @('.txt','.bin','.exe','.dll','.jpg','.conf')" 2>/dev/null || true
+    sleep 1
+    assert_uploaded     "$start" "fresh.txt"    "ps3/max-age-7d"
+    assert_not_uploaded "$start" "old.txt"      "ps3/max-age-7d"
+    assert_not_uploaded "$start" "ancient.txt"  "ps3/max-age-7d"
+
+    # extension filtering: only .exe and .dll
+    start=$(log_lines)
+    pwsh -NoProfile -ep bypass -c "& '$SCRIPTS_DIR/thunderstorm-collector.ps1' \
+        -ThunderstormServer '$STUB_HOST' -ThunderstormPort $STUB_PORT \
+        -Folder '$FIXTURES_DIR' -MaxAge 365 -MaxSize 100 \
+        -Extensions @('.exe', '.dll')" 2>/dev/null || true
+    sleep 1
+    assert_uploaded     "$start" "sample.exe"   "ps3/ext-filter"
+    assert_uploaded     "$start" "sample.dll"   "ps3/ext-filter"
+    assert_not_uploaded "$start" "photo.jpg"    "ps3/ext-filter"
+    assert_not_uploaded "$start" "fresh.txt"    "ps3/ext-filter"
+    assert_not_uploaded "$start" "noext"        "ps3/ext-filter"
+
+    echo ""
+fi
+
+if collector_enabled ps2 && command -v pwsh >/dev/null 2>&1; then
+    echo "── PowerShell 2+ Collector ─────────────────"
+
+    start=$(log_lines)
+    pwsh -NoProfile -ep bypass -c "& '$SCRIPTS_DIR/thunderstorm-collector-ps2.ps1' \
+        -ThunderstormServer '$STUB_HOST' -ThunderstormPort $STUB_PORT \
+        -Folder '$FIXTURES_DIR' -MaxSize 1 -MaxAge 365 \
+        -Extensions @('.txt','.bin','.exe','.dll','.jpg','.conf')" 2>/dev/null || true
+    sleep 1
+    assert_uploaded     "$start" "small.txt"    "ps2/max-size-1MB"
+    assert_not_uploaded "$start" "large.bin"    "ps2/max-size-1MB"
+
+    start=$(log_lines)
+    pwsh -NoProfile -ep bypass -c "& '$SCRIPTS_DIR/thunderstorm-collector-ps2.ps1' \
+        -ThunderstormServer '$STUB_HOST' -ThunderstormPort $STUB_PORT \
+        -Folder '$FIXTURES_DIR' -MaxAge 7 -MaxSize 100 \
+        -Extensions @('.txt','.bin','.exe','.dll','.jpg','.conf')" 2>/dev/null || true
+    sleep 1
+    assert_uploaded     "$start" "fresh.txt"    "ps2/max-age-7d"
+    assert_not_uploaded "$start" "old.txt"      "ps2/max-age-7d"
+
+    # PS2 extension filtering
+    start=$(log_lines)
+    pwsh -NoProfile -ep bypass -c "& '$SCRIPTS_DIR/thunderstorm-collector-ps2.ps1' \
+        -ThunderstormServer '$STUB_HOST' -ThunderstormPort $STUB_PORT \
+        -Folder '$FIXTURES_DIR' -MaxAge 365 -MaxSize 100 \
+        -Extensions @('.exe', '.dll')" 2>/dev/null || true
+    sleep 1
+    assert_uploaded     "$start" "sample.exe"   "ps2/ext-filter"
+    assert_uploaded     "$start" "sample.dll"   "ps2/ext-filter"
+    assert_not_uploaded "$start" "photo.jpg"    "ps2/ext-filter"
+
+    echo ""
+elif { collector_enabled ps3 || collector_enabled ps2; } && ! command -v pwsh >/dev/null 2>&1; then
+    echo "── PowerShell Collectors ─────────────────────"
+    skip "pwsh not available"
+    echo ""
+fi
+
+# ══════════════════════════════════════════════
+# SUMMARY
+# ══════════════════════════════════════════════
+echo "============================================"
+echo " Results: $PASS passed, $FAIL failed, $SKIP skipped"
+echo "============================================"
+
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/scripts/tests/run_operational_tests.sh
+++ b/scripts/tests/run_operational_tests.sh
@@ -1,0 +1,983 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Operational Feature Tests
+#
+# Tests operational features not covered by detection tests:
+#
+#  1.  Collection markers — begin/end markers sent, scan_id propagated
+#  2.  Interrupted marker — SIGINT sends interrupted marker before exit
+#  3.  Dry-run mode — no uploads, no server contact (bash/ash/python/perl)
+#  4.  Source identifier — --source sets source field in collection markers
+#  5.  Sync mode — --sync uses /api/check instead of /api/checkAsync
+#  6.  Multiple scan directories — scanning multiple dirs in one run
+#  7.  503 back-pressure — server returns 503, collector retries with Retry-After
+#  8.  Progress reporting — --progress flag doesn't crash, produces output
+#  9.  Syslog logging — --syslog flag doesn't crash (bash only)
+# 10.  curl vs wget fallback — bash collector works with wget when curl absent
+#
+# Requires: thunderstorm-stub server with YARA support
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+COLLECTOR_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+STUB_PORT="${STUB_PORT:-18200}"
+STUB_URL="http://localhost:${STUB_PORT}"
+STUB_LOG=""
+STUB_PID=""
+RULES_DIR=""
+COLLECTOR_FILTER_RAW="${THUNDERSTORM_TEST_COLLECTORS:-}"
+COLLECTOR_REQUIRE_MATCH="${THUNDERSTORM_TEST_REQUIRE_MATCH:-0}"
+COLLECTOR_REQUIRE_ALL="${THUNDERSTORM_TEST_REQUIRE_ALL:-0}"
+
+# Colours
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[1;36m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_SKIPPED=0
+FAILED_NAMES=""
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+pass() { printf "  ${GREEN}PASS${RESET} %s\n" "$*"; TESTS_PASSED=$((TESTS_PASSED + 1)); }
+fail() { printf "  ${RED}FAIL${RESET} %s\n" "$*"; TESTS_FAILED=$((TESTS_FAILED + 1)); FAILED_NAMES="$FAILED_NAMES  - $1\n"; }
+skip() { printf "  ${YELLOW}SKIP${RESET} %s\n" "$*"; TESTS_SKIPPED=$((TESTS_SKIPPED + 1)); }
+
+normalize_collector() {
+    case "$1" in
+        bash|ash|perl|ps3|ps2) printf '%s\n' "$1" ;;
+        python|python3) printf 'python\n' ;;
+        powershell|powershell3|pwsh|ps) printf 'ps3\n' ;;
+        powershell2|psv2) printf 'ps2\n' ;;
+        *) printf '%s\n' "$1" ;;
+    esac
+}
+
+collector_enabled() {
+    local current wanted
+    current="$(normalize_collector "$1")"
+    [ -z "$COLLECTOR_FILTER_RAW" ] && return 0
+
+    for wanted in ${COLLECTOR_FILTER_RAW//,/ }; do
+        if [ "$(normalize_collector "$wanted")" = "$current" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+is_truthy() {
+    case "${1:-0}" in
+        1|true|TRUE|yes|YES|on|ON) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+list_contains() {
+    local needle="$1" item
+    shift
+    for item in "$@"; do
+        [ "$item" = "$needle" ] && return 0
+    done
+    return 1
+}
+
+collector_script_path() {
+    case "$(normalize_collector "$1")" in
+        bash) printf '%s/thunderstorm-collector.sh\n' "$COLLECTOR_DIR" ;;
+        ash) printf '%s/thunderstorm-collector-ash.sh\n' "$COLLECTOR_DIR" ;;
+        python) printf '%s/thunderstorm-collector.py\n' "$COLLECTOR_DIR" ;;
+        perl) printf '%s/thunderstorm-collector.pl\n' "$COLLECTOR_DIR" ;;
+        ps3) printf '%s/thunderstorm-collector.ps1\n' "$COLLECTOR_DIR" ;;
+        ps2) printf '%s/thunderstorm-collector-ps2.ps1\n' "$COLLECTOR_DIR" ;;
+        *) return 1 ;;
+    esac
+}
+
+collector_runnable() {
+    local current script_path
+    current="$(normalize_collector "$1")"
+    script_path="$(collector_script_path "$current")" || return 1
+    [ -f "$script_path" ] || return 1
+
+    case "$current" in
+        bash) command -v bash >/dev/null 2>&1 ;;
+        ash) [ -n "$ASH_SHELL" ] ;;
+        python) command -v python3 >/dev/null 2>&1 ;;
+        perl) command -v perl >/dev/null 2>&1 && perl -MLWP::UserAgent -e1 2>/dev/null ;;
+        ps3|ps2) command -v pwsh >/dev/null 2>&1 ;;
+        *) return 1 ;;
+    esac
+}
+
+validate_available_collectors() {
+    local available=("$@")
+    local wanted normalized missing=()
+
+    if is_truthy "$COLLECTOR_REQUIRE_MATCH" && [ "${#available[@]}" -eq 0 ]; then
+        echo "ERROR: no runnable collectors matched THUNDERSTORM_TEST_COLLECTORS='${COLLECTOR_FILTER_RAW}'" >&2
+        exit 1
+    fi
+
+    if is_truthy "$COLLECTOR_REQUIRE_ALL" && [ -n "$COLLECTOR_FILTER_RAW" ]; then
+        for wanted in ${COLLECTOR_FILTER_RAW//,/ }; do
+            normalized="$(normalize_collector "$wanted")"
+            if ! list_contains "$normalized" "${available[@]}"; then
+                missing+=("$normalized")
+            fi
+        done
+        if [ "${#missing[@]}" -gt 0 ]; then
+            echo "ERROR: requested collectors are not runnable: ${missing[*]}" >&2
+            exit 1
+        fi
+    fi
+}
+
+MALICIOUS_CONTENT='X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*'
+
+detect_ash_shell() {
+    if command -v ash >/dev/null 2>&1; then
+        echo "ash"
+    elif command -v dash >/dev/null 2>&1; then
+        echo "dash"
+    elif command -v busybox >/dev/null 2>&1; then
+        echo "busybox sh"
+    else
+        echo ""
+    fi
+}
+
+ASH_SHELL="${ASH_SHELL:-$(detect_ash_shell)}"
+
+find_stub() {
+    local candidates=(
+        "${STUB_BIN_PATH:-}"
+        "$SCRIPT_DIR/../../../thunderstorm-stub-server/thunderstorm-stub"
+        "$(command -v thunderstorm-stub 2>/dev/null || true)"
+    )
+    for c in "${candidates[@]}"; do
+        [ -n "$c" ] && [ -x "$c" ] && echo "$c" && return 0
+    done
+    echo "ERROR: thunderstorm-stub not found" >&2
+    return 1
+}
+
+find_rules() {
+    local candidates=(
+        "${STUB_RULES_PATH:-}"
+        "$SCRIPT_DIR/../../../thunderstorm-stub-server/rules"
+    )
+    for c in "${candidates[@]}"; do
+        [ -n "$c" ] && [ -d "$c" ] && echo "$c" && return 0
+    done
+    echo "ERROR: rules directory not found" >&2
+    return 1
+}
+
+start_stub() {
+    local stub_bin; stub_bin="$(find_stub)"
+    RULES_DIR="$(find_rules)"
+    STUB_LOG="$(mktemp /tmp/oper-test-XXXXXX.jsonl)"
+
+    "$stub_bin" -port "$STUB_PORT" -rules-dir "$RULES_DIR" -log-file "$STUB_LOG" \
+        > /dev/null 2>&1 &
+    STUB_PID=$!
+    sleep 2
+    if ! curl -s "$STUB_URL/api/status" > /dev/null; then
+        echo "ERROR: stub failed to start on port $STUB_PORT" >&2
+        exit 1
+    fi
+}
+
+stop_stub() {
+    [ -n "$STUB_PID" ] && kill "$STUB_PID" 2>/dev/null && wait "$STUB_PID" 2>/dev/null || true
+    STUB_PID=""
+}
+
+clear_log() {
+    curl -s -X POST "$STUB_URL/api/test/reset" > /dev/null 2>&1 || true
+}
+
+query_log() {
+    local pattern="$1"
+    python3 -c "
+import json, sys
+for line in open('$STUB_LOG'):
+    line = line.strip()
+    if not line: continue
+    d = json.loads(line)
+    # Search in client_filename, type, marker fields
+    cf = d.get('subject', {}).get('client_filename', '')
+    mtype = d.get('type', '')
+    marker = d.get('marker', '')
+    source = d.get('source', '')
+    raw = json.dumps(d)
+    if '$pattern' in cf or '$pattern' in mtype or '$pattern' in marker or '$pattern' in source or '$pattern' in raw:
+        print(line)
+" 2>/dev/null
+}
+
+sync_stub() { sleep 1; }
+
+# Configure stub to return specific responses
+configure_stub() {
+    local config="$1"
+    curl -s -X POST "$STUB_URL/api/test/config" \
+        -H "Content-Type: application/json" \
+        -d "$config" > /dev/null
+}
+
+# Translate generic flags to PS parameter names
+_translate_ps_args() {
+    local -n out_args=$1; shift
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --max-size-kb) out_args+=("-MaxSize" "$(( $2 / 1024 ))"); shift 2 ;;
+            --max-age)     out_args+=("-MaxAge" "$2"); shift 2 ;;
+            *)             out_args+=("$1"); shift ;;
+        esac
+    done
+}
+
+run_collector() {
+    local name="$1"; shift
+    case "$name" in
+        bash)   run_bash "$@" ;;
+        ash)    run_ash "$@" ;;
+        python) run_python "$@" ;;
+        perl)   run_perl "$@" ;;
+        ps3)    run_ps3 "$@" ;;
+        ps2)    run_ps2 "$@" ;;
+    esac
+}
+
+run_bash() {
+    local dir="$1"; shift
+    bash "${COLLECTOR_DIR}/thunderstorm-collector.sh" \
+        --server localhost --port "$STUB_PORT" --dir "$dir" \
+        "$@" 2>&1
+}
+
+run_ash() {
+    local dir="$1"; shift
+    [ -n "$ASH_SHELL" ] || return 127
+    # Intentionally rely on shell word splitting so "busybox sh" works.
+    # shellcheck disable=SC2086
+    $ASH_SHELL "${COLLECTOR_DIR}/thunderstorm-collector-ash.sh" \
+        --server localhost --port "$STUB_PORT" --dir "$dir" \
+        "$@" 2>&1
+}
+
+run_python() {
+    local dir="$1"; shift
+    python3 "${COLLECTOR_DIR}/thunderstorm-collector.py" \
+        --server localhost --port "$STUB_PORT" --dir "$dir" \
+        "$@" 2>&1
+}
+
+run_perl() {
+    local dir="$1"; shift
+    perl "${COLLECTOR_DIR}/thunderstorm-collector.pl" \
+        -s localhost -p "$STUB_PORT" --dir "$dir" \
+        "$@" 2>&1
+}
+
+run_ps3() {
+    local dir="$1"; shift
+    local args=()
+    _translate_ps_args args "$@"
+    pwsh -NoProfile -File "${COLLECTOR_DIR}/thunderstorm-collector.ps1" \
+        -ThunderstormServer localhost -ThunderstormPort "$STUB_PORT" -Folder "$dir" \
+        "${args[@]}" 2>&1
+}
+
+run_ps2() {
+    local dir="$1"; shift
+    local args=()
+    _translate_ps_args args "$@"
+    pwsh -NoProfile -File "${COLLECTOR_DIR}/thunderstorm-collector-ps2.ps1" \
+        -ThunderstormServer localhost -ThunderstormPort "$STUB_PORT" -Folder "$dir" \
+        "${args[@]}" 2>&1
+}
+
+# ============================================================================
+# Tests
+# ============================================================================
+
+# ── 1. Collection markers — begin/end with scan_id ─────────────────────────
+test_collection_markers() {
+    local collector="$1"
+    clear_log
+
+    local fixtures; fixtures="$(mktemp -d /tmp/oper-test-XXXXXX)"
+    echo "$MALICIOUS_CONTENT" > "$fixtures/marker-${collector}.exe"
+
+    run_collector "$collector" "$fixtures" --max-age 30 >/dev/null 2>&1 || true
+    sync_stub
+
+    # Check for begin marker
+    local begin_entry; begin_entry="$(query_log 'begin')"
+    if [ -z "$begin_entry" ]; then
+        fail "$collector/collection-markers: no begin marker found"
+        rm -rf "$fixtures"
+        return
+    fi
+
+    # Check for end marker
+    local end_entry; end_entry="$(query_log 'end')"
+    if [ -z "$end_entry" ]; then
+        fail "$collector/collection-markers: no end marker found"
+        rm -rf "$fixtures"
+        return
+    fi
+
+    # Verify scan_id is present and consistent
+    local begin_scan_id; begin_scan_id="$(echo "$begin_entry" | head -1 | python3 -c "import json,sys; print(json.load(sys.stdin).get('scan_id',''))" 2>/dev/null)"
+    local end_scan_id; end_scan_id="$(echo "$end_entry" | head -1 | python3 -c "import json,sys; print(json.load(sys.stdin).get('scan_id',''))" 2>/dev/null)"
+
+    if [ -z "$begin_scan_id" ]; then
+        fail "$collector/collection-markers: begin marker missing scan_id"
+    elif [ "$begin_scan_id" != "$end_scan_id" ]; then
+        fail "$collector/collection-markers: scan_id mismatch (begin=$begin_scan_id end=$end_scan_id)"
+    else
+        pass "$collector/collection-markers: begin+end markers with matching scan_id=$begin_scan_id"
+    fi
+
+    # Verify end marker has stats
+    local has_stats; has_stats="$(echo "$end_entry" | head -1 | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+stats = d.get('stats', {})
+print('yes' if stats and 'submitted' in str(stats) else 'no')
+" 2>/dev/null)"
+    if [ "$has_stats" = "yes" ]; then
+        pass "$collector/collection-markers-stats: end marker includes stats"
+    else
+        fail "$collector/collection-markers-stats: end marker missing stats"
+    fi
+
+    rm -rf "$fixtures"
+}
+
+# ── 2. Interrupted marker via SIGINT ────────────────────────────────────────
+test_interrupted_marker() {
+    local collector="$1"
+    clear_log
+
+    # Create a large directory tree so the collector takes a while
+    local fixtures; fixtures="$(mktemp -d /tmp/oper-test-XXXXXX)"
+    for i in $(seq 1 200); do
+        echo "$MALICIOUS_CONTENT" > "$fixtures/file-${collector}-${i}.exe"
+    done
+
+    # Start collector in background
+    local pid_file; pid_file="$(mktemp /tmp/oper-pid-XXXXXX)"
+    case "$collector" in
+        bash)
+            bash "${COLLECTOR_DIR}/thunderstorm-collector.sh" \
+                --server localhost --port "$STUB_PORT" --dir "$fixtures" \
+                --max-age 30 > /dev/null 2>&1 &
+            echo $! > "$pid_file"
+            ;;
+        ash)
+            # shellcheck disable=SC2086
+            $ASH_SHELL "${COLLECTOR_DIR}/thunderstorm-collector-ash.sh" \
+                --server localhost --port "$STUB_PORT" --dir "$fixtures" \
+                --max-age 30 > /dev/null 2>&1 &
+            echo $! > "$pid_file"
+            ;;
+        python)
+            python3 "${COLLECTOR_DIR}/thunderstorm-collector.py" \
+                -s localhost -p "$STUB_PORT" -d "$fixtures" \
+                --max-age 30 > /dev/null 2>&1 &
+            echo $! > "$pid_file"
+            ;;
+        perl)
+            perl "${COLLECTOR_DIR}/thunderstorm-collector.pl" \
+                -s localhost -p "$STUB_PORT" --dir "$fixtures" \
+                --max-age 30 > /dev/null 2>&1 &
+            echo $! > "$pid_file"
+            ;;
+        ps3)
+            pwsh -NoProfile -File "${COLLECTOR_DIR}/thunderstorm-collector.ps1" \
+                -ThunderstormServer localhost -ThunderstormPort "$STUB_PORT" -Folder "$fixtures" \
+                -MaxAge 30 > /dev/null 2>&1 &
+            echo $! > "$pid_file"
+            ;;
+        ps2)
+            pwsh -NoProfile -File "${COLLECTOR_DIR}/thunderstorm-collector-ps2.ps1" \
+                -ThunderstormServer localhost -ThunderstormPort "$STUB_PORT" -Folder "$fixtures" \
+                -MaxAge 30 > /dev/null 2>&1 &
+            echo $! > "$pid_file"
+            ;;
+    esac
+
+    local coll_pid; coll_pid="$(cat "$pid_file")"
+
+    # Wait for begin marker to appear (collector is running)
+    local waited=0
+    while [ $waited -lt 10 ]; do
+        if query_log 'begin' | grep -q 'begin' 2>/dev/null; then
+            break
+        fi
+        sleep 0.5
+        waited=$((waited + 1))
+    done
+
+    # Send SIGINT (Ctrl-C)
+    kill -INT "$coll_pid" 2>/dev/null || true
+    # Wait for collector to finish
+    wait "$coll_pid" 2>/dev/null || true
+    sync_stub
+    sync_stub  # extra wait for marker
+
+    # Check for interrupted marker
+    local int_entry; int_entry="$(query_log 'interrupted')"
+    if [ -n "$int_entry" ]; then
+        pass "$collector/interrupted-marker: interrupted marker sent on SIGINT"
+    else
+        # Some collectors may not support interrupted markers
+        local end_entry; end_entry="$(query_log 'end')"
+        if [ -n "$end_entry" ]; then
+            # Sent end marker instead of interrupted — acceptable
+            skip "$collector/interrupted-marker: sent end marker instead of interrupted on SIGINT"
+        else
+            fail "$collector/interrupted-marker: no interrupted or end marker on SIGINT"
+        fi
+    fi
+
+    rm -rf "$fixtures" "$pid_file"
+}
+
+# ── 3. Dry-run mode ────────────────────────────────────────────────────────
+test_dry_run() {
+    local collector="$1"
+
+    # PS collectors don't support dry-run
+    case "$collector" in
+        ps3|ps2)
+            skip "$collector/dry-run: not supported"
+            return
+            ;;
+    esac
+
+    clear_log
+
+    local fixtures; fixtures="$(mktemp -d /tmp/oper-test-XXXXXX)"
+    echo "$MALICIOUS_CONTENT" > "$fixtures/dryrun-${collector}.exe"
+
+    local output
+    case "$collector" in
+        bash)   output="$(run_bash "$fixtures" --max-age 30 --dry-run 2>&1)" ;;
+        ash)    output="$(run_ash "$fixtures" --max-age 30 --dry-run 2>&1)" ;;
+        python) output="$(run_python "$fixtures" --max-age 30 --dry-run 2>&1)" ;;
+        perl)   output="$(run_perl "$fixtures" --max-age 30 --dry-run 2>&1)" ;;
+    esac
+    sync_stub
+
+    # Verify no uploads occurred
+    local upload_entry; upload_entry="$(query_log "dryrun-${collector}")"
+    if [ -n "$upload_entry" ]; then
+        fail "$collector/dry-run: file was uploaded (should not be)"
+    else
+        # Verify the dry-run output mentions the file
+        if echo "$output" | grep -qi "dryrun-${collector}\|dry.run\|would"; then
+            pass "$collector/dry-run: no upload, file listed in output"
+        else
+            fail "$collector/dry-run: no upload, but file not mentioned in output"
+        fi
+    fi
+
+    rm -rf "$fixtures"
+}
+
+# ── 4. Source identifier ────────────────────────────────────────────────────
+test_source_identifier() {
+    local collector="$1"
+    clear_log
+
+    local fixtures; fixtures="$(mktemp -d /tmp/oper-test-XXXXXX)"
+    echo "$MALICIOUS_CONTENT" > "$fixtures/source-${collector}.exe"
+
+    local source_name="test-source-${collector}"
+    case "$collector" in
+        bash)
+            run_bash "$fixtures" --max-age 30 --source "$source_name" >/dev/null 2>&1 || true
+            ;;
+        ash)
+            run_ash "$fixtures" --max-age 30 --source "$source_name" >/dev/null 2>&1 || true
+            ;;
+        python)
+            python3 "${COLLECTOR_DIR}/thunderstorm-collector.py" \
+                -s localhost -p "$STUB_PORT" -d "$fixtures" \
+                --max-age 30 --source "$source_name" >/dev/null 2>&1 || true
+            ;;
+        perl)
+            perl "${COLLECTOR_DIR}/thunderstorm-collector.pl" \
+                -s localhost -p "$STUB_PORT" --dir "$fixtures" \
+                --max-age 30 --source "$source_name" >/dev/null 2>&1 || true
+            ;;
+        ps3)
+            pwsh -NoProfile -File "${COLLECTOR_DIR}/thunderstorm-collector.ps1" \
+                -ThunderstormServer localhost -ThunderstormPort "$STUB_PORT" -Folder "$fixtures" \
+                -MaxAge 30 -Source "$source_name" >/dev/null 2>&1 || true
+            ;;
+        ps2)
+            pwsh -NoProfile -File "${COLLECTOR_DIR}/thunderstorm-collector-ps2.ps1" \
+                -ThunderstormServer localhost -ThunderstormPort "$STUB_PORT" -Folder "$fixtures" \
+                -MaxAge 30 -Source "$source_name" >/dev/null 2>&1 || true
+            ;;
+    esac
+    sync_stub
+
+    # Check collection markers for source field
+    local marker_entry; marker_entry="$(query_log 'begin')"
+    if [ -n "$marker_entry" ]; then
+        local source_in_marker; source_in_marker="$(echo "$marker_entry" | head -1 | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+print(d.get('source', ''))
+" 2>/dev/null)"
+        if [ "$source_in_marker" = "$source_name" ]; then
+            pass "$collector/source-id: source='$source_name' in collection marker"
+        else
+            fail "$collector/source-id: expected source='$source_name', got source='$source_in_marker'"
+        fi
+    else
+        # Check if source is in the upload URL query params
+        local upload_entry; upload_entry="$(query_log "source-${collector}")"
+        if [ -n "$upload_entry" ]; then
+            local src_in_upload; src_in_upload="$(echo "$upload_entry" | head -1 | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+s = d.get('subject', {}).get('source', '')
+print(s)
+" 2>/dev/null)"
+            if [ "$src_in_upload" = "$source_name" ]; then
+                pass "$collector/source-id: source='$source_name' in upload"
+            else
+                pass "$collector/source-id: file uploaded (source may be in URL params)"
+            fi
+        else
+            fail "$collector/source-id: no marker or upload found"
+        fi
+    fi
+
+    rm -rf "$fixtures"
+}
+
+# ── 5. Sync mode ───────────────────────────────────────────────────────────
+test_sync_mode() {
+    local collector="$1"
+
+    # PS collectors don't support --sync flag
+    case "$collector" in
+        ps3|ps2)
+            skip "$collector/sync-mode: not supported (PS always uses checkAsync)"
+            return
+            ;;
+    esac
+
+    clear_log
+
+    local fixtures; fixtures="$(mktemp -d /tmp/oper-test-XXXXXX)"
+    echo "$MALICIOUS_CONTENT" > "$fixtures/sync-${collector}.exe"
+
+    case "$collector" in
+        bash)   run_bash "$fixtures" --max-age 30 --sync >/dev/null 2>&1 || true ;;
+        ash)    run_ash "$fixtures" --max-age 30 --sync >/dev/null 2>&1 || true ;;
+        python) run_python "$fixtures" --max-age 30 --sync >/dev/null 2>&1 || true ;;
+        perl)   run_perl "$fixtures" --max-age 30 --sync >/dev/null 2>&1 || true ;;
+    esac
+    sync_stub
+
+    # In sync mode, the stub logs the scan immediately (no async queue)
+    local entry; entry="$(query_log "sync-${collector}")"
+    if [ -n "$entry" ]; then
+        local score; score="$(echo "$entry" | head -1 | python3 -c "import json,sys; print(json.load(sys.stdin).get('score',0))" 2>/dev/null)"
+        pass "$collector/sync-mode: file scanned synchronously (score=$score)"
+    else
+        fail "$collector/sync-mode: file not found in log"
+    fi
+
+    rm -rf "$fixtures"
+}
+
+# ── 6. Multiple scan directories ───────────────────────────────────────────
+test_multiple_dirs() {
+    local collector="$1"
+
+    # PS collectors only accept a single -Folder
+    case "$collector" in
+        ps3|ps2)
+            skip "$collector/multiple-dirs: PS accepts single -Folder only"
+            return
+            ;;
+    esac
+
+    clear_log
+
+    local dir1; dir1="$(mktemp -d /tmp/oper-test-XXXXXX)"
+    local dir2; dir2="$(mktemp -d /tmp/oper-test-XXXXXX)"
+    echo "$MALICIOUS_CONTENT" > "$dir1/multi1-${collector}.exe"
+    echo "$MALICIOUS_CONTENT" > "$dir2/multi2-${collector}.exe"
+
+    case "$collector" in
+        bash)
+            bash "${COLLECTOR_DIR}/thunderstorm-collector.sh" \
+                --server localhost --port "$STUB_PORT" \
+                --dir "$dir1" --dir "$dir2" \
+                --max-age 30 >/dev/null 2>&1 || true
+            ;;
+        ash)
+            # shellcheck disable=SC2086
+            $ASH_SHELL "${COLLECTOR_DIR}/thunderstorm-collector-ash.sh" \
+                --server localhost --port "$STUB_PORT" \
+                --dir "$dir1" --dir "$dir2" \
+                --max-age 30 >/dev/null 2>&1 || true
+            ;;
+        python)
+            python3 "${COLLECTOR_DIR}/thunderstorm-collector.py" \
+                -s localhost -p "$STUB_PORT" \
+                -d "$dir1" "$dir2" \
+                --max-age 30 >/dev/null 2>&1 || true
+            ;;
+        perl)
+            # Perl may only accept a single --dir — test and see
+            perl "${COLLECTOR_DIR}/thunderstorm-collector.pl" \
+                -s localhost -p "$STUB_PORT" --dir "$dir1" --dir "$dir2" \
+                --max-age 30 >/dev/null 2>&1 || true
+            ;;
+    esac
+    sync_stub
+
+    local f1; f1="$(query_log "multi1-${collector}")"
+    local f2; f2="$(query_log "multi2-${collector}")"
+
+    if [ -n "$f1" ] && [ -n "$f2" ]; then
+        pass "$collector/multiple-dirs: both directories scanned"
+    elif [ -n "$f1" ] || [ -n "$f2" ]; then
+        # Collector only scanned one dir — might only support single dir
+        if [ -n "$f1" ]; then
+            skip "$collector/multiple-dirs: only first directory scanned (single-dir only?)"
+        else
+            skip "$collector/multiple-dirs: only second directory scanned"
+        fi
+    else
+        fail "$collector/multiple-dirs: neither directory scanned"
+    fi
+
+    rm -rf "$dir1" "$dir2"
+}
+
+# ── 7. 503 back-pressure with Retry-After ──────────────────────────────────
+test_503_backpressure() {
+    local collector="$1"
+    clear_log
+
+    local fixtures; fixtures="$(mktemp -d /tmp/oper-test-XXXXXX)"
+    echo "$MALICIOUS_CONTENT" > "$fixtures/bp503-${collector}.exe"
+    echo "$MALICIOUS_CONTENT" > "$fixtures/bp503b-${collector}.exe"
+
+    # Configure stub: first upload returns 503 with Retry-After: 1
+    # Only the first request gets 503; subsequent requests proceed normally
+    configure_stub '{
+        "upload_rules": [
+            {"match_count": [1], "status": 503, "headers": {"Retry-After": "1"}}
+        ]
+    }'
+
+    local output
+    local collector_exit=0
+    case "$collector" in
+        bash)
+            output="$(timeout 30 bash "${COLLECTOR_DIR}/thunderstorm-collector.sh" \
+                --server localhost --port "$STUB_PORT" --dir "$fixtures" --max-age 30 --retries 5 2>&1)" || collector_exit=$?
+            ;;
+        ash)
+            # shellcheck disable=SC2086
+            output="$(timeout 30 $ASH_SHELL "${COLLECTOR_DIR}/thunderstorm-collector-ash.sh" \
+                --server localhost --port "$STUB_PORT" --dir "$fixtures" --max-age 30 --retries 5 2>&1)" || collector_exit=$?
+            ;;
+        python)
+            output="$(timeout 30 python3 "${COLLECTOR_DIR}/thunderstorm-collector.py" \
+                -s localhost -p "$STUB_PORT" -d "$fixtures" --max-age 30 --retries 5 2>&1)" || collector_exit=$?
+            ;;
+        perl)
+            output="$(timeout 30 perl "${COLLECTOR_DIR}/thunderstorm-collector.pl" \
+                -s localhost -p "$STUB_PORT" --dir "$fixtures" --max-age 30 --retries 5 2>&1)" || collector_exit=$?
+            ;;
+        ps3)
+            output="$(timeout 30 pwsh -NoProfile -File "${COLLECTOR_DIR}/thunderstorm-collector.ps1" \
+                -ThunderstormServer localhost -ThunderstormPort "$STUB_PORT" -Folder "$fixtures" -MaxAge 30 2>&1)" || collector_exit=$?
+            ;;
+        ps2)
+            output="$(timeout 30 pwsh -NoProfile -File "${COLLECTOR_DIR}/thunderstorm-collector-ps2.ps1" \
+                -ThunderstormServer localhost -ThunderstormPort "$STUB_PORT" -Folder "$fixtures" -MaxAge 30 2>&1)" || collector_exit=$?
+            ;;
+    esac
+    sync_stub
+    sync_stub  # extra wait for retry
+
+    # Reset config
+    configure_stub '{"upload_rules": []}'
+
+    # Check that at least one file was eventually submitted
+    local entry; entry="$(query_log "bp503")"
+    if [ -n "$entry" ]; then
+        # Check if output mentions retry/503
+        if echo "$output" | grep -qi '503\|retry\|busy\|back.off\|Retry-After'; then
+            pass "$collector/503-backpressure: retried after 503, file submitted"
+        else
+            pass "$collector/503-backpressure: file submitted (retry may be silent)"
+        fi
+    else
+        if echo "$output" | grep -qi '503\|busy\|Service Unavailable'; then
+            fail "$collector/503-backpressure: got 503 but never retried successfully"
+        else
+            fail "$collector/503-backpressure: no evidence of 503 handling"
+        fi
+    fi
+
+    rm -rf "$fixtures"
+}
+
+# ── 8. Progress reporting ──────────────────────────────────────────────────
+test_progress_reporting() {
+    local collector="$1"
+
+    # PS collectors use -Progress (switch) — handled differently
+    local progress_flag
+    case "$collector" in
+        bash)   progress_flag="--progress" ;;
+        ash)    progress_flag="--progress" ;;
+        python) progress_flag="--progress" ;;
+        perl)   progress_flag="--progress" ;;
+        ps3)    progress_flag="-Progress" ;;
+        ps2)    progress_flag="-Progress" ;;
+    esac
+
+    clear_log
+
+    local fixtures; fixtures="$(mktemp -d /tmp/oper-test-XXXXXX)"
+    for i in $(seq 1 5); do
+        echo "$MALICIOUS_CONTENT" > "$fixtures/prog-${collector}-${i}.exe"
+    done
+
+    local output
+    case "$collector" in
+        bash)
+            output="$(timeout 30 bash "${COLLECTOR_DIR}/thunderstorm-collector.sh" \
+                --server localhost --port "$STUB_PORT" --dir "$fixtures" --max-age 30 --progress 2>&1)" || true
+            ;;
+        ash)
+            # shellcheck disable=SC2086
+            output="$(timeout 30 $ASH_SHELL "${COLLECTOR_DIR}/thunderstorm-collector-ash.sh" \
+                --server localhost --port "$STUB_PORT" --dir "$fixtures" --max-age 30 --progress 2>&1)" || true
+            ;;
+        python)
+            output="$(timeout 30 python3 "${COLLECTOR_DIR}/thunderstorm-collector.py" \
+                -s localhost -p "$STUB_PORT" -d "$fixtures" --max-age 30 --progress 2>&1)" || true
+            ;;
+        perl)
+            output="$(timeout 30 perl "${COLLECTOR_DIR}/thunderstorm-collector.pl" \
+                -s localhost -p "$STUB_PORT" --dir "$fixtures" --max-age 30 --progress 2>&1)" || true
+            ;;
+        ps3)
+            output="$(timeout 30 pwsh -NoProfile -File "${COLLECTOR_DIR}/thunderstorm-collector.ps1" \
+                -ThunderstormServer localhost -ThunderstormPort "$STUB_PORT" -Folder "$fixtures" \
+                -MaxAge 30 -Progress 2>&1)" || true
+            ;;
+        ps2)
+            output="$(timeout 30 pwsh -NoProfile -File "${COLLECTOR_DIR}/thunderstorm-collector-ps2.ps1" \
+                -ThunderstormServer localhost -ThunderstormPort "$STUB_PORT" -Folder "$fixtures" \
+                -MaxAge 30 -Progress 2>&1)" || true
+            ;;
+    esac
+    sync_stub
+
+    # Check collector didn't crash and produced some output
+    local submitted; submitted="$(query_log "prog-${collector}")"
+    if [ -n "$submitted" ]; then
+        pass "$collector/progress: collector ran successfully with progress flag"
+    else
+        fail "$collector/progress: no files submitted with progress flag"
+    fi
+
+    rm -rf "$fixtures"
+}
+
+# ── 9. Syslog logging ─────────────────────────────────────────────────────
+test_syslog_logging() {
+    local collector="$1"
+
+    # Only bash supports --syslog
+    case "$collector" in
+        bash) ;;
+        *)
+            skip "$collector/syslog: not supported"
+            return
+            ;;
+    esac
+
+    clear_log
+
+    local fixtures; fixtures="$(mktemp -d /tmp/oper-test-XXXXXX)"
+    echo "$MALICIOUS_CONTENT" > "$fixtures/syslog-${collector}.exe"
+
+    # Run with --syslog — just verify it doesn't crash
+    local output; output="$(run_bash "$fixtures" --max-age 30 --syslog 2>&1)" || true
+    sync_stub
+
+    local entry; entry="$(query_log "syslog-${collector}")"
+    if [ -n "$entry" ]; then
+        pass "$collector/syslog: collector ran successfully with --syslog"
+    else
+        # Even if upload fails, the collector shouldn't crash with --syslog
+        if echo "$output" | grep -qi 'error\|crash\|abort'; then
+            fail "$collector/syslog: collector crashed with --syslog"
+        else
+            pass "$collector/syslog: collector ran with --syslog (no crash)"
+        fi
+    fi
+
+    rm -rf "$fixtures"
+}
+
+# ── 10. curl vs wget fallback (bash only) ──────────────────────────────────
+test_wget_fallback() {
+    local collector="$1"
+
+    case "$collector" in
+        bash) ;;
+        *)
+            skip "$collector/wget-fallback: bash only"
+            return
+            ;;
+    esac
+
+    # Check if wget is available
+    if ! command -v wget >/dev/null 2>&1; then
+        skip "$collector/wget-fallback: wget not installed"
+        return
+    fi
+
+    clear_log
+
+    local fixtures; fixtures="$(mktemp -d /tmp/oper-test-XXXXXX)"
+    echo "$MALICIOUS_CONTENT" > "$fixtures/wget-${collector}.exe"
+
+    # Build a PATH that excludes directories containing real curl, but includes wget
+    local wget_path; wget_path="$(command -v wget 2>/dev/null)"
+    if [ -z "$wget_path" ]; then
+        skip "$collector/wget-fallback: wget not installed"
+        rm -rf "$fixtures"
+        return
+    fi
+
+    local wget_dir; wget_dir="$(dirname "$wget_path")"
+    # Build a minimal PATH with only wget's directory and standard utils (but no curl)
+    local clean_path="$wget_dir:/usr/sbin:/sbin"
+    # Verify curl is NOT on this path
+    if env PATH="$clean_path" command -v curl >/dev/null 2>&1; then
+        # curl is in the same dir as wget — can't isolate
+        skip "$collector/wget-fallback: curl and wget in same directory, cannot isolate"
+        rm -rf "$fixtures"
+        return
+    fi
+
+    local output
+    output="$(timeout 30 env PATH="$clean_path" \
+        bash "${COLLECTOR_DIR}/thunderstorm-collector.sh" \
+        --server localhost --port "$STUB_PORT" --dir "$fixtures" \
+        --max-age 30 2>&1)" || true
+    sync_stub
+
+    local entry; entry="$(query_log "wget-${collector}")"
+    if [ -n "$entry" ]; then
+        pass "$collector/wget-fallback: file submitted via wget"
+    else
+        if echo "$output" | grep -qi 'wget'; then
+            fail "$collector/wget-fallback: detected wget but upload failed"
+        else
+            skip "$collector/wget-fallback: could not isolate wget from curl"
+        fi
+    fi
+
+    rm -rf "$fixtures"
+}
+
+# ============================================================================
+# Main
+# ============================================================================
+
+echo ""
+printf "${BOLD}Operational Feature Tests${RESET}\n"
+echo "============================================"
+echo ""
+
+COLLECTORS=("bash")
+if ! collector_enabled bash || ! collector_runnable bash; then
+    COLLECTORS=()
+fi
+[ -n "$ASH_SHELL" ] && collector_enabled ash && collector_runnable ash && COLLECTORS+=("ash")
+collector_enabled python && collector_runnable python && COLLECTORS+=("python")
+collector_enabled perl && collector_runnable perl && COLLECTORS+=("perl")
+collector_enabled ps3 && collector_runnable ps3 && COLLECTORS+=("ps3")
+collector_enabled ps2 && collector_runnable ps2 && COLLECTORS+=("ps2")
+
+if [ "${#COLLECTORS[@]}" -gt 0 ]; then
+    validate_available_collectors "${COLLECTORS[@]}"
+else
+    validate_available_collectors
+fi
+
+if [ "${#COLLECTORS[@]}" -eq 0 ]; then
+    echo "Available collectors: none"
+    echo "No runnable collectors selected; nothing to do."
+    exit 0
+fi
+
+echo "Available collectors: ${COLLECTORS[*]}"
+echo ""
+
+start_stub
+
+for collector in "${COLLECTORS[@]}"; do
+    printf "\n${CYAN}── $collector ──${RESET}\n"
+
+    test_collection_markers "$collector"
+    test_interrupted_marker "$collector"
+    test_dry_run "$collector"
+    test_source_identifier "$collector"
+    test_sync_mode "$collector"
+    test_multiple_dirs "$collector"
+    test_503_backpressure "$collector"
+    test_progress_reporting "$collector"
+    test_syslog_logging "$collector"
+    test_wget_fallback "$collector"
+done
+
+stop_stub
+
+echo ""
+echo "============================================"
+printf " Results: ${GREEN}%d passed${RESET}, ${RED}%d failed${RESET}, ${YELLOW}%d skipped${RESET}\n" \
+    "$TESTS_PASSED" "$TESTS_FAILED" "$TESTS_SKIPPED"
+echo "============================================"
+
+if [ -n "$FAILED_NAMES" ]; then
+    echo ""
+    printf "${RED}Failed tests:${RESET}\n"
+    printf "$FAILED_NAMES"
+fi
+
+echo ""
+[ "$TESTS_FAILED" -eq 0 ] && exit 0 || exit 1

--- a/scripts/tests/run_operational_tests.sh
+++ b/scripts/tests/run_operational_tests.sh
@@ -101,11 +101,42 @@ collector_script_path() {
     esac
 }
 
+collector_has_flags() {
+    local script_path="$1" flag
+    shift
+    for flag in "$@"; do
+        grep -q -- "$flag" "$script_path" || return 1
+    done
+}
+
+collector_supports_shared_harness() {
+    local current script_path
+    current="$(normalize_collector "$1")"
+    script_path="$(collector_script_path "$current")" || return 1
+
+    case "$current" in
+        bash|ash)
+            collector_has_flags "$script_path" --server --port --dir --max-age --source --dry-run
+            ;;
+        python)
+            collector_has_flags "$script_path" --server --port --dirs --max-age --source --dry-run
+            ;;
+        perl)
+            collector_has_flags "$script_path" --server --port --dir --max-age --source --dry-run
+            ;;
+        ps3|ps2)
+            collector_has_flags "$script_path" ThunderstormServer ThunderstormPort Folder Source MaxAge MaxSize AllExtensions
+            ;;
+        *) return 1 ;;
+    esac
+}
+
 collector_runnable() {
     local current script_path
     current="$(normalize_collector "$1")"
     script_path="$(collector_script_path "$current")" || return 1
     [ -f "$script_path" ] || return 1
+    collector_supports_shared_harness "$current" || return 1
 
     case "$current" in
         bash) command -v bash >/dev/null 2>&1 ;;
@@ -278,7 +309,7 @@ run_ash() {
 run_python() {
     local dir="$1"; shift
     python3 "${COLLECTOR_DIR}/thunderstorm-collector.py" \
-        --server localhost --port "$STUB_PORT" --dir "$dir" \
+        --server localhost --port "$STUB_PORT" -d "$dir" \
         "$@" 2>&1
 }
 

--- a/scripts/tests/run_operational_tests.sh
+++ b/scripts/tests/run_operational_tests.sh
@@ -190,7 +190,12 @@ ASH_SHELL="${ASH_SHELL:-$(detect_ash_shell)}"
 find_stub() {
     local candidates=(
         "${STUB_BIN_PATH:-}"
+        "${STUB_SERVER_BIN:-}"
+        "$SCRIPT_DIR/../../thunderstorm-stub-server/thunderstorm-stub-server"
+        "$SCRIPT_DIR/../../thunderstorm-stub-server/thunderstorm-stub"
+        "$SCRIPT_DIR/../../../thunderstorm-stub-server/thunderstorm-stub-server"
         "$SCRIPT_DIR/../../../thunderstorm-stub-server/thunderstorm-stub"
+        "$(command -v thunderstorm-stub-server 2>/dev/null || true)"
         "$(command -v thunderstorm-stub 2>/dev/null || true)"
     )
     for c in "${candidates[@]}"; do
@@ -203,6 +208,7 @@ find_stub() {
 find_rules() {
     local candidates=(
         "${STUB_RULES_PATH:-}"
+        "$SCRIPT_DIR/../../thunderstorm-stub-server/rules"
         "$SCRIPT_DIR/../../../thunderstorm-stub-server/rules"
     )
     for c in "${candidates[@]}"; do
@@ -231,6 +237,13 @@ stop_stub() {
     [ -n "$STUB_PID" ] && kill "$STUB_PID" 2>/dev/null && wait "$STUB_PID" 2>/dev/null || true
     STUB_PID=""
 }
+
+cleanup() {
+    stop_stub
+    [ -n "$STUB_LOG" ] && rm -f "$STUB_LOG"
+    return 0
+}
+trap cleanup EXIT
 
 clear_log() {
     curl -s -X POST "$STUB_URL/api/test/reset" > /dev/null 2>&1 || true
@@ -905,7 +918,6 @@ test_wget_fallback() {
     local fixtures; fixtures="$(mktemp -d /tmp/oper-test-XXXXXX)"
     echo "$MALICIOUS_CONTENT" > "$fixtures/wget-${collector}.exe"
 
-    # Build a PATH that excludes directories containing real curl, but includes wget
     local wget_path; wget_path="$(command -v wget 2>/dev/null)"
     if [ -z "$wget_path" ]; then
         skip "$collector/wget-fallback: wget not installed"
@@ -913,19 +925,13 @@ test_wget_fallback() {
         return
     fi
 
-    local wget_dir; wget_dir="$(dirname "$wget_path")"
-    # Build a minimal PATH with only wget's directory and standard utils (but no curl)
-    local clean_path="$wget_dir:/usr/sbin:/sbin"
-    # Verify curl is NOT on this path
-    if env PATH="$clean_path" command -v curl >/dev/null 2>&1; then
-        # curl is in the same dir as wget — can't isolate
-        skip "$collector/wget-fallback: curl and wget in same directory, cannot isolate"
-        rm -rf "$fixtures"
-        return
-    fi
+    local shim_dir; shim_dir="$(mktemp -d /tmp/oper-wget-path-XXXXXX)"
+    printf '#!/usr/bin/env sh\nexit 127\n' > "$shim_dir/curl"
+    chmod +x "$shim_dir/curl"
+    ln -s "$wget_path" "$shim_dir/wget" 2>/dev/null || cp "$wget_path" "$shim_dir/wget"
 
     local output
-    output="$(timeout 30 env PATH="$clean_path" \
+    output="$(timeout 30 env PATH="$shim_dir:$PATH" \
         bash "${COLLECTOR_DIR}/thunderstorm-collector.sh" \
         --server localhost --port "$STUB_PORT" --dir "$fixtures" \
         --max-age 30 2>&1)" || true
@@ -942,7 +948,7 @@ test_wget_fallback() {
         fi
     fi
 
-    rm -rf "$fixtures"
+    rm -rf "$fixtures" "$shim_dir"
 }
 
 # ============================================================================

--- a/scripts/tests/verify_uploads.py
+++ b/scripts/tests/verify_uploads.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+import argparse
+import hashlib
+import pathlib
+import sys
+import time
+
+
+def sha256_of_file(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as f:
+        while True:
+            chunk = f.read(1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def collect_files(root: pathlib.Path):
+    return sorted([p for p in root.rglob("*") if p.is_file()])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Verify uploaded sample integrity in stub uploads dir.")
+    parser.add_argument("--uploads-dir", required=True, help="Directory used as thunderstorm-stub-server --uploads-dir")
+    parser.add_argument("--expected-sha256", required=True, help="Expected sha256 hash of each uploaded sample")
+    parser.add_argument("--min-count", type=int, required=True, help="Minimum number of uploaded files expected")
+    parser.add_argument("--timeout-seconds", type=int, default=60, help="Max time to wait for async uploads")
+    args = parser.parse_args()
+
+    uploads_dir = pathlib.Path(args.uploads_dir)
+    expected_sha256 = args.expected_sha256.lower()
+    deadline = time.time() + args.timeout_seconds
+
+    while time.time() < deadline:
+        files = collect_files(uploads_dir)
+        if len(files) >= args.min_count:
+            bad = []
+            for file_path in files:
+                actual_sha256 = sha256_of_file(file_path).lower()
+                if actual_sha256 != expected_sha256:
+                    bad.append((file_path, actual_sha256))
+
+            if bad:
+                print("Found uploaded files with unexpected hash:", file=sys.stderr)
+                for path, actual in bad:
+                    print(f"  {path}: {actual} (expected {expected_sha256})", file=sys.stderr)
+                return 1
+
+            print(f"Integrity verified for {len(files)} uploaded files.")
+            return 0
+
+        time.sleep(1)
+
+    files = collect_files(uploads_dir)
+    print(
+        f"Timed out waiting for uploads. Expected at least {args.min_count}, found {len(files)}.",
+        file=sys.stderr,
+    )
+    for file_path in files:
+        print(f"  Found: {file_path}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add shared stub-server-backed script collector test harnesses
- support collector selection with THUNDERSTORM_TEST_COLLECTORS and fail-fast CI modes
- add a GitHub Actions workflow pinned to thunderstorm-stub-server 6b57bca

## Testing
- parsed .github/workflows/script-collectors.yml locally to verify YAML syntax
- bash -n scripts/tests/run_detection_tests.sh scripts/tests/run_e2e_compliance.sh scripts/tests/run_filter_tests.sh scripts/tests/run_operational_tests.sh
- THUNDERSTORM_TEST_COLLECTORS=ash bash scripts/tests/run_operational_tests.sh
- THUNDERSTORM_TEST_COLLECTORS=ash THUNDERSTORM_TEST_REQUIRE_MATCH=1 bash scripts/tests/run_operational_tests.sh