### PR TITLE
feat(scripts): harden bash collector

### DIFF
--- a/scripts/bash/thunderstorm-collector.sh
+++ b/scripts/bash/thunderstorm-collector.sh
@@ -1,177 +1,1179 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # THOR Thunderstorm Bash Collector
-# Florian Roth
-# September 2025
+# Florian Roth / Nextron Systems
+#
+# Goals:
+# - work on old and new Bash versions (Bash 3+)
+# - handle missing dependencies with fallbacks
+# - degrade gracefully on partial failures
 
-VERSION="0.3.0"
+VERSION="0.5.0"
 
-# Settings ------------------------------------------------------------
+# Defaults --------------------------------------------------------------------
 
-# Log
 LOGFILE="./thunderstorm.log"
 LOG_TO_FILE=1
-LOG_TO_SYSLOG=0 # Log to syslog is set to 'off' by default
+LOG_TO_SYSLOG=0
 LOG_TO_CMDLINE=1
+SYSLOG_FACILITY="user"
 
-# Thunderstorm Server
 THUNDERSTORM_SERVER="ygdrasil.nextron"
 THUNDERSTORM_PORT=8080
 USE_SSL=0
+INSECURE=0
+CA_CERT=""
 ASYNC_MODE=1
 
-# Source
-HOSTNAME=$(hostname -f)
-
-# Target selection 
-declare -a SCAN_FOLDERS=('/root' '/tmp' '/home' '/var' '/usr');  # folders to scan
 MAX_AGE=14
-MAX_FILE_SIZE=2000  # max file size to check in kilobyte, default 2 MB
+MAX_FILE_SIZE_KB=2000
+DEBUG=0
+DRY_RUN=0
+RETRIES=3
 
-# Debug
-DEBUG=1
+UPLOAD_TOOL=""
+declare -a TMP_FILES_ARR=()
+declare -a CURL_EXTRA_OPTS=()
+declare -a WGET_EXTRA_OPTS=()
 
-# Code ----------------------------------------------------------------
+# Keep defaults simple and stable for Bash 3+.
+SCAN_FOLDERS=('/root' '/tmp' '/home' '/var' '/usr')
 
-function timestamp {
-  date +%F_%T
+FILES_SCANNED=0
+FILES_SUBMITTED=0
+FILES_SKIPPED=0
+FILES_FAILED=0
+TOTAL_FILES=0
+SCAN_ID=""
+
+PROGRESS_MODE=""  # auto (empty), "on", or "off"
+SHOW_PROGRESS=0
+
+SCRIPT_NAME="${0##*/}"
+START_TS="$(date +%s 2>/dev/null || echo 0)"
+SOURCE_NAME=""
+
+# Filesystem exclusions -------------------------------------------------------
+# Pseudo-filesystems, virtual mounts, network shares, and cloud storage that
+# should never be walked. Pruned at the find level for efficiency.
+
+# Hardcoded paths — always excluded
+EXCLUDE_PATHS=(
+    /proc /sys /dev /run
+    /sys/kernel/debug /sys/kernel/slab /sys/kernel/tracing /sys/devices
+    /snap /.snapshots
+)
+
+# Network and special filesystem types — mount points with these types are
+# discovered from /proc/mounts and excluded automatically.
+NETWORK_FS_TYPES="nfs nfs4 cifs smbfs smb3 sshfs fuse.sshfs afp webdav davfs2 fuse.rclone fuse.s3fs"
+SPECIAL_FS_TYPES="proc procfs sysfs devtmpfs devpts cgroup cgroup2 pstore bpf tracefs debugfs securityfs hugetlbfs mqueue autofs fusectl rpc_pipefs nsfs configfs binfmt_misc selinuxfs efivarfs ramfs"
+
+# Cloud storage folder names — if any path segment matches (case-insensitive),
+# the directory is pruned. Keep names with embedded spaces separate so the
+# find-level pruning logic does not accidentally exclude generic names such as
+# "Drive" or "Google" on unrelated paths.
+CLOUD_DIR_NAMES="OneDrive Dropbox .dropbox GoogleDrive iCloudDrive Nextcloud ownCloud MEGA MEGAsync Tresorit SyncThing"
+CLOUD_DIR_NAMES_SPACED="Google Drive|iCloud Drive"
+CLOUD_DIR_PATTERNS="OneDrive -|OneDrive-|Nextcloud-"
+
+# get_excluded_mounts: parse /proc/mounts and return mount points for
+# network and special filesystem types (one per line).
+get_excluded_mounts() {
+    [ -r /proc/mounts ] || return 0
+    while IFS=' ' read -r _dev _mp _fstype _rest; do
+        case " $NETWORK_FS_TYPES $SPECIAL_FS_TYPES " in
+            *" $_fstype "*) printf '%s\n' "$_mp" ;;
+        esac
+    done < /proc/mounts
 }
 
-function log {
-    local type="$1"
-    local message="$2"
-    local ts
-    ts=$(timestamp)
+# is_cloud_path: check if a path contains a known cloud storage folder name.
+# Returns 0 (true) if it matches, 1 (false) otherwise.
+is_cloud_path() {
+    local path_lower
+    path_lower="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+    local name name_lower
+    for name in $CLOUD_DIR_NAMES; do
+        name_lower="$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')"
+        case "$path_lower" in
+            *"/$name_lower"/*|*"/$name_lower") return 0 ;;
+        esac
+    done
+    local old_ifs
+    old_ifs="$IFS"
+    IFS='|'
+    for name in $CLOUD_DIR_NAMES_SPACED; do
+        name_lower="$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')"
+        case "$path_lower" in
+            *"/$name_lower"/*|*"/$name_lower") IFS="$old_ifs"; return 0 ;;
+        esac
+    done
+    for name in $CLOUD_DIR_PATTERNS; do
+        name_lower="$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')"
+        case "$path_lower" in
+            *"/$name_lower"*) IFS="$old_ifs"; return 0 ;;
+        esac
+    done
+    IFS="$old_ifs"
+    # macOS: ~/Library/CloudStorage
+    case "$path_lower" in
+        */library/cloudstorage/*|*/library/cloudstorage) return 0 ;;
+    esac
+    return 1
+}
 
-    # Only report debug messages if mode is enabled
-    if [ "$type" == "debug" ] && [ $DEBUG -ne 1 ]; then
-        return 0
+# Helpers ---------------------------------------------------------------------
+
+timestamp() {
+    date "+%Y-%m-%d_%H:%M:%S" 2>/dev/null || date
+}
+
+cleanup_tmp_files() {
+    local f
+    for f in "${TMP_FILES_ARR[@]}"; do
+        [ -n "$f" ] && [ -f "$f" ] && rm -f "$f"
+    done
+    # Remove fallback temp directory if it exists (created by mktemp_portable)
+    local _fallback_dir="${TMPDIR:-/tmp}/thunderstorm.$$"
+    [ -d "$_fallback_dir" ] && rm -rf "$_fallback_dir"
+}
+
+INTERRUPTED=0
+
+send_interrupted_marker() {
+    if [ "$DRY_RUN" -eq 0 ] && [ -n "$THUNDERSTORM_SERVER" ]; then
+        local _elapsed=0
+        local _now
+        _now="$(date +%s 2>/dev/null || echo "$START_TS")"
+        if [ "$START_TS" -gt 0 ] 2>/dev/null; then
+            _elapsed=$(( _now - START_TS ))
+            [ "$_elapsed" -lt 0 ] && _elapsed=0
+        fi
+        local _stats="\"stats\":{\"scanned\":${FILES_SCANNED},\"submitted\":${FILES_SUBMITTED},\"skipped\":${FILES_SKIPPED},\"failed\":${FILES_FAILED},\"elapsed_seconds\":${_elapsed}}"
+        local _scheme="http"
+        [ "$USE_SSL" -eq 1 ] && _scheme="https"
+        local _base="${_scheme}://${THUNDERSTORM_SERVER}:${THUNDERSTORM_PORT}"
+        _base="${_base%/}"
+        collection_marker "$_base" "interrupted" "${SCAN_ID:-}" "$_stats" >/dev/null 2>&1
+    fi
+}
+
+on_signal() {
+    # Prevent recursive signal handling
+    trap '' INT TERM
+    INTERRUPTED=1
+    log_msg warn "Received signal, sending interrupted marker and exiting..."
+    send_interrupted_marker
+    cleanup_tmp_files
+    # Exit 1 for partial failure (interrupted collection)
+    exit 1
+}
+
+on_exit() {
+    [ "$INTERRUPTED" -eq 0 ] && cleanup_tmp_files
+}
+
+trap on_exit EXIT
+trap on_signal INT TERM
+
+log_msg() {
+    local level="$1"
+    shift
+    local message="$*"
+    local ts
+    local logger_prio
+    local clean
+
+    [ "$level" = "debug" ] && [ "$DEBUG" -ne 1 ] && return 0
+
+    ts="$(timestamp)"
+    clean="$message"
+    clean="${clean//$'\r'/ }"
+    clean="${clean//$'\n'/ }"
+
+    if [ "$LOG_TO_FILE" -eq 1 ]; then
+        if ! printf "%s %s %s\n" "$ts" "$level" "$clean" >> "$LOGFILE" 2>/dev/null; then
+            LOG_TO_FILE=0
+            printf "%s warn Could not write to log file '%s'; disabling file logging\n" "$ts" "$LOGFILE" >&2
+        fi
     fi
 
-    # Exclude certain strings (false positives)
-    for ex_string in "${EXCLUDE_STRINGS[@]}";
-    do
-        # echo "Checking if $ex_string is in $message"
-        if [ "${message/$ex_string}" != "$message" ]; then
-            return 0
+    if [ "$LOG_TO_SYSLOG" -eq 1 ] && command -v logger >/dev/null 2>&1; then
+        case "$level" in
+            error) logger_prio="err" ;;
+            warn) logger_prio="warning" ;;
+            debug) logger_prio="debug" ;;
+            *) logger_prio="info" ;;
+        esac
+        logger -p "${SYSLOG_FACILITY}.${logger_prio}" "${SCRIPT_NAME}: ${clean}" >/dev/null 2>&1 || true
+    fi
+
+    if [ "$LOG_TO_CMDLINE" -eq 1 ]; then
+        # Clear progress line before printing log messages to avoid interleaving
+        if [ "$SHOW_PROGRESS" -eq 1 ]; then
+            printf '\r\033[K' >&2
+        fi
+        case "$level" in
+            error|warn)
+                printf "[%s] %s\n" "$level" "$clean" >&2
+                ;;
+            *)
+                printf "[%s] %s\n" "$level" "$clean"
+                ;;
+        esac
+    fi
+}
+
+die() {
+    log_msg error "$*"
+    exit 2
+}
+
+print_banner() {
+    cat <<EOF
+==============================================================
+    ________                __            __
+   /_  __/ /  __ _____  ___/ /__ _______ / /____  ______ _
+    / / / _ \\/ // / _ \\/ _  / -_) __(_-</ __/ _ \\/ __/  ' \\
+   /_/ /_//_/\\_,_/_//_/\\_,_/\\__/_/ /___/\\__/\\___/_/ /_/_/_/
+   v${VERSION}
+
+   THOR Thunderstorm Collector for Linux/Unix
+==============================================================
+EOF
+}
+
+print_help() {
+    cat <<'EOF'
+Usage:
+  thunderstorm-collector.sh [options]
+
+Options:
+  -s, --server <host>        Thunderstorm server hostname or IP
+  -p, --port <port>          Thunderstorm port (default: 8080)
+  -d, --dir <path>           Directory to scan (repeatable)
+  --max-age <days>           Max file age in days (default: 14)
+  --max-size-kb <kb>         Max file size in KB (default: 2000)
+  --source <name>            Source identifier (default: hostname)
+  --ssl                      Use HTTPS
+  -k, --insecure             Skip TLS certificate verification
+  --ca-cert <path>           Path to custom CA certificate bundle for TLS
+  --sync                     Use /api/check (default: /api/checkAsync)
+  --retries <num>            Retry attempts per file (default: 3)
+            --dry-run                  Do not upload or contact the server; only show what would be submitted
+  --progress                 Force progress reporting
+  --no-progress              Disable progress reporting
+  --debug                    Enable debug log messages
+  --log-file <path>          Log file path (default: ./thunderstorm.log)
+  --no-log-file              Disable file logging
+  --syslog                   Enable syslog logging
+  --quiet                    Disable command-line logging
+  -h, --help                 Show this help text
+
+Examples:
+  bash thunderstorm-collector.sh --server thunderstorm.local
+  bash thunderstorm-collector.sh --server 10.0.0.5 --ssl --dir "/tmp/My Files" --dry-run
+EOF
+}
+
+is_integer() {
+    case "$1" in
+        ''|*[!0-9]*) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+is_positive_integer() {
+    is_integer "$1" || return 1
+    [ "$1" -gt 0 ] 2>/dev/null || return 1
+}
+
+detect_source_name() {
+    [ -n "$SOURCE_NAME" ] && return 0
+    if command -v hostname >/dev/null 2>&1; then
+        SOURCE_NAME="$(hostname -f 2>/dev/null)"
+        [ -z "$SOURCE_NAME" ] && SOURCE_NAME="$(hostname 2>/dev/null)"
+    fi
+    [ -z "$SOURCE_NAME" ] && SOURCE_NAME="$(uname -n 2>/dev/null)"
+    [ -z "$SOURCE_NAME" ] && SOURCE_NAME="unknown-host"
+}
+
+build_query_source() {
+    local src="$1"
+    if [ -n "$src" ]; then
+        local encoded
+        encoded="$(urlencode "$src")"
+        printf "?source=%s" "$encoded"
+    fi
+}
+
+urlencode() {
+    local input="$1"
+    local out=""
+    local i ch hex_bytes byte
+
+    for ((i = 0; i < ${#input}; i++)); do
+        ch="${input:i:1}"
+        case "$ch" in
+            [a-zA-Z0-9.~_-])
+                out="${out}${ch}"
+                ;;
+            *)
+                # Get hex bytes (handles multi-byte UTF-8 characters)
+                hex_bytes="$(printf '%s' "$ch" | od -An -tx1 | tr -d ' \n')"
+                while [ -n "$hex_bytes" ]; do
+                    byte="${hex_bytes:0:2}"
+                    hex_bytes="${hex_bytes:2}"
+                    [ -n "$byte" ] && out="${out}%$(printf '%s' "$byte" | tr '[:lower:]' '[:upper:]')"
+                done
+                ;;
+        esac
+    done
+    printf "%s" "$out"
+}
+
+sanitize_filename_for_multipart() {
+    local input="$1"
+    # Keep multipart header/form attribute values simple and safe.
+    input="${input//\"/_}"
+    input="${input//;/_}"
+    input="${input//\\/_}"
+    input="${input//$'\r'/_}"
+    input="${input//$'\n'/_}"
+    [ -z "$input" ] && input="sample.bin"
+    printf "%s" "$input"
+}
+
+file_size_kb() {
+    # Use wc for portability across GNU/BSD and older systems.
+    local bytes
+    bytes="$(wc -c < "$1" 2>/dev/null)"
+    # Intentionally split on whitespace to normalize wc output ("   123\n" -> "123").
+    # shellcheck disable=SC2086
+    set -- $bytes
+    bytes="$1"
+    case "$bytes" in
+        ''|*[!0-9]*) echo -1; return 1 ;;
+    esac
+    echo $(( (bytes + 1023) / 1024 ))
+}
+
+mktemp_portable() {
+    local t
+    t="$(mktemp "${TMPDIR:-/tmp}/thunderstorm.XXXXXX" 2>/dev/null)"
+    if [ -n "$t" ] && [ -f "$t" ]; then
+        echo "$t"
+        return 0
+    fi
+    # Fallback: create a private directory first (mkdir is atomic), then a file inside it.
+    # This avoids the TOCTOU race of creating a predictable file in a shared /tmp.
+    local _dir="${TMPDIR:-/tmp}/thunderstorm.$$"
+    if [ ! -d "$_dir" ]; then
+        ( umask 077 && mkdir "$_dir" ) 2>/dev/null || return 1
+    fi
+    t="$_dir/${RANDOM:-0}.$(date +%N 2>/dev/null || echo 0)"
+    : > "$t" 2>/dev/null || return 1
+    echo "$t"
+}
+
+detect_upload_tool() {
+    if command -v curl >/dev/null 2>&1; then
+        UPLOAD_TOOL="curl"
+        return 0
+    fi
+    if command -v wget >/dev/null 2>&1; then
+        UPLOAD_TOOL="wget"
+        return 0
+    fi
+    return 1
+}
+
+upload_with_curl() {
+    local endpoint="$1"
+    local filepath="$2"
+    local filename="$3"
+    local safe_filename
+    local resp_file
+    local header_file
+    local code
+    local http_code
+
+    safe_filename="$(sanitize_filename_for_multipart "$filename")"
+
+    resp_file="$(mktemp_portable)" || return 91
+    TMP_FILES_ARR+=("$resp_file")
+    header_file="$(mktemp_portable)" || return 91
+    TMP_FILES_ARR+=("$header_file")
+
+    # Build form argument safely — curl handles @path internally
+    local form_arg="file=@${filepath};filename=${safe_filename}"
+
+    local err_file
+    err_file="$(mktemp_portable)" || return 91
+    TMP_FILES_ARR+=("$err_file")
+
+    curl -sS --show-error -X POST "${CURL_EXTRA_OPTS[@]}" \
+        --max-time 300 \
+        -D "$header_file" \
+        "$endpoint" \
+        -F "$form_arg" \
+        > "$resp_file" 2>"$err_file"
+    code=$?
+
+    if [ $code -ne 0 ]; then
+        local _curl_err
+        _curl_err="$(cat "$err_file" 2>/dev/null)"
+        [ -n "$_curl_err" ] && log_msg debug "curl error: $_curl_err"
+    fi
+
+    # Extract HTTP status code from headers
+    http_code="$(grep -oE 'HTTP/[0-9.]+ [0-9]+' "$header_file" 2>/dev/null | tail -1 | grep -oE '[0-9]+$')"
+
+    # Handle 503 back-pressure
+    if [ "$http_code" = "503" ]; then
+        local retry_after
+        retry_after="$(grep -i '^Retry-After:' "$header_file" 2>/dev/null | head -1 | sed 's/[^0-9]//g')"
+        if [ -n "$retry_after" ] && [ "$retry_after" -gt 0 ] 2>/dev/null; then
+            [ "$retry_after" -gt 120 ] && retry_after=120
+            log_msg warn "Server returned 503, waiting ${retry_after}s (Retry-After)"
+            sleep "$retry_after"
+        fi
+        return 93
+    fi
+
+    if [ $code -ne 0 ]; then
+        return $code
+    fi
+
+    # Only 2xx responses count as a successful submission.
+    if [ -n "$http_code" ]; then
+        case "$http_code" in
+            2[0-9][0-9]) ;;
+            *)
+                local body
+                body="$(cat "$resp_file" 2>/dev/null)"
+                body="${body//$'\r'/ }"
+                body="${body//$'\n'/ }"
+                log_msg error "Server returned HTTP $http_code for '$filepath': $body"
+                return 92
+                ;;
+        esac
+    fi
+
+    return 0
+}
+
+upload_with_wget() {
+    # Portable multipart fallback for systems without curl.
+    local endpoint="$1"
+    local filepath="$2"
+    local filename="$3"
+    local safe_filename
+    local boundary
+    local body_file
+    local resp_file
+    local header_file
+    local code
+
+    safe_filename="$(sanitize_filename_for_multipart "$filename")"
+
+    # Generate a boundary that does not appear in the file content or metadata.
+    # Retry with different random seeds to avoid multipart corruption.
+    local _boundary_attempts=0
+    boundary="----ThunderstormBoundary${$}${RANDOM}${RANDOM}$(date +%s%N 2>/dev/null || echo 0)"
+    while [ "$_boundary_attempts" -lt 10 ]; do
+        if ! LC_ALL=C grep -qF "$boundary" "$filepath" 2>/dev/null; then
+            # Also check it doesn't appear in metadata fields
+            case "${SOURCE_NAME}${filepath}" in
+                *"$boundary"*) ;;
+                *) break ;;
+            esac
+        fi
+        _boundary_attempts=$((_boundary_attempts + 1))
+        boundary="----ThunderstormBoundary${$}${RANDOM}${RANDOM}${_boundary_attempts}$(date +%s%N 2>/dev/null || echo 0)"
+    done
+    if [ "$_boundary_attempts" -ge 10 ]; then
+        log_msg warn "Could not find safe multipart boundary for '$filepath', upload may be malformed"
+    fi
+    body_file="$(mktemp_portable)" || return 93
+    TMP_FILES_ARR+=("$body_file")
+    resp_file="$(mktemp_portable)" || return 94
+    TMP_FILES_ARR+=("$resp_file")
+    header_file="$(mktemp_portable)" || return 94
+    TMP_FILES_ARR+=("$header_file")
+
+    {
+        printf -- "--%s\r\n" "$boundary"
+        printf 'Content-Disposition: form-data; name="file"; filename="%s"\r\n' "$safe_filename"
+        printf 'Content-Type: application/octet-stream\r\n\r\n'
+        cat "$filepath"
+        printf '\r\n--%s--\r\n' "$boundary"
+    } > "$body_file" 2>/dev/null || return 95
+
+    wget -S -O "$resp_file" "${WGET_EXTRA_OPTS[@]}" \
+        --timeout=300 \
+        --header="Content-Type: multipart/form-data; boundary=${boundary}" \
+        --post-file="$body_file" \
+        "$endpoint" 2>"$header_file"
+    code=$?
+
+    # Extract HTTP status code from headers (wget -S writes headers to stderr with leading spaces)
+    local http_code
+    http_code="$(grep -oE 'HTTP/[0-9.]+[[:space:]]+[0-9]+' "$header_file" 2>/dev/null | tail -1 | grep -oE '[0-9]+$')"
+
+    # Handle 503 back-pressure
+    if [ "$http_code" = "503" ]; then
+        local retry_after
+        retry_after="$(grep -i 'Retry-After' "$header_file" 2>/dev/null | head -1 | sed 's/[^0-9]//g')"
+        if [ -n "$retry_after" ] && [ "$retry_after" -gt 0 ] 2>/dev/null; then
+            [ "$retry_after" -gt 120 ] && retry_after=120
+            log_msg warn "Server returned 503, waiting ${retry_after}s (Retry-After)"
+            sleep "$retry_after"
+        fi
+        return 93
+    fi
+
+    if [ $code -ne 0 ]; then
+        return $code
+    fi
+
+    # Only 2xx responses count as a successful submission.
+    if [ -n "$http_code" ]; then
+        case "$http_code" in
+            2[0-9][0-9]) ;;
+            *)
+                local body
+                body="$(tr '\r\n' '  ' < "$resp_file" 2>/dev/null)"
+                log_msg error "Server returned HTTP $http_code for '$filepath': $body"
+                return 96
+                ;;
+        esac
+    fi
+
+    return 0
+}
+
+# collection_marker -- POST a begin/end marker to /api/collection
+# Args: $1=base_url  $2=type(begin|end)  $3=scan_id(optional)  $4=stats_json(optional)
+# Returns: scan_id extracted from response (empty if unsupported or failed)
+json_escape() {
+    local s="$1"
+    # Order matters: escape backslashes first, then other special chars
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\n'/\\n}"
+    s="${s//$'\r'/\\r}"
+    s="${s//$'\t'/\\t}"
+    s="${s//$'\010'/\\b}"   # backspace
+    s="${s//$'\014'/\\f}"   # form feed
+    # Remove remaining control characters (0x00-0x1f) that could break JSON
+    s="$(printf '%s' "$s" | tr -d '\000-\007\013\016-\037')"
+    printf '%s' "$s"
+}
+
+# collection_marker -- POST a begin/end marker to /api/collection
+# Args: $1=base_url  $2=type(begin|end)  $3=scan_id(optional)  $4=stats_json(optional)
+# Outputs: scan_id extracted from response on stdout (empty if unsupported or failed)
+# Returns: 0 on success, non-zero on failure
+collection_marker() {
+    local base_url="$1"
+    local marker_type="$2"
+    local scan_id="${3:-}"
+    local stats_json="${4:-}"
+    local marker_url="${base_url}/api/collection"
+    local body scan_id_out resp_file header_file
+
+    resp_file="$(mktemp_portable)" || return 1
+    TMP_FILES_ARR+=("$resp_file")
+    header_file="$(mktemp_portable)" || return 1
+    TMP_FILES_ARR+=("$header_file")
+
+    # Build JSON body with proper escaping
+    local safe_source safe_scan_id
+    safe_source="$(json_escape "$SOURCE_NAME")"
+    safe_scan_id="$(json_escape "$scan_id")"
+
+    local safe_marker_type
+    safe_marker_type="$(json_escape "$marker_type")"
+    body="{\"type\":\"${safe_marker_type}\""
+    body="${body},\"source\":\"${safe_source}\""
+    body="${body},\"collector\":\"bash/${VERSION}\""
+    body="${body},\"timestamp\":\"$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u)\""
+    [ -n "$scan_id"    ] && body="${body},\"scan_id\":\"${safe_scan_id}\""
+    [ -n "$stats_json" ] && body="${body},${stats_json}"
+    body="${body}}"
+
+    local _marker_rc=1
+    local _marker_attempts=1
+    [ "$marker_type" = "begin" ] && _marker_attempts=2
+
+    local _http_code
+    local _attempt=0
+    while [ "$_attempt" -lt "$_marker_attempts" ]; do
+        _attempt=$((_attempt + 1))
+        _marker_rc=1
+        : > "$header_file"
+        # Attempt POST — capture HTTP status to detect server-side errors
+        if command -v curl >/dev/null 2>&1; then
+            curl -sS -D "$header_file" -o "$resp_file" "${CURL_EXTRA_OPTS[@]}" \
+                -H "Content-Type: application/json" \
+                -d "$body" \
+                --max-time 10 \
+                "$marker_url" 2>/dev/null
+            _marker_rc=$?
+        elif command -v wget >/dev/null 2>&1; then
+            wget -S -O "$resp_file" "${WGET_EXTRA_OPTS[@]}" \
+                --header "Content-Type: application/json" \
+                --post-data "$body" \
+                --timeout=10 \
+                "$marker_url" 2>"$header_file"
+            _marker_rc=$?
+        fi
+        # Validate the HTTP status code even when wget exits non-zero on 4xx/5xx.
+        # 404/501 means the server doesn't implement marker endpoint; continue without scan_id.
+        _http_code="$(grep -oE 'HTTP/[0-9.]+[[:space:]]+[0-9]+' "$header_file" 2>/dev/null | tail -1 | grep -oE '[0-9]+$')"
+        if [ -n "$_http_code" ]; then
+            case "$_http_code" in
+                2[0-9][0-9])
+                    _marker_rc=0
+                    ;;
+                404|501)
+                    log_msg warn "Collection marker '$marker_type' not supported (HTTP $_http_code) — server does not implement /api/collection"
+                    _marker_rc=0
+                    ;;
+                *)
+                    log_msg warn "Collection marker '$marker_type' received HTTP $_http_code"
+                    _marker_rc=1
+                    ;;
+            esac
+        elif [ "$_marker_rc" -eq 0 ]; then
+            # Some clients may succeed without exposing a parseable status line.
+            _marker_rc=0
+        fi
+        if [ "$_marker_rc" -eq 0 ]; then
+            break
+        fi
+        if [ "$_attempt" -lt "$_marker_attempts" ]; then
+            log_msg warn "Begin marker failed (attempt $_attempt/$_marker_attempts), retrying in 2s..."
+            sleep 2
         fi
     done
 
-    # Remove line breaks
-    message=$(echo "$message" | tr -d '\r' | tr '\n' ' ') 
+    # Extract scan_id from response, handling JSON escapes (e.g. \" and \\ inside the value).
+    # Uses awk to find the "scan_id" key and parse the JSON string value properly.
+    scan_id_out="$(awk '
+    BEGIN { found = 0 }
+    {
+        s = s $0
+    }
+    END {
+        # Find "scan_id" key
+        idx = index(s, "\"scan_id\"")
+        if (idx == 0) exit
+        rest = substr(s, idx + length("\"scan_id\""))
+        # Skip whitespace and colon
+        gsub(/^[[:space:]]*:[[:space:]]*/, "", rest)
+        # Must start with quote
+        if (substr(rest, 1, 1) != "\"") exit
+        rest = substr(rest, 2)
+        val = ""
+        while (length(rest) > 0) {
+            c = substr(rest, 1, 1)
+            if (c == "\\") {
+                # Escaped character
+                nc = substr(rest, 2, 1)
+                if (nc == "\"") { val = val "\""; rest = substr(rest, 3) }
+                else if (nc == "\\") { val = val "\\"; rest = substr(rest, 3) }
+                else if (nc == "n") { val = val "\n"; rest = substr(rest, 3) }
+                else if (nc == "r") { val = val "\r"; rest = substr(rest, 3) }
+                else if (nc == "t") { val = val "\t"; rest = substr(rest, 3) }
+                else if (nc == "/") { val = val "/"; rest = substr(rest, 3) }
+                else if (nc == "b") { val = val "\b"; rest = substr(rest, 3) }
+                else if (nc == "f") { val = val "\f"; rest = substr(rest, 3) }
+                else if (nc == "u") {
+                    # \uXXXX unicode escape
+                    hex = substr(rest, 3, 4)
+                    rest = substr(rest, 7)
+                    if (length(hex) == 4) {
+                        # Convert hex to decimal
+                        cp = 0
+                        for (hi = 1; hi <= 4; hi++) {
+                            hc = substr(hex, hi, 1)
+                            if (hc >= "0" && hc <= "9") cp = cp * 16 + (hc + 0)
+                            else if (hc == "a" || hc == "A") cp = cp * 16 + 10
+                            else if (hc == "b" || hc == "B") cp = cp * 16 + 11
+                            else if (hc == "c" || hc == "C") cp = cp * 16 + 12
+                            else if (hc == "d" || hc == "D") cp = cp * 16 + 13
+                            else if (hc == "e" || hc == "E") cp = cp * 16 + 14
+                            else if (hc == "f" || hc == "F") cp = cp * 16 + 15
+                            else { cp = -1; break }
+                        }
+                        if (cp >= 32 && cp <= 126) {
+                            val = val sprintf("%c", cp)
+                        } else if (cp >= 0) {
+                            # Non-ASCII or control char: replace with underscore
+                            val = val "_"
+                        }
+                        # cp == -1: invalid hex, skip silently
+                    }
+                }
+                else { val = val nc; rest = substr(rest, 3) }
+            } else if (c == "\"") {
+                break
+            } else {
+                val = val c
+                rest = substr(rest, 2)
+            }
+        }
+        printf "%s", val
+    }' "$resp_file" 2>/dev/null)"
 
-    # Remove prefix (e.g. [+])
-    if [[ "${message:0:1}" == "[" ]]; then
-        message_cleaned="${message:4:${#message}}"
+    # Validate scan_id: reject empty values, control characters, and unreasonably long values.
+    # The value is JSON-escaped for markers and URL-encoded for query parameters, so we only
+    # need to guard against control characters and excessive length.
+    if [ ${#scan_id_out} -gt 256 ]; then
+        scan_id_out=""
     else
-        message_cleaned="$message"
+        # Remove any control characters (0x00-0x1f, 0x7f) — if the result differs, reject it
+        local _sanitized
+        _sanitized="$(printf '%s' "$scan_id_out" | tr -d '\000-\037\177')"
+        if [ "$_sanitized" != "$scan_id_out" ]; then
+            scan_id_out=""
+        fi
     fi
 
-    # Log to file
-    if [[ $LOG_TO_FILE -eq 1 ]]; then
-        echo "$ts $type $message_cleaned" >> "$LOGFILE"
-    fi
-    # Log to syslog
-    if [[ $LOG_TO_SYSLOG -eq 1 ]]; then
-        logger -p "$SYSLOG_FACILITY.$type" "$(basename "$0"): $message_cleaned"
-    fi
-    # Log to command line
-    if [[ $LOG_TO_CMDLINE -eq 1 ]]; then
-        echo "$message" >&2
-    fi
+    printf '%s' "$scan_id_out"
+    return "$_marker_rc"
 }
 
-function check_req 
-{
-    curl_avail=$(command -v curl)
-    if [[ -z $curl_avail ]]; then 
-        log error "The 'curl' command can't be found but is needed"
-        exit 1
+submit_file() {
+    local endpoint="$1"
+    local filepath="$2"
+    local filename
+    local try=1
+    local rc=1
+    local wait=2
+    local max_503_retries=5
+    local _503_count=0
+
+    # Preserve client-side path in multipart filename for server-side audit logs.
+    filename="$filepath"
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+        log_msg info "DRY-RUN: would submit '$filepath'"
+        return 0
     fi
-}
 
-# Program -------------------------------------------------------------
+    while [ "$try" -le "$RETRIES" ]; do
+        if [ "$UPLOAD_TOOL" = "curl" ]; then
+            upload_with_curl "$endpoint" "$filepath" "$filename"
+            rc=$?
+        else
+            upload_with_wget "$endpoint" "$filepath" "$filename"
+            rc=$?
+        fi
 
-echo "=============================================================="
-echo "    ________                __            __                "
-echo "   /_  __/ /  __ _____  ___/ /__ _______ / /____  ______ _  "
-echo "    / / / _ \/ // / _ \/ _  / -_) __(_-</ __/ _ \/ __/  ' \ "
-echo "   /_/ /_//_/\_,_/_//_/\_,_/\__/_/ /___/\__/\___/_/ /_/_/_/ "
-echo "   v$VERSION"
-echo " "
-echo "   THOR Thunderstorm Collector for Linux/Unix"
-echo "   Florian Roth, September 2020"
-echo "=============================================================="
+        if [ "$rc" -eq 0 ]; then
+            return 0
+        fi
 
-# Root check
-if [ "$(id -u)" != "0" ]; then
-   log error "This script should be run as root to have access to all files on disk" 1>&2
-fi
-
-echo "Writing log file to $LOGFILE ..."
-
-log info "Started Thunderstorm Collector - Version $VERSION"
-log info "Transmitting samples to $THUNDERSTORM_SERVER"
-log info "Processing folders ${SCAN_FOLDERS[*]}"
-log info "Only check files created / modified within $MAX_AGE days"
-log info "Only process files smaller $MAX_FILE_SIZE KB"
-
-# Check requirements
-check_req
-
-# Some presets
-api_endpoint="check"
-if [[ $ASYNC_MODE -eq 1 ]]; then
-    api_endpoint="checkAsync"
-fi
-scheme="http"
-if [[ $USE_SSL -eq 1 ]]; then
-    scheme="https"
-fi
-source=""
-if [[ -n $HOSTNAME ]]; then
-    source="?source=${HOSTNAME}"
-fi
-
-# Loop over filesystem
-for scandir in "${SCAN_FOLDERS[@]}";
-do
-    find "$scandir" -type f  -mtime -$MAX_AGE 2> /dev/null | while read -r file_path
-    do
-        if [ -f "${file_path}" ]; then
-            # Check Size
-            filesize=$(du -k "$file_path" | cut -f1)
-            if [ "${filesize}" -gt $MAX_FILE_SIZE ]; then
+        # 503 back-pressure: sleep already happened in upload function,
+        # retry without counting against the normal retry budget (up to a cap)
+        if [ "$rc" -eq 93 ]; then
+            _503_count=$((_503_count + 1))
+            if [ "$_503_count" -lt "$max_503_retries" ]; then
+                log_msg warn "Retrying '$filepath' after 503 back-pressure ($_503_count/$max_503_retries)"
                 continue
             fi
-            log debug "Submitting ${file_path} ..."
-            successful=0
-
-            for retry in {1..3}; do
-                # Submit sample
-                result=$(curl -s -X POST \
-                        "$scheme://$THUNDERSTORM_SERVER:$THUNDERSTORM_PORT/api/$api_endpoint$source" \
-                        --form "file=@${file_path};filename=${file_path}")
-                curl_exit=$?
-                if [ $curl_exit -ne 0 ]; then
-                    log error "Upload failed with code $curl_exit"
-                    sleep $((2 << retry))
-                    continue
-                fi
-
-                # If 'reason' in result
-                if [ "${result/reason}" != "$result" ]; then
-                    log error "$result"
-                    sleep $((2 << retry))
-                    continue
-                fi
-                successful=1
-                break
-            done
-            if [ $successful -ne 1 ]; then
-                log error "Could not upload ${file_path}"
-            fi
+            log_msg warn "Too many 503 responses for '$filepath', giving up"
+            return "$rc"
         fi
-    done 
-done
-exit 0
+
+        log_msg warn "Upload failed for '$filepath' (attempt ${try}/${RETRIES}, code ${rc})"
+        if [ "$try" -lt "$RETRIES" ]; then
+            sleep "$wait"
+            wait=$((wait * 2))
+            # Cap backoff at 60 seconds
+            [ "$wait" -gt 60 ] && wait=60
+        fi
+        try=$((try + 1))
+    done
+
+    return "$rc"
+}
+
+parse_args() {
+    local arg
+    local add_dir_mode=0
+
+    while [ $# -gt 0 ]; do
+        arg="$1"
+        case "$arg" in
+            -h|--help)
+                print_help
+                exit 0
+                ;;
+            -s|--server)
+                [ -n "${2:-}" ] || die "Missing value for $arg"
+                THUNDERSTORM_SERVER="$2"
+                shift
+                ;;
+            -p|--port)
+                [ -n "${2:-}" ] || die "Missing value for $arg"
+                THUNDERSTORM_PORT="$2"
+                shift
+                ;;
+            -d|--dir)
+                [ -n "${2:-}" ] || die "Missing value for $arg"
+                if [ "$add_dir_mode" -eq 0 ]; then
+                    SCAN_FOLDERS=()
+                    add_dir_mode=1
+                fi
+                SCAN_FOLDERS+=("$2")
+                shift
+                ;;
+            --max-age)
+                [ -n "${2:-}" ] || die "Missing value for $arg"
+                MAX_AGE="$2"
+                shift
+                ;;
+            --max-size-kb)
+                [ -n "${2:-}" ] || die "Missing value for $arg"
+                MAX_FILE_SIZE_KB="$2"
+                shift
+                ;;
+            --source)
+                [ -n "${2:-}" ] || die "Missing value for $arg"
+                SOURCE_NAME="$2"
+                shift
+                ;;
+            --ssl)
+                USE_SSL=1
+                ;;
+            -k|--insecure)
+                INSECURE=1
+                ;;
+            --ca-cert)
+                [ -n "${2:-}" ] || die "Missing value for $arg"
+                CA_CERT="$2"
+                USE_SSL=1
+                shift
+                ;;
+            --sync)
+                ASYNC_MODE=0
+                ;;
+            --retries)
+                [ -n "${2:-}" ] || die "Missing value for $arg"
+                RETRIES="$2"
+                shift
+                ;;
+            --dry-run)
+                DRY_RUN=1
+                ;;
+            --debug)
+                DEBUG=1
+                ;;
+            --log-file)
+                [ -n "${2:-}" ] || die "Missing value for $arg"
+                LOGFILE="$2"
+                shift
+                ;;
+            --no-log-file)
+                LOG_TO_FILE=0
+                ;;
+            --syslog)
+                LOG_TO_SYSLOG=1
+                ;;
+            --quiet)
+                LOG_TO_CMDLINE=0
+                ;;
+            --progress)
+                PROGRESS_MODE="on"
+                ;;
+            --no-progress)
+                PROGRESS_MODE="off"
+                ;;
+            --)
+                shift
+                break
+                ;;
+            -*)
+                die "Unknown option: $arg (use --help)"
+                ;;
+            *)
+                # Positional args are treated as additional directories.
+                if [ "$add_dir_mode" -eq 0 ]; then
+                    SCAN_FOLDERS=()
+                    add_dir_mode=1
+                fi
+                SCAN_FOLDERS+=("$arg")
+                ;;
+        esac
+        shift
+    done
+}
+
+validate_config() {
+    is_integer "$THUNDERSTORM_PORT" || die "Port must be numeric: '$THUNDERSTORM_PORT'"
+    is_integer "$MAX_AGE" || die "max-age must be numeric: '$MAX_AGE'"
+    is_integer "$MAX_FILE_SIZE_KB" || die "max-size-kb must be numeric: '$MAX_FILE_SIZE_KB'"
+    is_integer "$RETRIES" || die "retries must be numeric: '$RETRIES'"
+
+    [ "$THUNDERSTORM_PORT" -gt 0 ] || die "Port must be greater than 0"
+    [ "$MAX_AGE" -ge 0 ] || die "max-age must be >= 0"
+    [ "$MAX_FILE_SIZE_KB" -gt 0 ] || die "max-size-kb must be > 0"
+    [ "$RETRIES" -ge 1 ] || die "retries must be >= 1"
+
+    [ -n "$THUNDERSTORM_SERVER" ] || die "Server must not be empty"
+    if [ "${#SCAN_FOLDERS[@]}" -eq 0 ]; then
+        die "At least one directory is required"
+    fi
+    if [ -n "$CA_CERT" ] && [ ! -f "$CA_CERT" ]; then
+        die "CA certificate file not found: '$CA_CERT'"
+    fi
+    if [ -n "$CA_CERT" ] && [ "$INSECURE" -eq 1 ]; then
+        log_msg warn "--ca-cert and --insecure are both set; --insecure takes precedence"
+    fi
+}
+
+main() {
+    local scheme="http"
+    local endpoint_name="check"
+    local query_source=""
+    local api_endpoint=""
+    local base_url=""
+    local scandir
+    local file_path
+    local size_kb
+    local elapsed=0
+    local find_mtime
+    local find_results_file
+
+    parse_args "$@"
+    detect_source_name
+    validate_config
+    print_banner
+
+    if [ "$(id -u 2>/dev/null || echo 1)" != "0" ]; then
+        log_msg warn "Running without root privileges; some files may be inaccessible"
+    fi
+
+    if [ "$USE_SSL" -eq 1 ]; then
+        scheme="https"
+    fi
+    CURL_EXTRA_OPTS=()
+    WGET_EXTRA_OPTS=()
+    if [ "$INSECURE" -eq 1 ]; then
+        CURL_EXTRA_OPTS+=("-k")
+        WGET_EXTRA_OPTS+=("--no-check-certificate")
+    fi
+    if [ -n "$CA_CERT" ]; then
+        CURL_EXTRA_OPTS+=("--cacert" "$CA_CERT")
+        WGET_EXTRA_OPTS+=("--ca-certificate=$CA_CERT")
+    fi
+    if [ "$ASYNC_MODE" -eq 1 ]; then
+        endpoint_name="checkAsync"
+    fi
+
+    query_source="$(build_query_source "$SOURCE_NAME")"
+    base_url="${scheme}://${THUNDERSTORM_SERVER}:${THUNDERSTORM_PORT}"
+    # Strip any trailing slash from base_url
+    base_url="${base_url%/}"
+    api_endpoint="${base_url}/api/${endpoint_name}${query_source}"
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+        detect_upload_tool || true
+    fi
+
+    log_msg info "Started Thunderstorm Collector - Version $VERSION"
+    log_msg info "Server: $THUNDERSTORM_SERVER"
+    log_msg info "Port: $THUNDERSTORM_PORT"
+    log_msg info "API endpoint: $api_endpoint"
+    log_msg info "Max age (days): $MAX_AGE"
+    log_msg info "Max size (KB): $MAX_FILE_SIZE_KB"
+    log_msg info "Source: $SOURCE_NAME"
+    log_msg info "Folders: ${SCAN_FOLDERS[*]}"
+    [ "$DRY_RUN" -eq 1 ] && log_msg info "Dry-run mode enabled"
+
+    # Send collection begin marker; capture scan_id if server returns one
+    if [ "$DRY_RUN" -eq 0 ]; then
+        if ! detect_upload_tool; then
+            log_msg error "Neither 'curl' nor 'wget' is installed; unable to upload samples"
+            exit 2
+        fi
+        local _begin_resp_file
+        local _begin_rc=0
+        _begin_resp_file="$(mktemp_portable)" || { log_msg error "Cannot create temp file"; exit 2; }
+        TMP_FILES_ARR+=("$_begin_resp_file")
+        collection_marker "$base_url" "begin" "" "" > "$_begin_resp_file"
+        _begin_rc=$?
+        SCAN_ID="$(cat "$_begin_resp_file" 2>/dev/null)"
+        # If the begin marker failed after retry, the server is unreachable — fatal error
+        if [ "$_begin_rc" -ne 0 ]; then
+            log_msg error "Cannot connect to Thunderstorm server at ${base_url} (begin marker failed after retry)"
+            exit 2
+        fi
+        if [ -n "$SCAN_ID" ]; then
+            log_msg info "Collection scan_id: $SCAN_ID"
+            case "$api_endpoint" in
+                *\?*) api_endpoint="${api_endpoint}&scan_id=$(urlencode "$SCAN_ID")" ;;
+                *)    api_endpoint="${api_endpoint}?scan_id=$(urlencode "$SCAN_ID")" ;;
+            esac
+        fi
+    else
+        log_msg info "Dry-run mode: skipping server connection"
+    fi
+
+    # Determine progress display mode
+    if [ "$PROGRESS_MODE" = "on" ]; then
+        SHOW_PROGRESS=1
+    elif [ "$PROGRESS_MODE" = "off" ]; then
+        SHOW_PROGRESS=0
+    elif [ -t 2 ]; then
+        SHOW_PROGRESS=1
+    else
+        SHOW_PROGRESS=0
+    fi
+
+    # Build find exclusions once (shared across all scan dirs)
+    local find_excludes=()
+    local _ep
+    for _ep in "${EXCLUDE_PATHS[@]}"; do
+        [ -d "$_ep" ] && find_excludes+=(-path "$_ep" -prune -o)
+    done
+    local _mount_list
+    _mount_list="$(get_excluded_mounts)"
+    if [ -n "$_mount_list" ]; then
+        while IFS= read -r _ep; do
+            [ -n "$_ep" ] && [ -d "$_ep" ] && find_excludes+=(-path "$_ep" -prune -o)
+        done <<< "$_mount_list"
+    fi
+
+    # Prune known cloud storage directory names at the find level so they are
+    # excluded from both the file count and processing (keeps progress accurate).
+    local _cloud_name
+    for _cloud_name in $CLOUD_DIR_NAMES; do
+        find_excludes+=(\( -iname "$_cloud_name" -type d -prune \) -o)
+    done
+    local _old_ifs="$IFS"
+    IFS='|'
+    for _cloud_name in $CLOUD_DIR_NAMES_SPACED; do
+        find_excludes+=(\( -iname "$_cloud_name" -type d -prune \) -o)
+    done
+    for _cloud_name in $CLOUD_DIR_PATTERNS; do
+        find_excludes+=(\( -iname "${_cloud_name}*" -type d -prune \) -o)
+    done
+    IFS="$_old_ifs"
+    # Also prune macOS CloudStorage
+    find_excludes+=(\( -iname "CloudStorage" -path "*/Library/CloudStorage" -type d -prune \) -o)
+
+    # First pass: collect all file lists and count total files for progress
+    local all_find_files=()
+    for scandir in "${SCAN_FOLDERS[@]}"; do
+        if [ ! -d "$scandir" ]; then
+            log_msg warn "Skipping non-directory path '$scandir'"
+            continue
+        fi
+
+        log_msg info "Scanning '$scandir'"
+        find_results_file="$(mktemp_portable)" || {
+            log_msg error "Could not create temporary file list for '$scandir'"
+            continue
+        }
+        TMP_FILES_ARR+=("$find_results_file")
+        if [ "$MAX_AGE" -gt 0 ]; then
+            find "$scandir" "${find_excludes[@]}" -type f -mtime "-${MAX_AGE}" -print0 > "$find_results_file" 2>/dev/null || true
+        else
+            # MAX_AGE=0 means no age filter — collect all files regardless of modification time
+            find "$scandir" "${find_excludes[@]}" -type f -print0 > "$find_results_file" 2>/dev/null || true
+        fi
+        all_find_files+=("$find_results_file")
+
+        # Count files in this result set (each entry is null-terminated by -print0)
+        local _count=0
+        if [ -s "$find_results_file" ]; then
+            # Count null bytes = number of file entries from -print0
+            _count="$(tr -cd '\0' < "$find_results_file" 2>/dev/null | wc -c)"
+            # Normalize whitespace from wc output
+            _count="${_count//[[:space:]]/}"
+            _count="${_count:-0}"
+        fi
+        TOTAL_FILES=$((TOTAL_FILES + _count))
+    done
+
+    log_msg info "Found $TOTAL_FILES candidate files"
+
+    local _processed=0
+    for find_results_file in "${all_find_files[@]}"; do
+        while IFS= read -r -d '' file_path; do
+            # Check for interruption between files
+            [ "$INTERRUPTED" -eq 1 ] && break 2
+
+            _processed=$((_processed + 1))
+
+            # Show progress
+            if [ "$SHOW_PROGRESS" -eq 1 ] && [ "$TOTAL_FILES" -gt 0 ]; then
+                printf '\r[%d/%d] %d%%' "$_processed" "$TOTAL_FILES" "$(( _processed * 100 / TOTAL_FILES ))" >&2
+            fi
+
+            [ -f "$file_path" ] || continue
+
+            FILES_SCANNED=$((FILES_SCANNED + 1))
+
+            # Skip files inside cloud storage folders
+            if is_cloud_path "$file_path"; then
+                FILES_SKIPPED=$((FILES_SKIPPED + 1))
+                log_msg debug "Skipping cloud storage path '$file_path'"
+                continue
+            fi
+
+            size_kb="$(file_size_kb "$file_path")"
+            if [ "$size_kb" -lt 0 ]; then
+                FILES_SKIPPED=$((FILES_SKIPPED + 1))
+                log_msg debug "Skipping unreadable file '$file_path'"
+                continue
+            fi
+
+            if [ "$size_kb" -gt "$MAX_FILE_SIZE_KB" ]; then
+                FILES_SKIPPED=$((FILES_SKIPPED + 1))
+                log_msg debug "Skipping '$file_path' due to size (${size_kb}KB)"
+                continue
+            fi
+
+            log_msg debug "Submitting '$file_path'"
+            if submit_file "$api_endpoint" "$file_path"; then
+                FILES_SUBMITTED=$((FILES_SUBMITTED + 1))
+            else
+                FILES_FAILED=$((FILES_FAILED + 1))
+                log_msg error "Could not upload '$file_path'"
+            fi
+        done < "$find_results_file"
+    done
+
+    if [ "$START_TS" -gt 0 ] 2>/dev/null; then
+        elapsed=$(( $(date +%s 2>/dev/null || echo "$START_TS") - START_TS ))
+        [ "$elapsed" -lt 0 ] && elapsed=0
+    fi
+
+    # Clear progress line if we were showing progress
+    if [ "$SHOW_PROGRESS" -eq 1 ]; then
+        printf '\r\033[K' >&2
+    fi
+
+    log_msg info "Run completed: scanned=$FILES_SCANNED submitted=$FILES_SUBMITTED skipped=$FILES_SKIPPED failed=$FILES_FAILED seconds=$elapsed"
+
+    # Send collection end marker with run statistics
+    if [ "$DRY_RUN" -eq 0 ]; then
+        local stats_json="\"stats\":{\"scanned\":${FILES_SCANNED},\"submitted\":${FILES_SUBMITTED},\"skipped\":${FILES_SKIPPED},\"failed\":${FILES_FAILED},\"elapsed_seconds\":${elapsed}}"
+        collection_marker "$base_url" "end" "$SCAN_ID" "$stats_json" >/dev/null
+    fi
+
+    if [ "$FILES_FAILED" -gt 0 ]; then
+        return 1
+    fi
+    return 0
+}
+
+main "$@"
+exit $?

--- a/scripts/tests/run_tests.sh
+++ b/scripts/tests/run_tests.sh
@@ -653,17 +653,49 @@ test_source_url_encoding() {
 # ── 23. Retries on server down ───────────────────────────────────────────────
 
 test_retries_on_connection_failure() {
-    # Don't start stub — let it fail
     stop_stub
     local d; d="$(create_sample_dir retry_fail)"
     create_file "$d/a.txt"
+    local fakebin; fakebin="$(create_fake_tool_path retry_fail)"
+    cat > "$fakebin/curl" <<'EOF'
+#!/bin/sh
+hdr=""
+outfile=""
+endpoint=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -D) hdr="$2"; shift 2 ;;
+        -o) outfile="$2"; shift 2 ;;
+        -F|-H|-d|--max-time|--cacert) shift 2 ;;
+        -sS|--show-error|-X|-k) shift ;;
+        http://*|https://*) endpoint="$1"; shift ;;
+        *) shift ;;
+    esac
+done
 
-    local dead_port; dead_port="$(pick_port)"
-    local out; out="$(bash "$COLLECTOR" \
-        --server 127.0.0.1 --port "$dead_port" --no-log-file \
+case "$endpoint" in
+    */api/collection)
+        [ -n "$hdr" ] && printf 'HTTP/1.1 204 No Content\r\n\r\n' > "$hdr"
+        [ -n "$outfile" ] && : > "$outfile"
+        exit 0
+        ;;
+    *)
+        exit 7
+        ;;
+esac
+EOF
+    chmod +x "$fakebin/curl"
+
+    local out rc
+    set +e
+    out="$(env PATH="$fakebin" bash "$COLLECTOR" \
+        --server 127.0.0.1 --port 8080 --no-log-file --no-progress \
         --dir "$d" --max-age 30 --retries 2 2>&1)"
+    rc=$?
+    set -e
 
     local failed; failed="$(parse_collector_stat "$out" failed)"
+    assert_eq "exit code" "1" "$rc" || return 1
     assert_eq "failed" "1" "$failed" || return 1
     assert_contains "retry message" "attempt" "$out" || return 1
 }

--- a/scripts/tests/run_tests.sh
+++ b/scripts/tests/run_tests.sh
@@ -1,0 +1,927 @@
+#!/usr/bin/env bash
+#
+# Test suite for the bash collector.
+#
+# Modes:
+#   1. Stub server (CI/GitHub Actions):
+#      Provide a thunderstorm-stub-server binary. Tests start/stop it automatically.
+#      ./scripts/tests/run_tests.sh [path/to/thunderstorm-stub-server]
+#
+#   2. External server (real Thunderstorm or already-running stub):
+#      Set THUNDERSTORM_TEST_SERVER and THUNDERSTORM_TEST_PORT.
+#      Skips tests that require stub-side verification (audit log, uploads dir).
+#      THUNDERSTORM_TEST_SERVER=10.0.0.5 THUNDERSTORM_TEST_PORT=8081 ./scripts/tests/run_tests.sh
+#
+# Environment variables:
+#   STUB_SERVER_BIN          Path to thunderstorm-stub-server binary
+#   THUNDERSTORM_TEST_SERVER External server host (skips stub lifecycle)
+#   THUNDERSTORM_TEST_PORT   External server port (default: 8080)
+#   TEST_FILTER              Run only tests matching this grep pattern
+#
+# Stub binary lookup order (when no external server):
+#   1. First CLI argument
+#   2. $STUB_SERVER_BIN
+#   3. ../thunderstorm-stub-server/thunderstorm-stub-server (sibling checkout)
+#   4. thunderstorm-stub-server in $PATH
+
+set -euo pipefail
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$TESTS_DIR/../.." && pwd)"
+COLLECTOR="$REPO_ROOT/scripts/thunderstorm-collector.sh"
+
+# ── Locate stub server ────────────────────────────────────────────────────────
+
+find_stub_server() {
+    if [ -n "${1:-}" ] && [ -x "$1" ]; then
+        echo "$1"; return 0
+    fi
+    if [ -n "${STUB_SERVER_BIN:-}" ] && [ -x "$STUB_SERVER_BIN" ]; then
+        echo "$STUB_SERVER_BIN"; return 0
+    fi
+    local sibling="$REPO_ROOT/../thunderstorm-stub-server/thunderstorm-stub-server"
+    if [ -x "$sibling" ]; then
+        echo "$sibling"; return 0
+    fi
+    if command -v thunderstorm-stub-server >/dev/null 2>&1; then
+        command -v thunderstorm-stub-server; return 0
+    fi
+    return 1
+}
+
+# ── Mode selection ─────────────────────────────────────────────────────────────
+
+EXTERNAL_SERVER="${THUNDERSTORM_TEST_SERVER:-}"
+EXTERNAL_PORT="${THUNDERSTORM_TEST_PORT:-8080}"
+USE_EXTERNAL=0
+STUB_BIN=""
+
+if [ -n "$EXTERNAL_SERVER" ]; then
+    USE_EXTERNAL=1
+else
+    STUB_BIN="$(find_stub_server "${1:-}")" || {
+        echo "ERROR: thunderstorm-stub-server binary not found." >&2
+        echo "Build it: cd ../thunderstorm-stub-server && go build -o thunderstorm-stub-server ." >&2
+        echo "Or set THUNDERSTORM_TEST_SERVER to use an external server." >&2
+        exit 1
+    }
+fi
+
+# ── Test infrastructure ──────────────────────────────────────────────────────
+
+STUB_PORT=0
+STUB_PID=""
+TEST_TMP=""
+UPLOADS_DIR=""
+AUDIT_LOG=""
+STUB_LOG=""
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+FAILED_NAMES=""
+
+# Colours (disabled if not a terminal)
+if [ -t 1 ]; then
+    GREEN='\033[0;32m'; RED='\033[0;31m'; YELLOW='\033[0;33m'; BOLD='\033[1m'; RESET='\033[0m'
+else
+    GREEN=''; RED=''; YELLOW=''; BOLD=''; RESET=''
+fi
+
+setup_tmp() {
+    TEST_TMP="$(mktemp -d)"
+    UPLOADS_DIR="$TEST_TMP/uploads"
+    AUDIT_LOG="$TEST_TMP/audit.jsonl"
+    STUB_LOG="$TEST_TMP/stub.log"
+    mkdir -p "$UPLOADS_DIR"
+}
+
+cleanup() {
+    stop_stub
+    if [ -n "$TEST_TMP" ] && [ -d "$TEST_TMP" ]; then
+        rm -rf "$TEST_TMP"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+# Pick an available port
+pick_port() {
+    local port
+    if command -v python3 >/dev/null 2>&1; then
+        port="$(python3 -c 'import socket; s=socket.socket(); s.bind(("",0)); print(s.getsockname()[1]); s.close()' 2>/dev/null || true)"
+        if [ -n "$port" ] && [ "$port" -ge 1 ] 2>/dev/null; then
+            echo "$port"
+            return 0
+        fi
+    fi
+    if command -v shuf >/dev/null 2>&1; then
+        shuf -i 10000-60000 -n 1
+    else
+        echo $(( RANDOM % 50000 + 10000 ))
+    fi
+}
+
+start_stub() {
+    if [ "$USE_EXTERNAL" -eq 1 ]; then
+        STUB_PORT="$EXTERNAL_PORT"
+        return 0
+    fi
+    STUB_PORT="$(pick_port)"
+    # Clean state for each test
+    rm -rf "$UPLOADS_DIR"/* "$AUDIT_LOG" 2>/dev/null || true
+    "$STUB_BIN" \
+        --port "$STUB_PORT" \
+        --uploads-dir "$UPLOADS_DIR" \
+        --log-file "$AUDIT_LOG" \
+        >"$STUB_LOG" 2>&1 &
+    STUB_PID=$!
+    # Wait for server readiness
+    local i
+    for i in $(seq 1 30); do
+        if curl -fsS "http://127.0.0.1:$STUB_PORT/api/status" >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 0.2
+    done
+    echo "ERROR: Stub server did not start on port $STUB_PORT" >&2
+    cat "$STUB_LOG" >&2
+    return 1
+}
+
+stop_stub() {
+    if [ "$USE_EXTERNAL" -eq 1 ]; then
+        return 0
+    fi
+    if [ -n "$STUB_PID" ]; then
+        kill "$STUB_PID" 2>/dev/null || true
+        wait "$STUB_PID" 2>/dev/null || true
+        STUB_PID=""
+    fi
+}
+
+restart_stub() {
+    stop_stub
+    start_stub
+}
+
+# Whether stub-side verification (audit log, uploads dir) is available
+has_stub_verification() {
+    [ "$USE_EXTERNAL" -eq 0 ]
+}
+
+# The server address used by the collector
+server_host() {
+    if [ "$USE_EXTERNAL" -eq 1 ]; then
+        echo "$EXTERNAL_SERVER"
+    else
+        echo "127.0.0.1"
+    fi
+}
+
+# Run collector with standard flags, additional args appended
+run_collector() {
+    bash "$COLLECTOR" \
+        --server "$(server_host)" \
+        --port "$STUB_PORT" \
+        --no-log-file \
+        "$@" 2>&1
+}
+
+# Get scanned_samples from stub /api/status
+stub_scanned() {
+    curl -fsS "http://127.0.0.1:$STUB_PORT/api/status" 2>/dev/null \
+        | python3 -c "import sys,json; print(json.load(sys.stdin)['scanned_samples'])" 2>/dev/null || echo 0
+}
+
+# Count files in uploads dir
+upload_count() {
+    find "$UPLOADS_DIR" -type f 2>/dev/null | wc -l | tr -d ' '
+}
+
+# Extract stat from collector output: "scanned=4 submitted=3 ..."
+parse_collector_stat() {
+    local output="$1" key="$2"
+    echo "$output" | grep -oE "${key}=[0-9]+" | tail -1 | cut -d= -f2
+}
+
+# ── Test result helpers ──────────────────────────────────────────────────────
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "$expected" != "$actual" ]; then
+        printf "    ${RED}FAIL${RESET}: %s — expected '%s', got '%s'\n" "$label" "$expected" "$actual"
+        return 1
+    fi
+    return 0
+}
+
+assert_ge() {
+    local label="$1" min="$2" actual="$3"
+    if [ "$actual" -lt "$min" ] 2>/dev/null; then
+        printf "    ${RED}FAIL${RESET}: %s — expected >= %s, got '%s'\n" "$label" "$min" "$actual"
+        return 1
+    fi
+    return 0
+}
+
+assert_contains() {
+    local label="$1" needle="$2" haystack="$3"
+    if ! echo "$haystack" | grep -qF -- "$needle"; then
+        printf "    ${RED}FAIL${RESET}: %s — output does not contain '%s'\n" "$label" "$needle"
+        return 1
+    fi
+    return 0
+}
+
+assert_not_contains() {
+    local label="$1" needle="$2" haystack="$3"
+    if echo "$haystack" | grep -qF -- "$needle"; then
+        printf "    ${RED}FAIL${RESET}: %s — output unexpectedly contains '%s'\n" "$label" "$needle"
+        return 1
+    fi
+    return 0
+}
+
+run_test() {
+    local name="$1"
+    # Filter support
+    if [ -n "${TEST_FILTER:-}" ] && ! echo "$name" | grep -q "$TEST_FILTER"; then
+        return 0
+    fi
+    TESTS_RUN=$((TESTS_RUN + 1))
+    printf "  ${BOLD}%-55s${RESET}" "$name"
+    if "$name"; then
+        printf " ${GREEN}PASS${RESET}\n"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        printf " ${RED}FAIL${RESET}\n"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        FAILED_NAMES="$FAILED_NAMES  - $name\n"
+    fi
+}
+
+# ── Test fixtures ────────────────────────────────────────────────────────────
+
+create_sample_dir() {
+    local dir="$TEST_TMP/samples/$1"
+    mkdir -p "$dir"
+    echo "$dir"
+}
+
+create_file() {
+    local path="$1"
+    shift
+    mkdir -p "$(dirname "$path")"
+    if [ $# -gt 0 ]; then
+        printf '%s' "$1" > "$path"
+    else
+        printf 'sample content %s\n' "$(basename "$path")" > "$path"
+    fi
+}
+
+create_file_bytes() {
+    local path="$1" size="$2"
+    mkdir -p "$(dirname "$path")"
+    dd if=/dev/urandom of="$path" bs=1 count="$size" 2>/dev/null
+}
+
+create_fake_tool_path() {
+    local dir="$TEST_TMP/fake-tools-$1"
+    mkdir -p "$dir"
+    local cmd path
+    for cmd in bash awk cat date find grep head hostname id mktemp od rm sed sleep tail tr uname wc; do
+        path="$(command -v "$cmd" 2>/dev/null || true)"
+        [ -n "$path" ] && ln -sf "$path" "$dir/$cmd"
+    done
+    echo "$dir"
+}
+
+set_file_age_days() {
+    local path="$1" days="$2"
+    local ts
+    if date --version >/dev/null 2>&1; then
+        # GNU date
+        ts="$(date -d "$days days ago" +%Y%m%d%H%M.%S)"
+    else
+        # BSD date
+        ts="$(date -v-${days}d +%Y%m%d%H%M.%S)"
+    fi
+    touch -t "$ts" "$path"
+}
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TESTS
+# ══════════════════════════════════════════════════════════════════════════════
+
+# ── 1. Basic upload (async) ──────────────────────────────────────────────────
+
+test_basic_async_upload() {
+    restart_stub
+    local d; d="$(create_sample_dir basic_async)"
+    create_file "$d/a.txt"
+    create_file "$d/b.bin"
+    create_file "$d/c.dat"
+
+    local out; out="$(run_collector --dir "$d" --source basic-async --max-age 30)"
+    local submitted; submitted="$(parse_collector_stat "$out" submitted)"
+    local failed; failed="$(parse_collector_stat "$out" failed)"
+
+    assert_eq "submitted" "3" "$submitted" || return 1
+    assert_eq "failed" "0" "$failed" || return 1
+    # Wait briefly for async processing, then check server
+    sleep 0.5
+    assert_ge "stub scanned" 3 "$(stub_scanned)" || return 1
+}
+
+# ── 2. Basic upload (sync) ──────────────────────────────────────────────────
+
+test_basic_sync_upload() {
+    has_stub_verification || { echo "    (skipped: sync scan too slow on external server)"; return 0; }
+    restart_stub
+    local d; d="$(create_sample_dir basic_sync)"
+    create_file "$d/sample.bin"
+
+    local out; out="$(run_collector --dir "$d" --sync --source sync-test --max-age 30)"
+    local submitted; submitted="$(parse_collector_stat "$out" submitted)"
+
+    assert_eq "submitted" "1" "$submitted" || return 1
+    assert_eq "upload_count" "1" "$(upload_count)" || return 1
+}
+
+# ── 3. Dry-run: no uploads ──────────────────────────────────────────────────
+
+test_dry_run_no_uploads() {
+    restart_stub
+    local d; d="$(create_sample_dir dry_run)"
+    create_file "$d/a.txt"
+    create_file "$d/b.txt"
+
+    local out; out="$(run_collector --dir "$d" --dry-run --max-age 30)"
+    local submitted; submitted="$(parse_collector_stat "$out" submitted)"
+
+    assert_eq "submitted" "2" "$submitted" || return 1
+    if has_stub_verification; then
+        assert_eq "upload_count" "0" "$(upload_count)" || return 1
+        assert_eq "stub_scanned" "0" "$(stub_scanned)" || return 1
+    fi
+}
+
+# ── 4. Max file size filter ─────────────────────────────────────────────────
+
+test_max_file_size_filter() {
+    restart_stub
+    local d; d="$(create_sample_dir size_filter)"
+    create_file "$d/small.bin" "small"                    # ~5 bytes
+    create_file_bytes "$d/big.bin" 60000                  # ~59 KB
+
+    # Set max size to 50 KB
+    local out; out="$(run_collector --dir "$d" --max-size-kb 50 --max-age 30 --debug)"
+    local submitted; submitted="$(parse_collector_stat "$out" submitted)"
+    local skipped; skipped="$(parse_collector_stat "$out" skipped)"
+
+    assert_eq "submitted" "1" "$submitted" || return 1
+    assert_eq "skipped" "1" "$skipped" || return 1
+}
+
+# ── 5. Max age filter ───────────────────────────────────────────────────────
+
+test_max_age_filter() {
+    restart_stub
+    local d; d="$(create_sample_dir age_filter)"
+    create_file "$d/recent.txt" "new"
+    create_file "$d/old.txt" "old"
+    set_file_age_days "$d/old.txt" 60
+
+    local out; out="$(run_collector --dir "$d" --max-age 30)"
+    local scanned; scanned="$(parse_collector_stat "$out" scanned)"
+    local submitted; submitted="$(parse_collector_stat "$out" submitted)"
+
+    # find -mtime -30 should exclude the 60-day-old file entirely
+    assert_eq "scanned" "1" "$scanned" || return 1
+    assert_eq "submitted" "1" "$submitted" || return 1
+}
+
+# ── 6. Multiple directories ─────────────────────────────────────────────────
+
+test_multiple_directories() {
+    restart_stub
+    local d1; d1="$(create_sample_dir multi_a)"
+    local d2; d2="$(create_sample_dir multi_b)"
+    create_file "$d1/x.txt"
+    create_file "$d2/y.txt"
+    create_file "$d2/z.txt"
+
+    local out; out="$(run_collector --dir "$d1" --dir "$d2" --max-age 30)"
+    local submitted; submitted="$(parse_collector_stat "$out" submitted)"
+
+    assert_eq "submitted" "3" "$submitted" || return 1
+}
+
+# ── 7. Non-existent directory warning ────────────────────────────────────────
+
+test_nonexistent_directory_warning() {
+    restart_stub
+    local d; d="$(create_sample_dir exists)"
+    create_file "$d/a.txt"
+
+    # Also pass a non-existent dir — collector should warn but continue
+    local out; out="$(bash "$COLLECTOR" \
+        --server "$(server_host)" --port "$STUB_PORT" --no-log-file \
+        --dir /nonexistent_path_$RANDOM --dir "$d" --max-age 30 2>&1)"
+
+    assert_contains "warn about missing dir" "non-directory" "$out" || return 1
+    local submitted; submitted="$(parse_collector_stat "$out" submitted)"
+    assert_eq "submitted" "1" "$submitted" || return 1
+}
+
+# ── 8. Source parameter arrives at server ────────────────────────────────────
+
+test_source_parameter_received() {
+    has_stub_verification || { echo "    (skipped: needs stub server)"; return 0; }
+    restart_stub
+    local d; d="$(create_sample_dir source_test)"
+    create_file "$d/s.bin"
+
+    run_collector --dir "$d" --source "my-test-source" --sync --max-age 30 >/dev/null
+    sleep 0.3
+
+    # Check the JSONL audit log for the source
+    assert_contains "source in audit log" "my-test-source" "$(cat "$AUDIT_LOG" 2>/dev/null)" || return 1
+}
+
+# ── 9. File content integrity ────────────────────────────────────────────────
+
+test_file_content_integrity() {
+    has_stub_verification || { echo "    (skipped: needs stub server)"; return 0; }
+    restart_stub
+    local d; d="$(create_sample_dir integrity)"
+    local content="THUNDERSTORM_INTEGRITY_TEST_$(date +%s)"
+    create_file "$d/check.bin" "$content"
+    local expected_sha; expected_sha="$(sha256sum "$d/check.bin" | awk '{print $1}')"
+
+    run_collector --dir "$d" --sync --max-age 30 >/dev/null
+    sleep 0.3
+
+    # Verify the uploaded file has the same hash
+    local uploaded_file
+    uploaded_file="$(find "$UPLOADS_DIR" -type f | head -1)"
+    [ -n "$uploaded_file" ] || { printf "    ${RED}FAIL${RESET}: no uploaded file found\n"; return 1; }
+    local actual_sha; actual_sha="$(sha256sum "$uploaded_file" | awk '{print $1}')"
+    assert_eq "sha256" "$expected_sha" "$actual_sha" || return 1
+}
+
+# ── 10. Filename with spaces ────────────────────────────────────────────────
+
+test_filename_with_spaces() {
+    restart_stub
+    local d; d="$(create_sample_dir spaces)"
+    create_file "$d/my important file.txt" "spaces test"
+
+    local out; out="$(run_collector --dir "$d" --max-age 30)"
+    local submitted; submitted="$(parse_collector_stat "$out" submitted)"
+    local failed; failed="$(parse_collector_stat "$out" failed)"
+
+    assert_eq "submitted" "1" "$submitted" || return 1
+    assert_eq "failed" "0" "$failed" || return 1
+}
+
+# ── 11. Filename with special characters ────────────────────────────────────
+
+test_filename_special_chars() {
+    restart_stub
+    local d; d="$(create_sample_dir special)"
+    # Filenames that stress multipart encoding
+    create_file "$d/file with (parens).txt" "parens"
+    create_file "$d/file'with'quotes.txt" "quotes"
+    create_file "$d/file&with&amps.bin" "amps"
+    # Semicolons and double-quotes are sanitized by the collector
+    create_file "$d/normal.txt" "baseline"
+
+    local out; out="$(run_collector --dir "$d" --max-age 30)"
+    local submitted; submitted="$(parse_collector_stat "$out" submitted)"
+    local failed; failed="$(parse_collector_stat "$out" failed)"
+
+    assert_eq "submitted" "4" "$submitted" || return 1
+    assert_eq "failed" "0" "$failed" || return 1
+}
+
+# ── 12. Empty directory ─────────────────────────────────────────────────────
+
+test_empty_directory() {
+    restart_stub
+    local d; d="$(create_sample_dir empty)"
+
+    local out; out="$(run_collector --dir "$d" --max-age 30)"
+    local scanned; scanned="$(parse_collector_stat "$out" scanned)"
+    local submitted; submitted="$(parse_collector_stat "$out" submitted)"
+
+    assert_eq "scanned" "0" "$scanned" || return 1
+    assert_eq "submitted" "0" "$submitted" || return 1
+}
+
+# ── 13. Nested directories ──────────────────────────────────────────────────
+
+test_nested_directories() {
+    restart_stub
+    local d; d="$(create_sample_dir nested)"
+    create_file "$d/top.txt"
+    create_file "$d/a/mid.txt"
+    create_file "$d/a/b/deep.txt"
+    create_file "$d/a/b/c/deeper.txt"
+
+    local out; out="$(run_collector --dir "$d" --max-age 30)"
+    local submitted; submitted="$(parse_collector_stat "$out" submitted)"
+
+    assert_eq "submitted" "4" "$submitted" || return 1
+}
+
+# ── 14. Symlinks are not followed ───────────────────────────────────────────
+
+test_symlinks_not_followed() {
+    restart_stub
+    local d; d="$(create_sample_dir symlinks)"
+    local other; other="$(create_sample_dir symlink_target)"
+    create_file "$d/real.txt"
+    create_file "$other/secret.txt"
+    ln -sf "$other" "$d/link_to_other" 2>/dev/null || {
+        # Skip on systems that don't support symlinks in temp
+        return 0
+    }
+
+    local out; out="$(run_collector --dir "$d" --max-age 30)"
+    local submitted; submitted="$(parse_collector_stat "$out" submitted)"
+
+    # find -type f only returns regular files, not symlink targets
+    # But find does follow symlinked directories by default on some systems.
+    # The key thing: real.txt should always be submitted.
+    assert_ge "submitted at least real.txt" 1 "$submitted" || return 1
+}
+
+# ── 15. Validation: invalid port ────────────────────────────────────────────
+
+test_invalid_port_rejected() {
+    local out; out="$(bash "$COLLECTOR" \
+        --server 127.0.0.1 --port "notaport" --no-log-file \
+        --dir /tmp --max-age 30 2>&1)" || true
+
+    assert_contains "port validation" "Port must be numeric" "$out" || return 1
+}
+
+# ── 16. Validation: invalid max-age ─────────────────────────────────────────
+
+test_invalid_max_age_rejected() {
+    local out; out="$(bash "$COLLECTOR" \
+        --server 127.0.0.1 --port 8080 --no-log-file \
+        --dir /tmp --max-age "abc" 2>&1)" || true
+
+    assert_contains "max-age validation" "max-age must be numeric" "$out" || return 1
+}
+
+# ── 17. Validation: invalid max-size-kb ──────────────────────────────────────
+
+test_invalid_max_size_rejected() {
+    local out; out="$(bash "$COLLECTOR" \
+        --server 127.0.0.1 --port 8080 --no-log-file \
+        --dir /tmp --max-size-kb "xyz" 2>&1)" || true
+
+    assert_contains "max-size validation" "max-size-kb must be numeric" "$out" || return 1
+}
+
+# ── 18. Validation: missing server ───────────────────────────────────────────
+
+test_missing_server_rejected() {
+    local out; out="$(bash "$COLLECTOR" \
+        --server "" --port 8080 --no-log-file \
+        --dir /tmp 2>&1)" || true
+
+    # Empty string is caught as "Missing value" by the arg parser
+    assert_contains "server validation" "Missing value" "$out" || return 1
+}
+
+# ── 19. Unknown option rejected ──────────────────────────────────────────────
+
+test_unknown_option_rejected() {
+    local out; out="$(bash "$COLLECTOR" \
+        --server 127.0.0.1 --port 8080 --no-log-file \
+        --dir /tmp --bogus-flag 2>&1)" || true
+
+    assert_contains "unknown option" "Unknown option" "$out" || return 1
+}
+
+# ── 20. Help flag ────────────────────────────────────────────────────────────
+
+test_help_flag() {
+    local out; out="$(bash "$COLLECTOR" --help 2>&1)"
+
+    assert_contains "help shows usage" "Usage:" "$out" || return 1
+    assert_contains "help shows options" "--server" "$out" || return 1
+    assert_contains "help shows examples" "Examples:" "$out" || return 1
+}
+
+# ── 21. Log file is written ─────────────────────────────────────────────────
+
+test_log_file_written() {
+    restart_stub
+    local d; d="$(create_sample_dir log_file)"
+    create_file "$d/a.txt"
+    local log_path="$TEST_TMP/collector-test.log"
+
+    bash "$COLLECTOR" \
+        --server "$(server_host)" --port "$STUB_PORT" \
+        --dir "$d" --max-age 30 --source log-test \
+        --log-file "$log_path" --quiet 2>&1 >/dev/null
+
+    [ -f "$log_path" ] || { printf "    ${RED}FAIL${RESET}: log file not created\n"; return 1; }
+    assert_contains "log has collector info" "Thunderstorm Collector" "$(cat "$log_path")" || return 1
+    assert_contains "log has completion" "Run completed" "$(cat "$log_path")" || return 1
+}
+
+# ── 22. Source URL-encoding ──────────────────────────────────────────────────
+
+test_source_url_encoding() {
+    has_stub_verification || { echo "    (skipped: needs stub server)"; return 0; }
+    restart_stub
+    local d; d="$(create_sample_dir urlenc)"
+    create_file "$d/a.bin"
+
+    run_collector --dir "$d" --source "host with spaces" --sync --max-age 30 >/dev/null
+    sleep 0.3
+
+    # The source should arrive at the server (URL-decoded)
+    assert_contains "source in audit" "host with spaces" "$(cat "$AUDIT_LOG" 2>/dev/null)" || return 1
+}
+
+# ── 23. Retries on server down ───────────────────────────────────────────────
+
+test_retries_on_connection_failure() {
+    # Don't start stub — let it fail
+    stop_stub
+    local d; d="$(create_sample_dir retry_fail)"
+    create_file "$d/a.txt"
+
+    local dead_port; dead_port="$(pick_port)"
+    local out; out="$(bash "$COLLECTOR" \
+        --server 127.0.0.1 --port "$dead_port" --no-log-file \
+        --dir "$d" --max-age 30 --retries 2 2>&1)"
+
+    local failed; failed="$(parse_collector_stat "$out" failed)"
+    assert_eq "failed" "1" "$failed" || return 1
+    assert_contains "retry message" "attempt" "$out" || return 1
+}
+
+# ── 24. Full path as multipart filename ──────────────────────────────────────
+
+test_full_path_sent_as_filename() {
+    restart_stub
+    local d; d="$(create_sample_dir fullpath)"
+    create_file "$d/sample.bin" "path test"
+
+    local out; out="$(run_collector --dir "$d" --max-age 30)"
+    local submitted; submitted="$(parse_collector_stat "$out" submitted)"
+    local failed; failed="$(parse_collector_stat "$out" failed)"
+
+    assert_eq "submitted" "1" "$submitted" || return 1
+    assert_eq "failed" "0" "$failed" || return 1
+}
+
+# ── 25. Zero-byte file ──────────────────────────────────────────────────────
+
+test_zero_byte_file() {
+    restart_stub
+    local d; d="$(create_sample_dir zerobyte)"
+    : > "$d/empty.bin"
+
+    local out; out="$(run_collector --dir "$d" --max-age 30)"
+    local submitted; submitted="$(parse_collector_stat "$out" submitted)"
+    local failed; failed="$(parse_collector_stat "$out" failed)"
+
+    # Zero-byte file: size 0 KB, should pass size filter (it's under any limit)
+    # and be submitted (the server may or may not accept it — that's server-side)
+    assert_ge "submitted or failed" 1 "$((submitted + failed))" || return 1
+}
+
+# ── 26. Max-age 0 includes all files ────────────────────────────────────────
+
+test_max_age_zero_includes_all() {
+    restart_stub
+    local d; d="$(create_sample_dir age_zero)"
+    create_file "$d/recent.txt" "new"
+    create_file "$d/old.txt" "old"
+    set_file_age_days "$d/old.txt" 365
+
+    local out; out="$(run_collector --dir "$d" --max-age 0)"
+    local scanned; scanned="$(parse_collector_stat "$out" scanned)"
+
+    # -mtime -0 matches files modified in the last 0 days (i.e., today or
+    # the last 24h, which depends on find implementation). This is tricky.
+    # With max-age 0, the collector uses find -mtime -0. On GNU find this
+    # matches files modified in the last 24h. The old file should be excluded.
+    # This test documents the actual behavior.
+    assert_ge "scanned at least 1" 1 "$scanned" || return 1
+}
+
+# ── 27. Max-age CLI override actually takes effect ───────────────────────────
+
+test_max_age_cli_override_applied() {
+    restart_stub
+    local d; d="$(create_sample_dir age_override)"
+    create_file "$d/recent.txt" "new"
+    create_file "$d/medium.txt" "medium age"
+    set_file_age_days "$d/medium.txt" 20
+
+    # Default MAX_AGE is 14 days. Pass --max-age 30 on CLI.
+    # If the bug where find_mtime was set before parse_args is present,
+    # the 20-day-old file would be excluded (find -mtime -14).
+    # With the fix, --max-age 30 means find -mtime -30, so it's included.
+    local out; out="$(run_collector --dir "$d" --max-age 30)"
+    local scanned; scanned="$(parse_collector_stat "$out" scanned)"
+
+    assert_eq "scanned" "2" "$scanned" || return 1
+}
+
+# ── 28. Positional directory args ────────────────────────────────────────────
+
+test_positional_directory_args() {
+    restart_stub
+    local d1; d1="$(create_sample_dir pos_a)"
+    local d2; d2="$(create_sample_dir pos_b)"
+    create_file "$d1/x.txt"
+    create_file "$d2/y.txt"
+
+    # Pass directories as positional args (not --dir)
+    local out; out="$(bash "$COLLECTOR" \
+        --server "$(server_host)" --port "$STUB_PORT" --no-log-file \
+        --max-age 30 "$d1" "$d2" 2>&1)"
+
+    local submitted; submitted="$(parse_collector_stat "$out" submitted)"
+    assert_eq "submitted" "2" "$submitted" || return 1
+}
+
+# ── 29. Begin-marker failures stay fatal even with no candidate files ───────
+
+test_begin_marker_failure_is_fatal() {
+    stop_stub
+    local d; d="$(create_sample_dir begin_marker_failure)"
+    local fakebin; fakebin="$(create_fake_tool_path begin_marker_failure)"
+    cat > "$fakebin/curl" <<'EOF'
+#!/bin/sh
+exit 7
+EOF
+    chmod +x "$fakebin/curl"
+
+    local out rc
+    set +e
+    out="$(env PATH="$fakebin" bash "$COLLECTOR" \
+        --server 127.0.0.1 --port 65534 --no-log-file --no-progress \
+        --dir "$d" 2>&1)"
+    rc=$?
+    set -e
+
+    assert_eq "exit code" "2" "$rc" || return 1
+    assert_contains "begin marker failure message" "begin marker failed after retry" "$out" || return 1
+}
+
+# ── 30. Wget 404 on /api/collection stays non-fatal ─────────────────────────
+
+test_wget_collection_marker_404_nonfatal() {
+    stop_stub
+    local d; d="$(create_sample_dir wget_marker_404)"
+    local fakebin; fakebin="$(create_fake_tool_path wget_marker_404)"
+    cat > "$fakebin/wget" <<'EOF'
+#!/bin/sh
+printf '  HTTP/1.1 404 Not Found\n' >&2
+exit 8
+EOF
+    chmod +x "$fakebin/wget"
+
+    local out rc
+    set +e
+    out="$(env PATH="$fakebin" bash "$COLLECTOR" \
+        --server 127.0.0.1 --port 8080 --no-log-file --no-progress \
+        --dir "$d" 2>&1)"
+    rc=$?
+    set -e
+
+    assert_eq "exit code" "0" "$rc" || return 1
+    assert_contains "optional marker warning" "not supported (HTTP 404)" "$out" || return 1
+    assert_not_contains "marker not fatal" "begin marker failed after retry" "$out" || return 1
+}
+
+# ── 31. Redirect upload responses are rejected ───────────────────────────────
+
+test_redirect_upload_rejected() {
+    stop_stub
+    local d; d="$(create_sample_dir redirect_upload)"
+    create_file "$d/sample.bin" "redirect-test"
+    local fakebin; fakebin="$(create_fake_tool_path redirect_upload)"
+    cat > "$fakebin/curl" <<'EOF'
+#!/bin/sh
+hdr=""
+outfile=""
+endpoint=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -D) hdr="$2"; shift 2 ;;
+        -o) outfile="$2"; shift 2 ;;
+        -F|-H|-d|--max-time|--cacert) shift 2 ;;
+        -sS|--show-error|-X|-k) shift ;;
+        http://*|https://*) endpoint="$1"; shift ;;
+        *) shift ;;
+    esac
+done
+
+case "$endpoint" in
+    */api/collection)
+        [ -n "$hdr" ] && printf 'HTTP/1.1 204 No Content\r\n\r\n' > "$hdr"
+        [ -n "$outfile" ] && : > "$outfile"
+        ;;
+    *)
+        [ -n "$hdr" ] && printf 'HTTP/1.1 302 Found\r\nLocation: https://example.invalid/other\r\n\r\n' > "$hdr"
+        if [ -n "$outfile" ]; then
+            printf 'redirect' > "$outfile"
+        else
+            printf 'redirect'
+        fi
+        ;;
+esac
+exit 0
+EOF
+    chmod +x "$fakebin/curl"
+
+    local out rc
+    set +e
+    out="$(env PATH="$fakebin" bash "$COLLECTOR" \
+        --server 127.0.0.1 --port 8080 --no-log-file --no-progress \
+        --dir "$d" --retries 1 2>&1)"
+    rc=$?
+    set -e
+
+    local submitted; submitted="$(parse_collector_stat "$out" submitted)"
+    local failed; failed="$(parse_collector_stat "$out" failed)"
+
+    assert_eq "exit code" "1" "$rc" || return 1
+    assert_eq "submitted" "0" "$submitted" || return 1
+    assert_eq "failed" "1" "$failed" || return 1
+    assert_contains "redirect status logged" "HTTP 302" "$out" || return 1
+}
+
+# ══════════════════════════════════════════════════════════════════════════════
+# RUN
+# ══════════════════════════════════════════════════════════════════════════════
+
+printf "\n${BOLD}Thunderstorm Bash Collector — Test Suite${RESET}\n"
+printf "  Collector: %s\n" "$COLLECTOR"
+if [ "$USE_EXTERNAL" -eq 1 ]; then
+    printf "  Server:    %s:%s (external)\n" "$EXTERNAL_SERVER" "$EXTERNAL_PORT"
+    printf "  Note:      stub-verification tests will be skipped\n\n"
+else
+    printf "  Stub:      %s\n\n" "$STUB_BIN"
+fi
+
+setup_tmp
+
+# Validation tests (no server needed)
+run_test test_help_flag
+run_test test_invalid_port_rejected
+run_test test_invalid_max_age_rejected
+run_test test_invalid_max_size_rejected
+run_test test_missing_server_rejected
+run_test test_unknown_option_rejected
+
+# Functional tests (need stub server)
+run_test test_basic_async_upload
+run_test test_basic_sync_upload
+run_test test_dry_run_no_uploads
+run_test test_max_file_size_filter
+run_test test_max_age_filter
+run_test test_multiple_directories
+run_test test_nonexistent_directory_warning
+run_test test_source_parameter_received
+run_test test_file_content_integrity
+run_test test_filename_with_spaces
+run_test test_filename_special_chars
+run_test test_empty_directory
+run_test test_nested_directories
+run_test test_symlinks_not_followed
+run_test test_log_file_written
+run_test test_source_url_encoding
+run_test test_retries_on_connection_failure
+run_test test_full_path_sent_as_filename
+run_test test_zero_byte_file
+run_test test_max_age_zero_includes_all
+run_test test_max_age_cli_override_applied
+run_test test_positional_directory_args
+run_test test_begin_marker_failure_is_fatal
+run_test test_wget_collection_marker_404_nonfatal
+run_test test_redirect_upload_rejected
+
+# Summary
+printf "\n${BOLD}Results:${RESET} %d/%d passed" "$TESTS_PASSED" "$TESTS_RUN"
+if [ "$TESTS_FAILED" -gt 0 ]; then
+    printf ", ${RED}%d failed${RESET}\n" "$TESTS_FAILED"
+    printf "\n${RED}Failed tests:${RESET}\n"
+    printf "$FAILED_NAMES"
+    exit 1
+else
+    printf " ${GREEN}✓${RESET}\n\n"
+    exit 0
+fi

--- a/scripts/tests/run_tests.sh
+++ b/scripts/tests/run_tests.sh
@@ -28,7 +28,7 @@ set -euo pipefail
 
 TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$TESTS_DIR/../.." && pwd)"
-COLLECTOR="$REPO_ROOT/scripts/thunderstorm-collector.sh"
+COLLECTOR="$REPO_ROOT/scripts/bash/thunderstorm-collector.sh"
 
 # ── Locate stub server ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- replace the bash script collector with the hardened implementation from script-robustness
- add the bash-specific stub-server-backed test suite

## Base
Stacked on #43 (`codex/script-test-base`) for the shared test harness and CI workflow.

## Testing
- bash -n scripts/thunderstorm-collector.sh scripts/tests/run_tests.sh